### PR TITLE
Add nix flake

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,7 @@
 name: Build
 
 on:
+  workflow-dispatch:
   push:
     branches: [ "master" ]
   pull_request:
@@ -35,3 +36,27 @@ jobs:
 
       - name: Check formatting
         run: cargo fmt --check
+
+
+
+  build-nix:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: cachix/install-nix-action@v17
+        with:
+          install_url: https://nixos.org/nix/install
+          extra_nix_config: |
+            auto-optimise-store = true
+            experimental-features = nix-command flakes
+
+      - uses: cachix/cachix-action@v11
+        with:
+          name: jakestanger
+          signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
+
+      - run: nix build --print-build-logs
+
+      - uses: loophp/flake-lock-update-workflow/.github/workflows/auto-upgrade-flakes.yaml@main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 name: Build
 
 on:
-  workflow-dispatch:
+  workflow_dispatch:
   push:
     branches: [ "master" ]
   pull_request:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,6 +58,3 @@ jobs:
           signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
 
       - run: nix build --print-build-logs
-
-  update-nix-flake-lock:
-    uses: loophp/flake-lock-update-workflow/.github/workflows/auto-upgrade-flakes.yaml@main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,4 +59,5 @@ jobs:
 
       - run: nix build --print-build-logs
 
-      - uses: loophp/flake-lock-update-workflow/.github/workflows/auto-upgrade-flakes.yaml@main
+  update-nix-flake-lock:
+    uses: loophp/flake-lock-update-workflow/.github/workflows/auto-upgrade-flakes.yaml@main

--- a/.github/workflows/update-nix-flake-lock.yml
+++ b/.github/workflows/update-nix-flake-lock.yml
@@ -1,0 +1,27 @@
+name: update-nix-flake-lock
+on:
+  workflow_dispatch: # allows manual triggering
+  schedule:
+    - cron: '0 0 1 * *' # first day of every month
+
+jobs:
+  update-nix-flake-lock:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v16
+        with:
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update flake.lock
+        uses: DeterminateSystems/update-flake-lock@vX
+        with:
+          pr-title: "Update flake.lock" # Title of PR to be created
+          pr-labels: |                  # Labels to be set on the PR
+            dependencies
+            automated

--- a/README.md
+++ b/README.md
@@ -27,6 +27,22 @@ yay -S ironbar-git
 
 [aur package](https://aur.archlinux.org/packages/ironbar-git)
 
+### Nix Flake
+```nix
+# Add the ironbar flake input
+inputs.ironbar.url = "github:JakeStanger/ironbar";
+
+# And add the home-manager module
+inputs.ironbar.homeManagerModules.default
+
+# And configure
+programs.ironbar = {
+    enable = true;
+    config = {};
+    style = ""
+};
+```
+
 ### Source
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ inputs.ironbar.homeManagerModules.default
 programs.ironbar = {
     enable = true;
     config = {};
-    style = ""
+    style = "";
 };
 ```
 

--- a/README.md
+++ b/README.md
@@ -28,20 +28,47 @@ yay -S ironbar-git
 [aur package](https://aur.archlinux.org/packages/ironbar-git)
 
 ### Nix Flake
+
+#### Example
+Here is an example nix flake that uses ironbar, this is just a 
+proof of concept, please adapt it to your config
+
 ```nix
-# Add the ironbar flake input
-inputs.ironbar.url = "github:JakeStanger/ironbar";
+{
+  # Add the ironbar flake input
+  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+  inputs.ironbar = {
+    url = "github:JakeStanger/ironbar";
+    inputs.nixpkgs.follows = "nixpkgs";
+  };
+  inputs.hm = {
+    url = "github:nix-community/home-manager";
+    inputs.nixpkgs.follows = "nixpkgs";
+  };
 
-# And add the home-manager module
-inputs.ironbar.homeManagerModules.default
-
-# And configure
-programs.ironbar = {
-    enable = true;
-    config = {};
-    style = "";
-};
+  outputs = inputs: {
+    homeManagerConfigurations."USER@HOSTNAME" = inputs.hm.lib.homeManagerConfiguration {
+      pkgs = nixpkgs.legacyPackages.x86_64-linux;
+      modules = [
+        # And add the home-manager module
+        inputs.ironbar.homeManagerModules.default
+        {
+          # And configure
+          programs.ironbar = {
+            enable = true;
+            config = {};
+            style = "";
+          };
+        }
+      ];
+    };
+  };
+}
 ```
+
+#### Binary Caching
+There is also a cachix cache at `https://app.cachix.org/cache/jakestanger`
+incase you don't want to compile ironbar!
 
 ### Source
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,64 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1668994630,
+        "narHash": "sha256-1lqx6HLyw6fMNX/hXrrETG1vMvZRGm2XVC9O/Jt0T6c=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "af50806f7c6ab40df3e6b239099e8f8385f6c78b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1669084742,
+        "narHash": "sha256-aLYwYVnrmEE1LVqd17v99CuqVmAZQrlgi2DVTAs4wFg=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "9652ef34c7439eca9f86cee11e94dbef5c9adb09",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,135 +1,142 @@
 {
-	description = "Nix Flake for ironbar";
-	inputs = {
-		nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-		rust-overlay = {
+  description = "Nix Flake for ironbar";
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    rust-overlay = {
       url = "github:oxalica/rust-overlay";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     #nci.url = "github:yusdacra/nix-cargo-integration";
     #nci.inputs.nixpkgs.follows = "nixpkgs";
-		#nci.inputs.rust-overlay.follows = "rust-overlay";
-	};
-	outputs = { 
-		self, 
-		nixpkgs,
-		rust-overlay,
-		... 
-	}: let
-		inherit (nixpkgs) lib;
-		genSystems = lib.genAttrs [
-			"aarch64-linux"
-			"x86_64-linux"
-		];
-    pkgsFor = system: import nixpkgs {
-      inherit system;
+    #nci.inputs.rust-overlay.follows = "rust-overlay";
+  };
+  outputs = {
+    self,
+    nixpkgs,
+    rust-overlay,
+    ...
+  }: let
+    inherit (nixpkgs) lib;
+    genSystems = lib.genAttrs [
+      "aarch64-linux"
+      "x86_64-linux"
+    ];
+    pkgsFor = system:
+      import nixpkgs {
+        inherit system;
 
-      overlays = [
-      	self.overlays.default
-        rust-overlay.overlays.default
-      ];
-    };
-		mkRustToolchain = pkgs: pkgs.rust-bin.stable.latest.default;
-	in {
-		overlays.default = final: prev:
-      let
-      	rust = mkRustToolchain final;
-
-        rustPlatform = prev.makeRustPlatform {
-        	cargo = rust;
-          rustc = rust;
-        };
-      in {
-				ironbar = rustPlatform.buildRustPackage {
-					pname = "ironbar";
-					version = self.rev or "dirty";
-					src = builtins.path { name = "ironbar"; path = prev.lib.cleanSource ./.; };
-					cargoDeps = rustPlatform.importCargoLock { lockFile = ./Cargo.lock; };
-					cargoLock.lockFile = ./Cargo.lock;
-					nativeBuildInputs = with prev; [ pkg-config ];
-					buildInputs = with prev; [ gtk3 gdk-pixbuf gtk-layer-shell libxkbcommon ];
-				};
+        overlays = [
+          self.overlays.default
+          rust-overlay.overlays.default
+        ];
       };
-		packages = genSystems (system:
-      let
+    mkRustToolchain = pkgs: pkgs.rust-bin.stable.latest.default;
+  in {
+    overlays.default = final: prev: let
+      rust = mkRustToolchain final;
+
+      rustPlatform = prev.makeRustPlatform {
+        cargo = rust;
+        rustc = rust;
+      };
+    in {
+      ironbar = rustPlatform.buildRustPackage {
+        pname = "ironbar";
+        version = self.rev or "dirty";
+        src = builtins.path {
+          name = "ironbar";
+          path = prev.lib.cleanSource ./.;
+        };
+        cargoDeps = rustPlatform.importCargoLock {lockFile = ./Cargo.lock;};
+        cargoLock.lockFile = ./Cargo.lock;
+        nativeBuildInputs = with prev; [pkg-config];
+        buildInputs = with prev; [gtk3 gdk-pixbuf gtk-layer-shell libxkbcommon];
+      };
+    };
+    packages = genSystems (
+      system: let
         pkgs = pkgsFor system;
       in
-        (self.overlays.default pkgs pkgs) // {
+        (self.overlays.default pkgs pkgs)
+        // {
           default = self.packages.${system}.ironbar;
         }
-      );
-		devShells = genSystems (system:
-      let
-        pkgs = pkgsFor system;
-        rust = mkRustToolchain pkgs;
-      in {
-        default = pkgs.mkShell {
-          packages = with pkgs; [
-            rust
-            rust-analyzer-unwrapped
-            gcc
-            gtk3
-            gtk-layer-shell
-            pkg-config
-          ];
+    );
+    devShells = genSystems (system: let
+      pkgs = pkgsFor system;
+      rust = mkRustToolchain pkgs;
+    in {
+      default = pkgs.mkShell {
+        packages = with pkgs; [
+          rust
+          rust-analyzer-unwrapped
+          gcc
+          gtk3
+          gtk-layer-shell
+          pkg-config
+        ];
 
-          RUST_SRC_PATH = "${rust}/lib/rustlib/src/rust/library";
-        };
+        RUST_SRC_PATH = "${rust}/lib/rustlib/src/rust/library";
+      };
     });
-		homeManagerModules.default = { config, lib, pkgs, ...}: let
-			cfg = config.programs.ironbar;
-			defaultIronbarPackage = self.packages.${pkgs.system}.default;
-			jsonFormat = pkgs.formats.json { };
-		in {
-			options.programs.ironbar = {
-				enable = lib.mkEnableOption "ironbar status bar";
-				package = lib.mkOption {
-					type = with lib.types; package;
-					default = defaultIronbarPackage;
-					description = "The package for ironbar to use";
-				};
-				systemd = lib.mkOption {
-					type = lib.types.bool;
-					default = pkgs.stdenv.isLinux;
-					description = "Whether to enable to systemd service for ironbar";
-				};
-				style = lib.mkOption {
-					type = lib.types.lines;
-					default = "";
-					description = "The stylesheet to apply to ironbar";
-				};
-				config = lib.mkOption {
-					type = jsonFormat.type;
-					default = {};
-					description = "The config to pass to ironbar";
-				};
-			};
-			config = lib.mkIf cfg.enable {
-				home.packages = [ cfg.package ];
-				xdg.configFile = {
-					"ironbar/config.json" = lib.mkIf (cfg.config != "") {
-						source = jsonFormat.generate "ironbar-config" cfg.config; 
-					};
-					"ironbar/style.css" = lib.mkIf (cfg.style != "") {
-						text = cfg.style;
-					};
-				};
-				systemd.user.services.ironbar = lib.mkIf cfg.systemd {
-					Unit =  {
-						Description = "Systemd service for Ironbar";
-						Requires = ["graphical-session.target"];
-					};
-					Service = {
-						Type = "simple";
-						ExecStart = "${cfg.package}/bin/ironbar";
-					};
-					Install.WantedBy = [
-						(lib.mkIf config.wayland.windowManager.hyprland.systemdIntegration "hyprland-session.target")
-						(lib.mkIf config.wayland.windowManager.sway.systemdIntegration "sway-session.target")
-					];
-				};
-			};
-		};
-	};
-
+    homeManagerModules.default = {
+      config,
+      lib,
+      pkgs,
+      ...
+    }: let
+      cfg = config.programs.ironbar;
+      defaultIronbarPackage = self.packages.${pkgs.system}.default;
+      jsonFormat = pkgs.formats.json {};
+    in {
+      options.programs.ironbar = {
+        enable = lib.mkEnableOption "ironbar status bar";
+        package = lib.mkOption {
+          type = with lib.types; package;
+          default = defaultIronbarPackage;
+          description = "The package for ironbar to use";
+        };
+        systemd = lib.mkOption {
+          type = lib.types.bool;
+          default = pkgs.stdenv.isLinux;
+          description = "Whether to enable to systemd service for ironbar";
+        };
+        style = lib.mkOption {
+          type = lib.types.lines;
+          default = "";
+          description = "The stylesheet to apply to ironbar";
+        };
+        config = lib.mkOption {
+          type = jsonFormat.type;
+          default = {};
+          description = "The config to pass to ironbar";
+        };
+      };
+      config = lib.mkIf cfg.enable {
+        home.packages = [cfg.package];
+        xdg.configFile = {
+          "ironbar/config.json" = lib.mkIf (cfg.config != "") {
+            source = jsonFormat.generate "ironbar-config" cfg.config;
+          };
+          "ironbar/style.css" = lib.mkIf (cfg.style != "") {
+            text = cfg.style;
+          };
+        };
+        systemd.user.services.ironbar = lib.mkIf cfg.systemd {
+          Unit = {
+            Description = "Systemd service for Ironbar";
+            Requires = ["graphical-session.target"];
+          };
+          Service = {
+            Type = "simple";
+            ExecStart = "${cfg.package}/bin/ironbar";
+          };
+          Install.WantedBy = [
+            (lib.mkIf config.wayland.windowManager.hyprland.systemdIntegration "hyprland-session.target")
+            (lib.mkIf config.wayland.windowManager.sway.systemdIntegration "sway-session.target")
+          ];
+        };
+      };
+    };
+  };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,135 @@
+{
+	description = "Nix Flake for ironbar";
+	inputs = {
+		nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+		rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    #nci.url = "github:yusdacra/nix-cargo-integration";
+    #nci.inputs.nixpkgs.follows = "nixpkgs";
+		#nci.inputs.rust-overlay.follows = "rust-overlay";
+	};
+	outputs = { 
+		self, 
+		nixpkgs,
+		rust-overlay,
+		... 
+	}: let
+		inherit (nixpkgs) lib;
+		genSystems = lib.genAttrs [
+			"aarch64-linux"
+			"x86_64-linux"
+		];
+    pkgsFor = system: import nixpkgs {
+      inherit system;
+
+      overlays = [
+      	self.overlays.default
+        rust-overlay.overlays.default
+      ];
+    };
+		mkRustToolchain = pkgs: pkgs.rust-bin.stable.latest.default;
+	in {
+		overlays.default = final: prev:
+      let
+      	rust = mkRustToolchain final;
+
+        rustPlatform = prev.makeRustPlatform {
+        	cargo = rust;
+          rustc = rust;
+        };
+      in {
+				ironbar = rustPlatform.buildRustPackage {
+					pname = "ironbar";
+					version = self.rev or "dirty";
+					src = builtins.path { name = "ironbar"; path = prev.lib.cleanSource ./.; };
+					cargoDeps = rustPlatform.importCargoLock { lockFile = ./Cargo.lock; };
+					cargoLock.lockFile = ./Cargo.lock;
+					nativeBuildInputs = with prev; [ pkg-config ];
+					buildInputs = with prev; [ gtk3 gdk-pixbuf gtk-layer-shell libxkbcommon ];
+				};
+      };
+		packages = genSystems (system:
+      let
+        pkgs = pkgsFor system;
+      in
+        (self.overlays.default pkgs pkgs) // {
+          default = self.packages.${system}.ironbar;
+        }
+      );
+		devShells = genSystems (system:
+      let
+        pkgs = pkgsFor system;
+        rust = mkRustToolchain pkgs;
+      in {
+        default = pkgs.mkShell {
+          packages = with pkgs; [
+            rust
+            rust-analyzer-unwrapped
+            gcc
+            gtk3
+            gtk-layer-shell
+            pkg-config
+          ];
+
+          RUST_SRC_PATH = "${rust}/lib/rustlib/src/rust/library";
+        };
+    });
+		homeManagerModules.default = { config, lib, pkgs, ...}: let
+			cfg = config.programs.ironbar;
+			defaultIronbarPackage = self.packages.${pkgs.system}.default;
+			jsonFormat = pkgs.formats.json { };
+		in {
+			options.programs.ironbar = {
+				enable = lib.mkEnableOption "ironbar status bar";
+				package = lib.mkOption {
+					type = with lib.types; package;
+					default = defaultIronbarPackage;
+					description = "The package for ironbar to use";
+				};
+				systemd = lib.mkOption {
+					type = lib.types.bool;
+					default = pkgs.stdenv.isLinux;
+					description = "Whether to enable to systemd service for ironbar";
+				};
+				style = lib.mkOption {
+					type = lib.types.lines;
+					default = "";
+					description = "The stylesheet to apply to ironbar";
+				};
+				config = lib.mkOption {
+					type = jsonFormat.type;
+					default = {};
+					description = "The config to pass to ironbar";
+				};
+			};
+			config = lib.mkIf cfg.enable {
+				home.packages = [ cfg.package ];
+				xdg.configFile = {
+					"ironbar/config.json" = lib.mkIf (cfg.config != "") {
+						source = jsonFormat.generate "ironbar-config" cfg.config; 
+					};
+					"ironbar/style.css" = lib.mkIf (cfg.style != "") {
+						text = cfg.style;
+					};
+				};
+				systemd.user.services.ironbar = lib.mkIf cfg.systemd {
+					Unit =  {
+						Description = "Systemd service for Ironbar";
+						Requires = ["graphical-session.target"];
+					};
+					Service = {
+						Type = "simple";
+						ExecStart = "${cfg.package}/bin/ironbar";
+					};
+					Install.WantedBy = [
+						(lib.mkIf config.wayland.windowManager.hyprland.systemdIntegration "hyprland-session.target")
+						(lib.mkIf config.wayland.windowManager.sway.systemdIntegration "sway-session.target")
+					];
+				};
+			};
+		};
+	};
+
+}


### PR DESCRIPTION
Adds nix flake with Home manager module for configuring, package for installing, and dev shell for development. Basically everything you will probably need to do with nix.

Though I didn't add non-flake support, since most people use flakes, but that can be easily added with https://github.com/edolstra/flake-compat.

<details>
<summary>And here is usage example (indentation is messed up, forgot to format 💀)</summary>

```nix
{ config, pkgs, ... }: {
	programs.ironbar = {
		enable = true;
		config = let 
			#workspaces = {
      #  type = "workspaces";
      #  all_monitors = false;
      #  # name_map = {
      #	# 	_1 = "fire";
      #  #     2 = "";
      #  #     3 = "";
      #  #     Games = "";
      #  #     Code = "";
      #  # };
    	#};

    launcher = {
        type = "launcher";
        favorites = ["firefox" "Steam"];
        show_names = false;
        show_icons = true;
        icon_theme = "Papirus";
    };

    mpd_local = { type = "mpd"; music_dir = "/home/jake/Music"; };
    #mpd_server = { type = "mpd" host = "localhost:6600" }

    sys_info = {
        type = "sys-info";
        format = ["{cpu-percent}% " "{memory-percent}% "];
    };

    tray = { type = "tray"; };
    clock = { type = "clock"; };

    #phone_battery = {
    #    type = "script";
    #    path = "/home/jake/bin/phone-battery";
    #};

    left = [ /*workspaces*/ launcher ];
    right = [ mpd_local /*phone_battery*/ sys_info clock tray ];
		in {
			anchor_to_edges = true;
    	position = "top";
    	start = left; end = right;
		};
		style = ''
	* {
    /* `otf-font-awesome` is required to be installed for icons */
    /*font-family: Noto Sans Nerd Font, sans-serif;*/
    font-family: monospace;
    font-size: 16px;

    /*color: white;*/
    /*background-color: #2d2d2d;*/
    /*background-color: red;*/
    border: none;

    /*opacity: 0.4;*/
}

#bar {
    border-top: 1px solid #424242;
}

.container {
    background-color: #2d2d2d;
}

/* test  34543*/

#right > * + * {
    margin-left: 20px;
}

#workspaces .item {
    color: white;
    background-color: #2d2d2d;
    border-radius: 0;
}

#workspaces .item.focused {
    box-shadow: inset 0 -3px;
    background-color: #1c1c1c;
}

#workspaces *:not(.focused):hover {
    box-shadow: inset 0 -3px;
}

#launcher .item {
    border-radius: 0;
    background-color: #2d2d2d;
    margin-right: 4px;
}

#launcher .item:not(.focused):hover {
    background-color: #1c1c1c;
}

#launcher .open {
    border-bottom: 2px solid #6699cc;
}

#launcher .focused {
    color: white;
    background-color: black;
    border-bottom: 4px solid #6699cc;
}

#launcher .urgent {
    color: white;
    background-color: #8f0a0a;
}

#clock {
    color: white;
    background-color: #2d2d2d;
    font-weight: bold;
}

#script {
    color: white;
}

#sysinfo {
    color: white;
}

#tray .item {
    background-color: #2d2d2d;
}

#mpd {
    background-color: #2d2d2d;
    color: white;
}

.popup {
    background-color: #2d2d2d;
    border: 1px solid #424242;
}

#popup-clock {
    padding: 1em;
}

#calendar-clock {
    color: white;
    font-size: 2.5em;
    padding-bottom: 0.1em;
}

#calendar {
    background-color: #2d2d2d;
    color: white;
}

#calendar .header {
    padding-top: 1em;
    border-top: 1px solid #424242;
    font-size: 1.5em;
}

#calendar:selected {
    background-color: #6699cc;
}

#popup-mpd {
    color: white;
    padding: 1em;
}

#popup-mpd #album-art {
    /*border: 1px solid #424242;*/
    margin-right: 1em;
}

#popup-mpd #title .icon, #popup-mpd #title .label {
    font-size: 1.7em;
}

#popup-mpd #controls * {
    border-radius: 0;
    background-color: #2d2d2d;
    color: white;
}

#popup-mpd #controls *:disabled {
    color: #424242;
}

#focused {
    color: white;
}
	'';
	};
}
```

</details>