### PR TITLE
feat: mouse event config options

### DIFF
--- a/docs/Configuration guide.md
+++ b/docs/Configuration guide.md
@@ -1,10 +1,12 @@
 By default, you get a single bar at the bottom of all your screens.
 To change that, you'll unsurprisingly need a config file.
 
-This page details putting together the skeleton for your config to get you to a stage where you can start configuring modules.
-It may look long and overwhelming, but that is just because the bar supports a lot of scenarios! 
+This page details putting together the skeleton for your config to get you to a stage where you can start configuring
+modules.
+It may look long and overwhelming, but that is just because the bar supports a lot of scenarios!
 
-If you want to see some ready-to-go config files check the [examples folder](https://github.com/JakeStanger/ironbar/tree/master/examples) 
+If you want to see some ready-to-go config files check
+the [examples folder](https://github.com/JakeStanger/ironbar/tree/master/examples)
 and the example pages in the sidebar.
 
 ## 1. Create config file
@@ -239,7 +241,7 @@ monitors:
 <details>
 <summary>Corn</summary>
 
-```
+```corn
 {
   monitors.DP-1 = [
     { start = [] }
@@ -281,8 +283,12 @@ For details on available modules and each of their config options, check the sid
 
 For information on the `Script` type, and embedding scripts in strings, see [here](script).
 
-| Name       | Type               | Default | Description                                                                                                        |
-|------------|--------------------|---------|--------------------------------------------------------------------------------------------------------------------|
-| `show_if`  | `Script [polling]` | `null`  | Polls the script to check its exit code. If exit code is zero, the module is shown. For other codes, it is hidden. |
-| `on_click` | `Script [polling]` | `null`  | Runs the script when the module is clicked.                                                                        |
-| `tooltip`  | `string`           | `null`  | Shows this text on hover. Supports embedding scripts between `{{double braces}}`.                                  |
+| Name              | Type               | Default | Description                                                                                                        |
+|-------------------|--------------------|---------|--------------------------------------------------------------------------------------------------------------------|
+| `show_if`         | `Script [polling]` | `null`  | Polls the script to check its exit code. If exit code is zero, the module is shown. For other codes, it is hidden. |
+| `on_click_left`   | `Script [oneshot]` | `null`  | Runs the script when the module is left clicked.                                                                   |
+| `on_click_middle` | `Script [oneshot]` | `null`  | Runs the script when the module is middle clicked.                                                                 |
+| `on_click_right`  | `Script [oneshot]` | `null`  | Runs the script when the module is right clicked.                                                                  |
+| `on_scroll_up`    | `Script [oneshot]` | `null`  | Runs the script when the module is scroll up on.                                                                   |
+| `on_scroll_down`  | `Script [oneshot]` | `null`  | Runs the script when the module is scrolled down on.                                                               |
+| `tooltip`         | `string`           | `null`  | Shows this text on hover. Supports embedding scripts between `{{double braces}}`.                                  |

--- a/docs/Scripts.md
+++ b/docs/Scripts.md
@@ -3,13 +3,16 @@ that allow script input to dynamically set values.
 
 Scripts are passed to `sh -c`.
 
-Two types of scripts exist: polling and watching:
+Three types of scripts exist: polling, oneshot and watching:
 
-- Polling scripts will run and wait for exit.
+- **Polling** scripts will run and wait for exit.
   Normally they will repeat this at an interval, hence the name, although in some cases they may only run on a user
   event.
   If the script exited code 0, the `stdout` will be used. Otherwise, `stderr` will be printed to the log.
-- Watching scripts start a long-running process. Every time the process writes to `stdout`, the last line is captured
+- **Oneshot** scripts are a variant of polling scripts. 
+  They wait for script to exit, and may do something with the output, but are only fired by user events instead of the interval.
+  Generally options that accept oneshot scripts do not support the other types.
+- **Watching** scripts start a long-running process. Every time the process writes to `stdout`, the last line is captured
   and used.
 
 One should prefer to use watch-mode where possible, as it removes the overhead of regularly spawning processes.
@@ -27,6 +30,8 @@ spawning the script.
 
 Both `mode` and `interval` are optional and can be excluded to fall back to their defaults of `poll` and `5000`
 respectively.
+
+For oneshot scripts, both the mode and interval are ignored.
 
 ### Shorthand (string)
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,0 +1,94 @@
+mod r#impl;
+
+use crate::modules::clock::ClockModule;
+use crate::modules::custom::CustomModule;
+use crate::modules::focused::FocusedModule;
+use crate::modules::launcher::LauncherModule;
+use crate::modules::mpd::MpdModule;
+use crate::modules::script::ScriptModule;
+use crate::modules::sysinfo::SysInfoModule;
+use crate::modules::tray::TrayModule;
+use crate::modules::workspaces::WorkspacesModule;
+use crate::script::ScriptInput;
+use serde::Deserialize;
+use std::collections::HashMap;
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct CommonConfig {
+    pub show_if: Option<ScriptInput>,
+
+    pub on_click_left: Option<ScriptInput>,
+    pub on_click_right: Option<ScriptInput>,
+    pub on_click_middle: Option<ScriptInput>,
+    pub on_scroll_up: Option<ScriptInput>,
+    pub on_scroll_down: Option<ScriptInput>,
+
+    pub tooltip: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ModuleConfig {
+    Clock(ClockModule),
+    Mpd(MpdModule),
+    Tray(TrayModule),
+    Workspaces(WorkspacesModule),
+    SysInfo(SysInfoModule),
+    Launcher(LauncherModule),
+    Script(ScriptModule),
+    Focused(FocusedModule),
+    Custom(CustomModule),
+}
+
+#[derive(Debug, Clone)]
+pub enum MonitorConfig {
+    Single(Config),
+    Multiple(Vec<Config>),
+}
+
+#[derive(Debug, Deserialize, Copy, Clone, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum BarPosition {
+    Top,
+    Bottom,
+    Left,
+    Right,
+}
+
+impl Default for BarPosition {
+    fn default() -> Self {
+        Self::Bottom
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct Config {
+    #[serde(default = "default_bar_position")]
+    pub position: BarPosition,
+    #[serde(default = "default_true")]
+    pub anchor_to_edges: bool,
+    #[serde(default = "default_bar_height")]
+    pub height: i32,
+
+    pub start: Option<Vec<ModuleConfig>>,
+    pub center: Option<Vec<ModuleConfig>>,
+    pub end: Option<Vec<ModuleConfig>>,
+
+    pub monitors: Option<HashMap<String, MonitorConfig>>,
+}
+
+const fn default_bar_position() -> BarPosition {
+    BarPosition::Bottom
+}
+
+const fn default_bar_height() -> i32 {
+    42
+}
+
+pub const fn default_false() -> bool {
+    false
+}
+
+pub const fn default_true() -> bool {
+    true
+}


### PR DESCRIPTION
Adds `on_click_middle`, `on_click_right`, `on_scroll_up`, `on_scroll_down`.

BREAKING CHANGE: `on_click` is now called `on_click_left` for consistency with new options.

Resolves #44.