### PR TITLE
s/pkgs.system/pkgs.hostPlatform.system/g

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -86,7 +86,7 @@
       ...
     }: let
       cfg = config.programs.ironbar;
-      defaultIronbarPackage = self.packages.${pkgs.system}.default;
+      defaultIronbarPackage = self.packages.${pkgs.hostPlatform.system}.default;
       jsonFormat = pkgs.formats.json {};
     in {
       options.programs.ironbar = {


### PR DESCRIPTION
similar to https://github.com/hyprwm/Hyprland/pull/1296

this fixes using ironbar on my system where I have `nixpkgs.config.allowAliases` set to false. Additionally, this is more correct and explicit for what happens when nixpkgs is used in cross compiling scenarios.