### PR TITLE
fix(hyprland): issues with tracking workspaces

### DIFF
--- a/src/clients/compositor/mod.rs
+++ b/src/clients/compositor/mod.rs
@@ -70,13 +70,13 @@ pub enum WorkspaceUpdate {
     /// This is re-sent to all subscribers when a new subscription is created.
     Init(Vec<Workspace>),
     Add(Workspace),
-    Remove(Workspace),
+    Remove(String),
     Update(Workspace),
     Move(Workspace),
     /// Declares focus moved from the old workspace to the new.
     Focus {
-        old: Workspace,
-        new: Workspace,
+        old: String,
+        new: String,
     },
 }
 

--- a/src/clients/compositor/sway.rs
+++ b/src/clients/compositor/sway.rs
@@ -131,12 +131,24 @@ impl From<WorkspaceEvent> for WorkspaceUpdate {
             WorkspaceChange::Init => {
                 Self::Add(event.current.expect("Missing current workspace").into())
             }
-            WorkspaceChange::Empty => {
-                Self::Remove(event.current.expect("Missing current workspace").into())
-            }
+            WorkspaceChange::Empty => Self::Remove(
+                event
+                    .current
+                    .expect("Missing current workspace")
+                    .name
+                    .unwrap_or_default(),
+            ),
             WorkspaceChange::Focus => Self::Focus {
-                old: event.old.expect("Missing old workspace").into(),
-                new: event.current.expect("Missing current workspace").into(),
+                old: event
+                    .old
+                    .expect("Missing old workspace")
+                    .name
+                    .unwrap_or_default(),
+                new: event
+                    .current
+                    .expect("Missing current workspace")
+                    .name
+                    .unwrap_or_default(),
             },
             WorkspaceChange::Move => {
                 Self::Move(event.current.expect("Missing current workspace").into())

--- a/src/modules/workspaces.rs
+++ b/src/modules/workspaces.rs
@@ -191,12 +191,12 @@ impl Module<gtk::Box> for WorkspacesModule {
                         }
                     }
                     WorkspaceUpdate::Focus { old, new } => {
-                        let old = button_map.get(&old.name);
+                        let old = button_map.get(&old);
                         if let Some(old) = old {
                             old.style_context().remove_class("focused");
                         }
 
-                        let new = button_map.get(&new.name);
+                        let new = button_map.get(&new);
                         if let Some(new) = new {
                             new.style_context().add_class("focused");
                         }
@@ -253,7 +253,7 @@ impl Module<gtk::Box> for WorkspacesModule {
                         }
                     }
                     WorkspaceUpdate::Remove(workspace) => {
-                        let button = button_map.get(&workspace.name);
+                        let button = button_map.get(&workspace);
                         if let Some(item) = button {
                             container.remove(item);
                         }


### PR DESCRIPTION
Fixes a couple of issues where switching workspaces rapidly on Hyprland (or sometimes not so rapidly) could cause the widget to come out of sync