### PR TITLE
WIP: fix various system tray issues

### DIFF
--- a/src/bar.rs
+++ b/src/bar.rs
@@ -84,7 +84,7 @@ fn setup_layer_shell(
     gtk_layer_shell::set_monitor(win, monitor);
     gtk_layer_shell::set_layer(win, gtk_layer_shell::Layer::Top);
     gtk_layer_shell::auto_exclusive_zone_enable(win);
-    gtk_layer_shell::set_namespace(win , env!("CARGO_PKG_NAME"));
+    gtk_layer_shell::set_namespace(win, env!("CARGO_PKG_NAME"));
 
     gtk_layer_shell::set_margin(win, gtk_layer_shell::Edge::Top, 0);
     gtk_layer_shell::set_margin(win, gtk_layer_shell::Edge::Bottom, 0);

--- a/src/modules/tray.rs
+++ b/src/modules/tray.rs
@@ -23,14 +23,21 @@ pub struct TrayModule {
 /// Gets a GTK `Image` component
 /// for the status notifier item's icon.
 fn get_icon(item: &StatusNotifierItem) -> Option<Image> {
-    item.icon_theme_path.as_ref().and_then(|path| {
-        let theme = IconTheme::new();
-        theme.append_search_path(path);
-
-        item.icon_name.as_ref().and_then(|icon_name| {
-            let icon_info = theme.lookup_icon(icon_name, 16, IconLookupFlags::empty());
-            icon_info.map(|icon_info| Image::from_pixbuf(icon_info.load_icon().ok().as_ref()))
+    let theme = item
+        .icon_theme_path
+        .as_ref()
+        .map(|path| {
+            let theme = IconTheme::new();
+            theme.append_search_path(path);
+            theme
         })
+        .unwrap_or_default();
+
+    item.icon_name.as_ref().and_then(|icon_name| {
+        tracing::info!("icon name: {icon_name}");
+        let icon_info = theme.lookup_icon(icon_name, 16, IconLookupFlags::empty());
+        tracing::info!("{icon_info:?}");
+        icon_info.map(|icon_info| Image::from_pixbuf(icon_info.load_icon().ok().as_ref()))
     })
 }
 

--- a/src/popup.rs
+++ b/src/popup.rs
@@ -29,7 +29,7 @@ impl Popup {
 
         gtk_layer_shell::init_for_window(&win);
         gtk_layer_shell::set_layer(&win, gtk_layer_shell::Layer::Overlay);
-        gtk_layer_shell::set_namespace(&win , env!("CARGO_PKG_NAME"));
+        gtk_layer_shell::set_namespace(&win, env!("CARGO_PKG_NAME"));
 
         gtk_layer_shell::set_margin(
             &win,


### PR DESCRIPTION
This is a work in progress to get better system tray integration. 

These are the issue I found so far : 
- [x] Fallback to default icon theme when tray item does not have a theme 
- [ ] Some tray items are not displayed (ex: element chat)
- [ ] Tray items only show up if launched after iron bar has started (this is probably something I need to fix in stray)

Let me know if you found more issues with the systray.

 