### PR TITLE
Fix dynamic string ordering

### DIFF
--- a/src/dynamic_string.rs
+++ b/src/dynamic_string.rs
@@ -71,6 +71,9 @@ impl DynamicString {
                     let tx = tx.clone();
                     let label_parts = label_parts.clone();
 
+                    // insert blank value to preserve segment order
+                    lock!(label_parts).push(String::new());
+
                     spawn(async move {
                         script
                             .run(|(out, _)| {


### PR DESCRIPTION
Fixes scripts inside dynamic strings such as tooltips and custom element labels not respecting their configured order.

Fixes #69 