### PR TITLE
Fix `nix run` support

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -57,6 +57,18 @@
           default = self.packages.${system}.ironbar;
         }
     );
+    apps = genSystems (system: let
+      pkgs = pkgsFor system;
+    in {
+      default = {
+        type = "app";
+        program = "${pkgs.ironbar}/bin/ironbar";
+      };
+      ironbar = {
+        type = "app";
+        program = "${pkgs.ironbar}/bin/ironbar";
+      };
+    });
     devShells = genSystems (system: let
       pkgs = pkgsFor system;
       rust = mkRustToolchain pkgs;

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -31,6 +31,6 @@ rustPlatform.buildRustPackage {
     description = "Customisable gtk-layer-shell wlroots/sway bar written in rust.";
     license = licenses.mit;
     platforms = platforms.linux;
-    mainProgram = "Hyprland";
+    mainProgram = "ironbar";
   };
 }


### PR DESCRIPTION
So, I had copied Hyprland's nix pkg metadata as a boilerplate, and forgot to replace one of the strings with `ironbar`, and someone brought it up with me that it was erroring weirdly, and so I fixed it, and also added direct support for `nix run` by defining `apps.<system>.default` instead of making it use a fallback ;). Also, I have tested this locally, can't show screenshot, because ironbar spits out a lot of stuff to stdout, and so I lost the output :P.