### PR TITLE
feat(custom): support common options in widgets

### DIFF
--- a/docs/modules/Custom.md
+++ b/docs/modules/Custom.md
@@ -15,7 +15,8 @@ It is well worth looking at the examples.
 There are many widget types, each with their own config options. 
 You can think of these like HTML elements and their attributes.
 
-Every widget has the following options available; `type` is mandatory.
+Every widget has the following options available; `type` is mandatory. 
+You can also add common [module-level options](https://github.com/JakeStanger/ironbar/wiki/configuration-guide#32-module-level-options) on a widget.
 
 | Name    | Type                                                              | Default | Description                   |
 |---------|-------------------------------------------------------------------|---------|-------------------------------|

--- a/src/modules/custom/box.rs
+++ b/src/modules/custom/box.rs
@@ -1,5 +1,6 @@
-use super::{try_get_orientation, CustomWidget, CustomWidgetContext, Widget};
+use super::{try_get_orientation, CustomWidget, CustomWidgetContext};
 use crate::build;
+use crate::modules::custom::WidgetConfig;
 use gtk::prelude::*;
 use gtk::Orientation;
 use serde::Deserialize;
@@ -9,7 +10,7 @@ pub struct BoxWidget {
     name: Option<String>,
     class: Option<String>,
     orientation: Option<String>,
-    widgets: Option<Vec<Widget>>,
+    widgets: Option<Vec<WidgetConfig>>,
 }
 
 impl CustomWidget for BoxWidget {
@@ -26,7 +27,7 @@ impl CustomWidget for BoxWidget {
 
         if let Some(widgets) = self.widgets {
             for widget in widgets {
-                widget.add_to(&container, context);
+                widget.widget.add_to(&container, context, widget.common);
             }
         }
 


### PR DESCRIPTION
Adds the ability to use common module-level options inside custom module widgets.

Resolves #74.