### PR TITLE
feat: wrap modules in a revealer to support animated show/hide

### DIFF
--- a/src/bar.rs
+++ b/src/bar.rs
@@ -190,11 +190,13 @@ fn add_modules(
     let popup = Popup::new(info, popup_gap);
     let popup = Arc::new(RwLock::new(popup));
 
+    let orientation = info.bar_position.get_orientation();
+
     macro_rules! add_module {
         ($module:expr, $id:expr) => {{
             let common = $module.common.take().expect("Common config did not exist");
             let widget = create_module(*$module, $id, &info, &Arc::clone(&popup))?;
-            let container = wrap_widget(&widget, common);
+            let container = wrap_widget(&widget, common, orientation);
             content.add(&container);
         }};
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -22,7 +22,7 @@ use crate::modules::workspaces::WorkspacesModule;
 use serde::Deserialize;
 use std::collections::HashMap;
 
-pub use self::common::CommonConfig;
+pub use self::common::{CommonConfig, TransitionType};
 pub use self::truncate::{EllipsizeMode, TruncateMode};
 
 #[derive(Debug, Deserialize, Clone)]

--- a/src/modules/custom/mod.rs
+++ b/src/modules/custom/mod.rs
@@ -120,7 +120,11 @@ impl Widget {
     fn add_to(self, parent: &gtk::Box, context: CustomWidgetContext, common: CommonConfig) {
         macro_rules! create {
             ($widget:expr) => {
-                wrap_widget(&$widget.into_widget(context), common)
+                wrap_widget(
+                    &$widget.into_widget(context),
+                    common,
+                    context.bar_orientation,
+                )
             };
         }
 


### PR DESCRIPTION
Resolves #72.

You can control the behaviour using two new `transition_type` and  `transition_duration` module-level options. Defaults to enabled with a 250ms slide animation.