### PR TITLE
fix: fallback to default icon theme for notifier items

### DIFF
--- a/src/modules/tray.rs
+++ b/src/modules/tray.rs
@@ -27,14 +27,19 @@ pub struct TrayModule {
 /// Attempts to get a GTK `Image` component
 /// for the status notifier item's icon.
 fn get_image_from_icon_name(item: &StatusNotifierItem) -> Option<Image> {
-    item.icon_theme_path.as_ref().and_then(|path| {
-        let theme = IconTheme::new();
-        theme.append_search_path(path);
-
-        item.icon_name.as_ref().and_then(|icon_name| {
-            let icon_info = theme.lookup_icon(icon_name, 16, IconLookupFlags::empty());
-            icon_info.map(|icon_info| Image::from_pixbuf(icon_info.load_icon().ok().as_ref()))
+    let theme = item
+        .icon_theme_path
+        .as_ref()
+        .map(|path| {
+            let theme = IconTheme::new();
+            theme.append_search_path(path);
+            theme
         })
+        .unwrap_or_default();
+
+    item.icon_name.as_ref().and_then(|icon_name| {
+        let icon_info = theme.lookup_icon(icon_name, 16, IconLookupFlags::empty());
+        icon_info.map(|icon_info| Image::from_pixbuf(icon_info.load_icon().ok().as_ref()))
     })
 }
 


### PR DESCRIPTION
Duplicates #65 because I cannot update `oknozor/master` directly.