### PR TITLE
fix(music): showing when no mpris player found

### DIFF
--- a/src/clients/music/mpris.rs
+++ b/src/clients/music/mpris.rs
@@ -231,6 +231,16 @@ impl MusicClient for Client {
             if let Err(err) = Self::send_update(&player, &self.tx) {
                 error!("{err:?}");
             }
+        } else {
+            let status = Status {
+                playlist_position: 0,
+                playlist_length: 0,
+                state: PlayerState::Stopped,
+                elapsed: None,
+                duration: None,
+                volume_percent: 0,
+            };
+            send!(self.tx, PlayerUpdate::Update(Box::new(None), status));
         }
 
         rx


### PR DESCRIPTION
The music module expects an event to be sent on subscription to the client to set up the initial state. This ensures an event is sent when in MPRIS mode when no player is initially found.