### PR TITLE
feat(upower): icon size option

### DIFF
--- a/docs/modules/Upower.md
+++ b/docs/modules/Upower.md
@@ -9,9 +9,10 @@ Displays system power information such as the battery percentage, and estimated 
 
 > Type: `upower`
 
-| Name     | Type     | Default         | Description                                       |
-|----------|----------|-----------------|---------------------------------------------------|
-| `format` | `string` | `{percentage}%` | Format string to use for the widget button label. |
+| Name        | Type      | Default         | Description                                       |
+|-------------|-----------|-----------------|---------------------------------------------------|
+| `format`    | `string`  | `{percentage}%` | Format string to use for the widget button label. |
+| `icon_size` | `integer` | `24`            | Size to render icon at.                           |
 
 <details>
 <summary>JSON</summary>

--- a/src/modules/upower.rs
+++ b/src/modules/upower.rs
@@ -24,12 +24,19 @@ pub struct UpowerModule {
     #[serde(default = "default_format")]
     format: String,
 
+    #[serde(default = "default_icon_size")]
+    icon_size: i32,
+
     #[serde(flatten)]
     pub common: Option<CommonConfig>,
 }
 
 fn default_format() -> String {
     String::from("{percentage}%")
+}
+
+const fn default_icon_size() -> i32 {
+    24
 }
 
 #[derive(Clone, Debug)]
@@ -180,7 +187,7 @@ impl Module<gtk::Button> for UpowerModule {
             .attach(None, move |properties: UpowerProperties| {
                 let format = format.replace("{percentage}", &properties.percentage.to_string());
                 let icon_name = String::from("icon:") + &properties.icon_name;
-                ImageProvider::parse(&icon_name, &icon_theme, 24)
+                ImageProvider::parse(&icon_name, &icon_theme, self.icon_size)
                     .map(|provider| provider.load_into_image(icon.clone()));
                 label.set_markup(format.as_ref());
                 Continue(true)


### PR DESCRIPTION
Adds missing `icon_size` config option to upower module.