### PR TITLE
fix(launcher): crash when focusing newly opened window in popup

### DIFF
--- a/src/modules/launcher/mod.rs
+++ b/src/modules/launcher/mod.rs
@@ -468,10 +468,6 @@ impl Module<gtk::Box> for LauncherModule {
                                 let tx = controller_tx.clone();
                                 button.connect_clicked(move |button| {
                                     try_send!(tx, ItemEvent::FocusWindow(win.id));
-
-                                    if let Some(win) = button.window() {
-                                        win.hide();
-                                    }
                                 });
                             }
 


### PR DESCRIPTION
Attempting to focus a newly opened window from the launcher popup attempted to close the popup directly in an invalid manner, which caused the bar to hard crash. The controller already handles this correctly, so removed this code.

Resolves #41 :tada: