### PR TITLE
ci: Add binaries to releases to avoid rebuilding on install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,154 @@
+name: Release
+
+on:
+  workflow_dispatch:
+  release:
+    types: [created]
+
+env:
+  CARGO_TERM_COLOR: always
+
+defaults:
+  run:
+    # necessary for windows
+    shell: bash
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install build deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgtk-3-dev libgtk-layer-shell-dev librust-atk-dev
+      - name: Cargo cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ./target
+          key: test-cargo-registry
+      - name: List
+        run: find ./
+      - name: Run tests
+        run: cargo test --verbose
+
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        # a list of all the targets
+        include:
+          - TARGET: x86_64-unknown-linux-gnu # tested in a debian container on a mac
+            OS: ubuntu-latest
+          # - TARGET: x86_64-unknown-linux-musl # test in an alpine container on a mac
+          #   OS: ubuntu-latest
+          # - TARGET: aarch64-unknown-linux-gnu # tested on aws t4g.nano
+          #   OS: ubuntu-latest
+          # - TARGET: aarch64-unknown-linux-musl # tested on aws t4g.nano in alpine container
+          #   OS: ubuntu-latest
+          # - TARGET: armv7-unknown-linux-gnueabihf # raspberry pi 2-3-4, not tested
+          #   OS: ubuntu-latest
+          # - TARGET: armv7-unknown-linux-musleabihf # raspberry pi 2-3-4, not tested
+          #   OS: ubuntu-latest
+          # - TARGET: arm-unknown-linux-gnueabihf # raspberry pi 0-1, not tested
+          #   OS: ubuntu-latest
+          # - TARGET: arm-unknown-linux-musleabihf # raspberry pi 0-1, not tested
+          #   OS: ubuntu-latest
+          # - TARGET: x86_64-apple-darwin # tested on a mac, is not properly signed so there are security warnings
+          #   OS: macos-latest
+          # - TARGET: x86_64-pc-windows-msvc # tested on a windows machine
+          #   OS: windows-latest
+    needs: test
+    runs-on: ${{ matrix.OS }}
+    env:
+      NAME: ironbar
+      TARGET: ${{ matrix.TARGET }}
+      OS: ${{ matrix.OS }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Cargo cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ./target
+          key: build-cargo-registry-${{matrix.TARGET}}
+      - name: List
+        run: find ./
+      - name: Install build deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgtk-3-dev libgtk-layer-shell-dev librust-atk-dev
+      - name: Install and configure dependencies
+        run: |
+          # dependencies are only needed on ubuntu as that's the only place where
+          # we make cross-compilation
+          if [[ $OS =~ ^ubuntu.*$ ]]; then
+            sudo apt-get install -qq crossbuild-essential-arm64 crossbuild-essential-armhf
+          fi
+
+          # some additional configuration for cross-compilation on linux
+          cat >>~/.cargo/config <<EOF
+          [target.aarch64-unknown-linux-gnu]
+          linker = "aarch64-linux-gnu-gcc"
+          [target.aarch64-unknown-linux-musl]
+          linker = "aarch64-linux-gnu-gcc"
+          [target.armv7-unknown-linux-gnueabihf]
+          linker = "arm-linux-gnueabihf-gcc"
+          [target.armv7-unknown-linux-musleabihf]
+          linker = "arm-linux-gnueabihf-gcc"
+          [target.arm-unknown-linux-gnueabihf]
+          linker = "arm-linux-gnueabihf-gcc"
+          [target.arm-unknown-linux-musleabihf]
+          linker = "arm-linux-gnueabihf-gcc"
+          EOF
+      - name: Install rust target
+        run: rustup target add $TARGET
+      - name: Run build
+        run: cargo build --release --verbose --target $TARGET
+      - name: List target
+        run: find ./target
+      - name: Compress
+        run: |
+          mkdir -p ./artifacts
+          # windows is the only OS using a different convention for executable file name
+          if [[ $OS =~ ^windows.*$ ]]; then
+              EXEC=$NAME.exe
+          else
+              EXEC=$NAME
+          fi
+          if [[ $GITHUB_REF_TYPE =~ ^tag$ ]]; then
+            TAG=$GITHUB_REF_NAME
+          else
+            TAG=$GITHUB_SHA
+          fi
+          mv ./target/$TARGET/release/$EXEC ./$EXEC
+          tar -czf ./artifacts/$NAME-$TARGET-$TAG.tar.gz $EXEC
+      - name: Archive artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: result
+          path: |
+            ./artifacts
+
+  # deploys to github releases on tag
+  deploy:
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: result
+          path: ./artifacts
+      - name: List
+        run: find ./artifacts
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: ./artifacts/*.tar.gz


### PR DESCRIPTION
I want to get cargo binstall working so the install time can be cut down. As a first step, i have added one target: x86_64-linux-gnu. I have left he boiler plate code for the other targets from https://github.com/nicolas-van/rust-cross-compile-example commented out so they can be added if someone can get them working.