### PR TITLE
[Feature] Add basic bar visibility change to IPC

### DIFF
--- a/docs/Configuration guide.md
+++ b/docs/Configuration guide.md
@@ -267,21 +267,22 @@ Check [here](config) for an example config file for a fully configured bar in ea
 
 The following table lists each of the top-level bar config options:
 
-| Name               | Type                                   | Default   | Description                                                                             |
-|--------------------|----------------------------------------|-----------|-----------------------------------------------------------------------------------------|
-| `position`         | `top` or `bottom` or `left` or `right` | `bottom`  | The bar's position on screen.                                                           |
-| `anchor_to_edges`  | `boolean`                              | `false`   | Whether to anchor the bar to the edges of the screen. Setting to false centres the bar. |
-| `height`           | `integer`                              | `42`      | The bar's height in pixels.                                                             |
-| `popup_gap`        | `integer`                              | `5`       | The gap between the bar and popup window.                                               |
-| `margin.top`       | `integer`                              | `0`       | The margin on the top of the bar                                                        |
-| `margin.bottom`    | `integer`                              | `0`       | The margin on the bottom of the bar                                                     |
-| `margin.left`      | `integer`                              | `0`       | The margin on the left of the bar                                                       |
-| `margin.right`     | `integer`                              | `0`       | The margin on the right of the bar                                                      |
-| `icon_theme`       | `string`                               | `null`    | Name of the GTK icon theme to use. Leave blank to use default.                          |
-| `ironvar_defaults` | `Map<string, string>`                  | `{}`      | Map of [ironvar](ironvars) keys against their default values.                           |
-| `start`            | `Module[]`                             | `[]`      | Array of left or top modules.                                                           |
-| `center`           | `Module[]`                             | `[]`      | Array of center modules.                                                                |
-| `end`              | `Module[]`                             | `[]`      | Array of right or bottom modules.                                                       |
+| Name               | Type                                   | Default   | Description                                                                                                     |
+|--------------------|----------------------------------------|-----------|-----------------------------------------------------------------------------------------------------------------|
+| `name`             | `string`                               | `bar-<n>` | A unique identifier for the bar, used for controlling it over IPC. If not set, uses a generated integer suffix. |
+| `position`         | `top` or `bottom` or `left` or `right` | `bottom`  | The bar's position on screen.                                                                                   |
+| `anchor_to_edges`  | `boolean`                              | `false`   | Whether to anchor the bar to the edges of the screen. Setting to false centres the bar.                         |
+| `height`           | `integer`                              | `42`      | The bar's height in pixels.                                                                                     |
+| `popup_gap`        | `integer`                              | `5`       | The gap between the bar and popup window.                                                                       |
+| `margin.top`       | `integer`                              | `0`       | The margin on the top of the bar                                                                                |
+| `margin.bottom`    | `integer`                              | `0`       | The margin on the bottom of the bar                                                                             |
+| `margin.left`      | `integer`                              | `0`       | The margin on the left of the bar                                                                               |
+| `margin.right`     | `integer`                              | `0`       | The margin on the right of the bar                                                                              |
+| `icon_theme`       | `string`                               | `null`    | Name of the GTK icon theme to use. Leave blank to use default.                                                  |
+| `ironvar_defaults` | `Map<string, string>`                  | `{}`      | Map of [ironvar](ironvars) keys against their default values.                                                   |
+| `start`            | `Module[]`                             | `[]`      | Array of left or top modules.                                                                                   |
+| `center`           | `Module[]`                             | `[]`      | Array of center modules.                                                                                        |
+| `end`              | `Module[]`                             | `[]`      | Array of right or bottom modules.                                                                               |
 
 ### 3.2 Module-level options
 

--- a/docs/Controlling Ironbar.md
+++ b/docs/Controlling Ironbar.md
@@ -111,6 +111,33 @@ Responds with `ok` if the stylesheet exists, otherwise `error`.
 }
 ```
 
+### `set_visible`
+
+Sets a bar's visibility.
+
+Responds with `ok` if the bar exists, otherwise `error`.
+
+```json
+{
+  "type": "set_visible",
+  "bar_name": "bar-123",
+  "visible": true
+}
+```
+
+### `get_visible`
+
+Gets a bar's visibility.
+
+Responds with `ok_value` and the visibility (`true`/`false`) if the bar exists, otherwise `error`.
+
+```json
+{
+  "type": "get_visible",
+  "bar_name": "bar-123"
+}
+```
+
 ## Responses
 
 ### `ok`

--- a/src/bar.rs
+++ b/src/bar.rs
@@ -21,6 +21,13 @@ pub fn create_bar(
     config: Config,
 ) -> Result<()> {
     let win = ApplicationWindow::builder().application(app).build();
+    let bar_name = config
+        .name
+        .clone()
+        .unwrap_or_else(|| format!("bar-{}", get_unique_usize()));
+
+    win.set_widget_name(&bar_name);
+    info!("Creating bar {}", bar_name);
 
     setup_layer_shell(
         &win,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -97,6 +97,7 @@ pub struct Config {
     pub margin: MarginConfig,
     #[serde(default = "default_popup_gap")]
     pub popup_gap: i32,
+    pub name: Option<String>,
 
     /// GTK icon theme to use.
     pub icon_theme: Option<String>,
@@ -125,6 +126,7 @@ impl Default for Config {
             position: Default::default(),
             height: default_bar_height(),
             margin: Default::default(),
+            name: None,
             popup_gap: default_popup_gap(),
             icon_theme: None,
             ironvar_defaults: None,

--- a/src/ipc/commands.rs
+++ b/src/ipc/commands.rs
@@ -37,4 +37,18 @@ pub enum Command {
         /// The path to the sheet.
         path: PathBuf,
     },
+
+    /// Set the visibility of the bar with the given name.
+    SetVisible {
+        ///Bar name to target.
+        bar_name: String,
+        /// The visibility status.
+        visible: bool,
+    },
+
+    /// Get the visibility of the bar with the given name.
+    GetVisible {
+        /// Bar name to target.
+        bar_name: String,
+    },
 }

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -146,6 +146,33 @@ impl Ipc {
                 }
             }
             Command::Ping => Response::Ok,
+            Command::SetVisible { bar_name, visible } => {
+                let windows = application.windows();
+                let found = windows
+                    .iter()
+                    .find(|window| window.widget_name() == bar_name);
+
+                if let Some(window) = found {
+                    window.set_visible(visible);
+                    Response::Ok
+                } else {
+                    Response::error("Bar not found")
+                }
+            }
+            Command::GetVisible { bar_name } => {
+                let windows = application.windows();
+                let found = windows
+                    .iter()
+                    .find(|window| window.widget_name() == bar_name);
+
+                if let Some(window) = found {
+                    Response::OkValue {
+                        value: window.is_visible().to_string(),
+                    }
+                } else {
+                    Response::error("Bar not found")
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Adds a `set_visible` IPC command which takes a boolean `visibility` and string `bar_name` fields.
Simultaneously adds a new config `name` option to name each bar individually (defaults to the monitor name)

Behavior as-is will show/hide *every* bar with a given name. e.g, 2 bars both with the name `test` will be shown/hidden if we pass
`{"type":"set_visible","visible"=true,bar_name="test"}`