### PR TITLE
feat(workspaces): visible CSS selector

### DIFF
--- a/docs/modules/Workspaces.md
+++ b/docs/modules/Workspaces.md
@@ -103,6 +103,7 @@ end:
 | `.workspaces`                  | Workspaces widget box                |
 | `.workspaces .item`            | Workspace button                     |
 | `.workspaces .item.focused`    | Workspace button (workspace focused) |
+| `.workspaces .item.visible`    | Workspace button (workspace visible, including focused) |
 | `.workspaces .item.inactive`   | Workspace button (favourite, not currently open)
 | `.workspaces .item .icon`      | Workspace button icon (any type)     |
 | `.workspaces .item .text-icon` | Workspace button icon (textual only) |

--- a/src/clients/compositor/mod.rs
+++ b/src/clients/compositor/mod.rs
@@ -75,8 +75,38 @@ pub struct Workspace {
     pub name: String,
     /// Name of the monitor (output) the workspace is located on
     pub monitor: String,
-    /// Whether the workspace is in focus
-    pub focused: bool,
+    /// How visible the workspace is
+    pub visibility: Visibility,
+}
+
+/// Indicates workspace visibility. Visible workspaces have a boolean flag to indicate if they are also focused.
+/// Yes, this is the same signature as Option<bool>, but it's impl is a lot more suited for our case.
+#[derive(Debug, Copy, Clone)]
+pub enum Visibility {
+    Visible(bool),
+    Hidden,
+}
+
+impl Visibility {
+    pub fn visible() -> Self {
+        Self::Visible(false)
+    }
+
+    pub fn focused() -> Self {
+        Self::Visible(true)
+    }
+
+    pub fn is_visible(self) -> bool {
+        matches!(self, Self::Visible(_))
+    }
+
+    pub fn is_focused(self) -> bool {
+        if let Self::Visible(focused) = self {
+            focused
+        } else {
+            false
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -90,8 +120,8 @@ pub enum WorkspaceUpdate {
     Move(Workspace),
     /// Declares focus moved from the old workspace to the new.
     Focus {
-        old: String,
-        new: String,
+        old: Option<Workspace>,
+        new: Workspace,
     },
 }
 


### PR DESCRIPTION
Adds CSS class `visible` to all workspace buttons whose workspaces are visible (displayed on a monitor), including the focused workspace. Like `focused`, the rule is `.workspaces .item.visible`.

Implementation replaces `focused: bool` of `clients::compositor::Workspace` with `visibility: Visibility`, which represents focused, visible, and hidden (not on a monitor). Both compositors' listeners now fill the changed field, `clients::compositor::WorkspaceUpdate::Focus` now carries `Workspace`s rather than workspace names, and `modules::workspaces::WorkspacesModule` now adds/removes the new CSS class according to the `Workspace`s.

Fixes #282 