### PR TITLE
fix: Home Manager systemdIntegration warnings

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -193,8 +193,8 @@
               ExecStart = "${pkg}/bin/ironbar";
             };
             Install.WantedBy = [
-              (lib.mkIf config.wayland.windowManager.hyprland.systemdIntegration "hyprland-session.target")
-              (lib.mkIf config.wayland.windowManager.sway.systemdIntegration "sway-session.target")
+              (lib.mkIf config.wayland.windowManager.hyprland.systemd.enable "hyprland-session.target")
+              (lib.mkIf config.wayland.windowManager.sway.systemd.enable "sway-session.target")
             ];
           };
         };


### PR DESCRIPTION
The option for wayland.windowManager.hyprland.systemdIntegration has been renamed to wayland.windowManager.hyprland.systemd.enable as of home-manager commit ed0770e96225f998ea128549ad446d9b1568cb2c. 

The option for wayland.windowManager.sway.systemdIntegration has been renamed to wayland.windowManager.sway.systemd.enable as of home-manager commit 0144ac418ef633bfc9dbd89b8c199ad3a617c59f. 

Using the systemdIntegration options will still work for as long as the corresponding mkRenamedModuleOption stays in the respective home-manager modules but using the old option triggers a warning about the the renamed options.