### PR TITLE
feat: bar auto-hide options

### DIFF
--- a/docs/Configuration guide.md
+++ b/docs/Configuration guide.md
@@ -267,22 +267,24 @@ Check [here](config) for an example config file for a fully configured bar in ea
 
 The following table lists each of the top-level bar config options:
 
-| Name               | Type                                   | Default   | Description                                                                                                     |
-|--------------------|----------------------------------------|-----------|-----------------------------------------------------------------------------------------------------------------|
-| `name`             | `string`                               | `bar-<n>` | A unique identifier for the bar, used for controlling it over IPC. If not set, uses a generated integer suffix. |
-| `position`         | `top` or `bottom` or `left` or `right` | `bottom`  | The bar's position on screen.                                                                                   |
-| `anchor_to_edges`  | `boolean`                              | `false`   | Whether to anchor the bar to the edges of the screen. Setting to false centres the bar.                         |
-| `height`           | `integer`                              | `42`      | The bar's height in pixels.                                                                                     |
-| `popup_gap`        | `integer`                              | `5`       | The gap between the bar and popup window.                                                                       |
-| `margin.top`       | `integer`                              | `0`       | The margin on the top of the bar                                                                                |
-| `margin.bottom`    | `integer`                              | `0`       | The margin on the bottom of the bar                                                                             |
-| `margin.left`      | `integer`                              | `0`       | The margin on the left of the bar                                                                               |
-| `margin.right`     | `integer`                              | `0`       | The margin on the right of the bar                                                                              |
-| `icon_theme`       | `string`                               | `null`    | Name of the GTK icon theme to use. Leave blank to use default.                                                  |
-| `ironvar_defaults` | `Map<string, string>`                  | `{}`      | Map of [ironvar](ironvars) keys against their default values.                                                   |
-| `start`            | `Module[]`                             | `[]`      | Array of left or top modules.                                                                                   |
-| `center`           | `Module[]`                             | `[]`      | Array of center modules.                                                                                        |
-| `end`              | `Module[]`                             | `[]`      | Array of right or bottom modules.                                                                               |
+| Name               | Type                                   | Default                              | Description                                                                                                                |
+|--------------------|----------------------------------------|--------------------------------------|----------------------------------------------------------------------------------------------------------------------------|
+| `name`             | `string`                               | `bar-<n>`                            | A unique identifier for the bar, used for controlling it over IPC. If not set, uses a generated integer suffix.            |
+| `position`         | `top` or `bottom` or `left` or `right` | `bottom`                             | The bar's position on screen.                                                                                              |
+| `anchor_to_edges`  | `boolean`                              | `false`                              | Whether to anchor the bar to the edges of the screen. Setting to false centres the bar.                                    |
+| `height`           | `integer`                              | `42`                                 | The bar's height in pixels.                                                                                                |
+| `popup_gap`        | `integer`                              | `5`                                  | The gap between the bar and popup window.                                                                                  |
+| `margin.top`       | `integer`                              | `0`                                  | The margin on the top of the bar                                                                                           |
+| `margin.bottom`    | `integer`                              | `0`                                  | The margin on the bottom of the bar                                                                                        |
+| `margin.left`      | `integer`                              | `0`                                  | The margin on the left of the bar                                                                                          |
+| `margin.right`     | `integer`                              | `0`                                  | The margin on the right of the bar                                                                                         |
+| `icon_theme`       | `string`                               | `null`                               | Name of the GTK icon theme to use. Leave blank to use default.                                                             |
+| `ironvar_defaults` | `Map<string, string>`                  | `{}`                                 | Map of [ironvar](ironvars) keys against their default values.                                                              |
+| `start_hidden`     | `boolean`                              | `false`, or `true` if `autohide` set | Whether the bar should be hidden when the application starts. Enabled by default when `autohide` is set.                   |
+| `autohide`         | `integer`                              | `null`                               | The duration in milliseconds before the bar is hidden after the cursor leaves. Leave unset to disable auto-hide behaviour. |
+| `start`            | `Module[]`                             | `[]`                                 | Array of left or top modules.                                                                                              |
+| `center`           | `Module[]`                             | `[]`                                 | Array of center modules.                                                                                                   |
+| `end`              | `Module[]`                             | `[]`                                 | Array of right or bottom modules.                                                                                          |
 
 ### 3.2 Module-level options
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -99,6 +99,11 @@ pub struct Config {
     pub popup_gap: i32,
     pub name: Option<String>,
 
+    #[serde(default)]
+    pub start_hidden: Option<bool>,
+    #[serde(default)]
+    pub autohide: Option<u64>,
+
     /// GTK icon theme to use.
     pub icon_theme: Option<String>,
 
@@ -127,6 +132,8 @@ impl Default for Config {
             height: default_bar_height(),
             margin: MarginConfig::default(),
             name: None,
+            start_hidden: None,
+            autohide: None,
             popup_gap: default_popup_gap(),
             icon_theme: None,
             ironvar_defaults: None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,6 @@ use glib::PropertySet;
 use gtk::gdk::Display;
 use gtk::prelude::*;
 use gtk::Application;
-use lazy_static::lazy_static;
 use tokio::runtime::Handle;
 use tokio::task::{block_in_place, spawn_blocking};
 use tracing::{debug, error, info, warn};
@@ -93,7 +92,7 @@ async fn run_with_args() {
 static COUNTER: AtomicUsize = AtomicUsize::new(1);
 
 #[cfg(feature = "ipc")]
-lazy_static! {
+lazy_static::lazy_static! {
     static ref VARIABLE_MANAGER: Arc<RwLock<VariableManager>> = arc_rw!(VariableManager::new());
 }
 


### PR DESCRIPTION
Adds two new bar-level options:

- `start_hidden`, which stops a bar from showing when Ironbar starts. It can then be hidden via IPC or auto-hide.
- `autohide`, which takes a delay after which the bar will be hidden when the cursor leaves. Hovering at the screen edge where the bar is located reveals the bar again.

Resolves #167