### PR TITLE
feat: use top-level config as fallback when using monitor-based config

### DIFF
--- a/docs/Configuration guide.md
+++ b/docs/Configuration guide.md
@@ -95,7 +95,11 @@ Create a map/object called `monitors` inside the top-level object.
 Each of the map's keys should be an output name,
 and each value should be an object containing the bar config.
 
-To find your output names, run `wayland-info | grep wl_output -A1`.
+You can still define a top-level "default" config to use for unspecified monitors.
+Alternatively, leave the top-level `start`, `center` and `end` keys null to hide bars on unspecified monitors.
+
+> [!TIP]
+> To find your output names, run `wayland-info | grep wl_output -A1`.
 
 <details>
 <summary>JSON</summary>

--- a/src/main.rs
+++ b/src/main.rs
@@ -276,6 +276,9 @@ fn create_bars(app: &Application, display: &Display, config: &Config) -> Result<
 
     let num_monitors = display.n_monitors();
 
+    let show_default_bar =
+        config.start.is_some() || config.center.is_some() || config.end.is_some();
+
     let mut all_bars = vec![];
     for i in 0..num_monitors {
         let monitor = display
@@ -306,12 +309,13 @@ fn create_bars(app: &Application, display: &Display, config: &Config) -> Result<
                 .iter()
                 .map(|config| create_bar(app, &monitor, monitor_name.to_string(), config.clone()))
                 .collect::<Result<_>>()?,
-            None => vec![create_bar(
+            None if show_default_bar => vec![create_bar(
                 app,
                 &monitor,
                 monitor_name.to_string(),
                 config.clone(),
             )?],
+            None => vec![],
         };
 
         all_bars.append(&mut bars);


### PR DESCRIPTION
This allows you to configure a default bar to use, then override specific monitors.

Not setting anything at the top level will hide bars which are not explicitly configured.

This actually came about as a bug in the recent refactorings, but now it's a feature :)