### PR TITLE
fix: some modules crashing due to recent gtk refactor

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ use glib::PropertySet;
 use gtk::gdk::Display;
 use gtk::prelude::*;
 use gtk::Application;
-use tokio::runtime::{Handle, Runtime};
+use tokio::runtime::Runtime;
 use tokio::task::{block_in_place, JoinHandle};
 use tracing::{debug, error, info, warn};
 use universal_config::ConfigLoader;
@@ -370,5 +370,5 @@ where
 ///
 /// TODO: remove all instances of this once async trait funcs are stable
 pub fn await_sync<F: Future>(f: F) -> F::Output {
-    block_in_place(|| Handle::current().block_on(f))
+    block_in_place(|| Ironbar::runtime().block_on(f))
 }


### PR DESCRIPTION
Fixes a crash introduced by commit bea442e where the `await_sync` function incorrectly tried to use the current tokio runtime, which it is often outside, instead of the singleton.

Fixes #382