### PR TITLE
Workspace Issues Fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1220,9 +1220,9 @@ dependencies = [
 
 [[package]]
 name = "glib"
-version = "0.18.4"
+version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951bbd7fdc5c044ede9f05170f05a3ae9479239c3afdfe2d22d537a3add15c4e"
+checksum = "233daaf6e83ae6a12a52055f568f9d7cf4671dabb78ff9560ab6da230ce00ee5"
 dependencies = [
  "bitflags 2.4.0",
  "futures-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ workspaces = ["futures-util"]
 # core
 gtk = "0.18.1"
 gtk-layer-shell = "0.8.0"
-glib = "0.18.4"
+glib = "0.18.5"
 tokio = { version = "1.35.1", features = [
   "macros",
   "rt-multi-thread",

--- a/src/clients/compositor/hyprland.rs
+++ b/src/clients/compositor/hyprland.rs
@@ -84,7 +84,6 @@ impl EventClient {
                         },
                         |workspace| {
                             // there may be another type of update so dispatch that regardless of focus change
-                            send!(tx, WorkspaceUpdate::Update(workspace.clone()));
                             if !workspace.visibility.is_focused() {
                                 Self::send_focus_change(&mut prev_workspace, workspace, &tx);
                             }

--- a/src/clients/compositor/mod.rs
+++ b/src/clients/compositor/mod.rs
@@ -116,13 +116,17 @@ pub enum WorkspaceUpdate {
     Init(Vec<Workspace>),
     Add(Workspace),
     Remove(String),
-    Update(Workspace),
     Move(Workspace),
     /// Declares focus moved from the old workspace to the new.
     Focus {
         old: Option<Workspace>,
         new: Workspace,
     },
+    /// An update was triggered by the compositor but this was not mapped by Ironbar.
+    ///
+    /// This is purely used for ergonomics within the compositor clients
+    /// and should be ignored by consumers.
+    Unknown,
 }
 
 pub trait WorkspaceClient {

--- a/src/clients/compositor/sway.rs
+++ b/src/clients/compositor/sway.rs
@@ -31,8 +31,11 @@ impl SwayEventClient {
 
                 while let Some(event) = events.next().await {
                     trace!("event: {:?}", event);
-                    if let Event::Workspace(ev) = event? {
-                        workspace_tx.send(WorkspaceUpdate::from(*ev))?;
+                    if let Event::Workspace(event) = event? {
+                        let event = WorkspaceUpdate::from(*event);
+                        if !matches!(event, WorkspaceUpdate::Unknown) {
+                            workspace_tx.send(event)?;
+                        }
                     };
                 }
 
@@ -172,7 +175,7 @@ impl From<WorkspaceEvent> for WorkspaceUpdate {
             WorkspaceChange::Move => {
                 Self::Move(event.current.expect("Missing current workspace").into())
             }
-            _ => Self::Update(event.current.expect("Missing current workspace").into()),
+            _ => Self::Unknown,
         }
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -26,7 +26,7 @@ use serde::Deserialize;
 use std::collections::HashMap;
 
 pub use self::common::{CommonConfig, TransitionType};
-pub use self::truncate::{EllipsizeMode, TruncateMode};
+pub use self::truncate::TruncateMode;
 
 #[derive(Debug, Deserialize, Clone)]
 #[serde(tag = "type", rename_all = "snake_case")]

--- a/src/dynamic_value/dynamic_bool.rs
+++ b/src/dynamic_value/dynamic_bool.rs
@@ -39,7 +39,7 @@ impl DynamicBool {
             _ => self,
         };
 
-        let (tx, mut rx) = mpsc::channel(32);
+        let (tx, rx) = mpsc::channel(32);
 
         glib_recv_mpsc!(rx, val => f(val));
 

--- a/src/dynamic_value/dynamic_string.rs
+++ b/src/dynamic_value/dynamic_string.rs
@@ -32,7 +32,7 @@ where
     let tokens = parse_input(input);
 
     let label_parts = arc_mut!(vec![]);
-    let (tx, mut rx) = mpsc::channel(32);
+    let (tx, rx) = mpsc::channel(32);
 
     for (i, segment) in tokens.into_iter().enumerate() {
         match segment {

--- a/src/image/provider.rs
+++ b/src/image/provider.rs
@@ -145,7 +145,7 @@ impl<'a> ImageProvider<'a> {
         #[cfg(feature = "http")]
         if let ImageLocation::Remote(url) = &self.location {
             let url = url.clone();
-            let (tx, mut rx) = mpsc::channel(64);
+            let (tx, rx) = mpsc::channel(64);
 
             spawn(async move {
                 let bytes = Self::get_bytes_from_http(url).await;

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -22,7 +22,7 @@ impl Ipc {
     ///
     /// Once started, the server will begin accepting connections.
     pub fn start(&self, application: &Application, ironbar: Rc<Ironbar>) {
-        let (cmd_tx, mut cmd_rx) = mpsc::channel(32);
+        let (cmd_tx, cmd_rx) = mpsc::channel(32);
         let (res_tx, mut res_rx) = mpsc::channel(32);
 
         let path = self.path.clone();

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -58,13 +58,15 @@ macro_rules! try_send {
 /// ```
 #[macro_export]
 macro_rules! glib_recv {
-    ($rx:expr, $val:ident => $expr:expr) => {
+    ($rx:expr, $val:ident => $expr:expr) => {{
         glib::spawn_future_local(async move {
-            while let Ok($val) = $rx.recv().await {
+            // re-delcare in case ie `context.subscribe()` is passed directly
+            let mut rx = $rx;
+            while let Ok($val) = rx.recv().await {
                 $expr
             }
         });
-    };
+    }};
 }
 
 /// Spawns a `GLib` future on the local thread, and calls `rx.recv()`
@@ -83,13 +85,15 @@ macro_rules! glib_recv {
 /// ```
 #[macro_export]
 macro_rules! glib_recv_mpsc {
-    ($rx:expr, $val:ident => $expr:expr) => {
+    ($rx:expr, $val:ident => $expr:expr) => {{
         glib::spawn_future_local(async move {
-            while let Some($val) = $rx.recv().await {
+            // re-delcare in case ie `context.subscribe()` is passed directly
+            let mut rx = $rx;
+            while let Some($val) = rx.recv().await {
                 $expr
             }
         });
-    };
+    }};
 }
 
 /// Locks a `Mutex`.

--- a/src/modules/clipboard.rs
+++ b/src/modules/clipboard.rs
@@ -145,7 +145,7 @@ impl Module<Button> for ClipboardModule {
     fn into_popup(
         self,
         tx: mpsc::Sender<Self::ReceiveMessage>,
-        mut rx: broadcast::Receiver<Self::SendMessage>,
+        rx: broadcast::Receiver<Self::SendMessage>,
         _info: &ModuleInfo,
     ) -> Option<gtk::Box>
     where

--- a/src/modules/clock.rs
+++ b/src/modules/clock.rs
@@ -110,7 +110,7 @@ impl Module<Button> for ClockModule {
         let format = self.format.clone();
         let locale = Locale::try_from(self.locale.as_str()).unwrap_or(Locale::POSIX);
 
-        let mut rx = context.subscribe();
+        let rx = context.subscribe();
         glib_recv!(rx, date => {
             let date_string = format!("{}", date.format_localized(&format, locale));
             label.set_label(&date_string);
@@ -126,7 +126,7 @@ impl Module<Button> for ClockModule {
     fn into_popup(
         self,
         _tx: mpsc::Sender<Self::ReceiveMessage>,
-        mut rx: broadcast::Receiver<Self::SendMessage>,
+        rx: broadcast::Receiver<Self::SendMessage>,
         _info: &ModuleInfo,
     ) -> Option<gtk::Box> {
         let container = gtk::Box::new(Orientation::Vertical, 0);

--- a/src/modules/custom/progress.rs
+++ b/src/modules/custom/progress.rs
@@ -47,7 +47,7 @@ impl CustomWidget for ProgressWidget {
             let script = Script::from(value);
             let progress = progress.clone();
 
-            let (tx, mut rx) = mpsc::channel(128);
+            let (tx, rx) = mpsc::channel(128);
 
             spawn(async move {
                 script

--- a/src/modules/custom/slider.rs
+++ b/src/modules/custom/slider.rs
@@ -106,7 +106,7 @@ impl CustomWidget for SliderWidget {
             let script = Script::from(value);
             let scale = scale.clone();
 
-            let (tx, mut rx) = mpsc::channel(128);
+            let (tx, rx) = mpsc::channel(128);
 
             spawn(async move {
                 script

--- a/src/modules/launcher/mod.rs
+++ b/src/modules/launcher/mod.rs
@@ -337,7 +337,7 @@ impl Module<gtk::Box> for LauncherModule {
             let mut buttons = IndexMap::<String, ItemButton>::new();
 
             let tx = context.tx.clone();
-            let mut rx = context.subscribe();
+            let rx = context.subscribe();
             glib_recv!(rx, event => {
                 match event {
                     LauncherUpdate::AddItem(item) => {
@@ -428,7 +428,7 @@ impl Module<gtk::Box> for LauncherModule {
     fn into_popup(
         self,
         controller_tx: mpsc::Sender<Self::ReceiveMessage>,
-        mut rx: broadcast::Receiver<Self::SendMessage>,
+        rx: broadcast::Receiver<Self::SendMessage>,
         _info: &ModuleInfo,
     ) -> Option<gtk::Box> {
         const MAX_WIDTH: i32 = 250;

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -256,7 +256,7 @@ fn register_popup_content(
 /// and communicating update messages between controllers and widgets/popups.
 fn setup_receiver<TSend>(
     tx: broadcast::Sender<TSend>,
-    mut rx: mpsc::Receiver<ModuleUpdateEvent<TSend>>,
+    rx: mpsc::Receiver<ModuleUpdateEvent<TSend>>,
     popup: Rc<RefCell<Popup>>,
     name: &'static str,
     id: usize,

--- a/src/modules/music/mod.rs
+++ b/src/modules/music/mod.rs
@@ -214,7 +214,7 @@ impl Module<Button> for MusicModule {
             let button = button.clone();
 
             let tx = context.tx.clone();
-            let mut rx = context.subscribe();
+            let rx = context.subscribe();
 
             glib_recv!(rx, event => {
                 let ControllerEvent::Update(mut event) = event else {
@@ -263,7 +263,7 @@ impl Module<Button> for MusicModule {
     fn into_popup(
         self,
         tx: mpsc::Sender<Self::ReceiveMessage>,
-        mut rx: broadcast::Receiver<Self::SendMessage>,
+        rx: broadcast::Receiver<Self::SendMessage>,
         info: &ModuleInfo,
     ) -> Option<gtk::Box> {
         let icon_theme = info.icon_theme;

--- a/src/modules/upower.rs
+++ b/src/modules/upower.rs
@@ -181,7 +181,7 @@ impl Module<gtk::Button> for UpowerModule {
         label.set_angle(info.bar_position.get_angle());
         let format = self.format.clone();
 
-        let mut rx = context.subscribe();
+        let rx = context.subscribe();
         glib_recv!(rx, properties => {
             let format = format.replace("{percentage}", &properties.percentage.to_string());
             let icon_name = String::from("icon:") + &properties.icon_name;
@@ -203,7 +203,7 @@ impl Module<gtk::Button> for UpowerModule {
     fn into_popup(
         self,
         _tx: mpsc::Sender<Self::ReceiveMessage>,
-        mut rx: broadcast::Receiver<Self::SendMessage>,
+        rx: broadcast::Receiver<Self::SendMessage>,
         _info: &ModuleInfo,
     ) -> Option<gtk::Box>
     where

--- a/src/modules/workspaces.rs
+++ b/src/modules/workspaces.rs
@@ -10,7 +10,7 @@ use serde::Deserialize;
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 use tokio::sync::mpsc::{Receiver, Sender};
-use tracing::trace;
+use tracing::{debug, trace, warn};
 
 #[derive(Debug, Deserialize, Clone, Copy, Eq, PartialEq)]
 #[serde(rename_all = "snake_case")]
@@ -162,9 +162,10 @@ impl Module<gtk::Box> for WorkspacesModule {
                 client.subscribe_workspace_change()
             };
 
-            trace!("Set up Sway workspace subscription");
+            trace!("Set up workspace subscription");
 
             while let Ok(payload) = srx.recv().await {
+                debug!("Received update: {payload:?}");
                 send_async!(tx, ModuleUpdateEvent::Update(payload));
             }
         });
@@ -351,7 +352,7 @@ impl Module<gtk::Box> for WorkspacesModule {
                             }
                         }
                     }
-                    WorkspaceUpdate::Update(_) => {}
+                    WorkspaceUpdate::Unknown => warn!("Received unknown type workspace event")
                 };
             });
         }

--- a/src/modules/workspaces.rs
+++ b/src/modules/workspaces.rs
@@ -97,6 +97,10 @@ fn create_button(
         style_context.add_class("focused");
     }
 
+    if !visibility.is_visible() {
+        style_context.add_class("inactive")
+    }
+
     {
         let tx = tx.clone();
         let name = name.to_string();

--- a/src/style.rs
+++ b/src/style.rs
@@ -35,7 +35,7 @@ pub fn load_css(style_path: PathBuf) {
         GTK_STYLE_PROVIDER_PRIORITY_USER as u32,
     );
 
-    let (tx, mut rx) = mpsc::channel(8);
+    let (tx, rx) = mpsc::channel(8);
 
     spawn(async move {
         let style_path2 = style_path.clone();


### PR DESCRIPTION
Important commits:

**fix(regression): GTK refactor causing updates to be missed**

Regression introduced by recent GTK refactor.

The `glib_recv` macros  previously using the passed in expression as the receiver, which was causing a new receiver to be created *every* time an event was received. This caused some peculiar behaviours where some events just never got through if sent too close to each other.

This was most obvious in the `workspaces` module.

Fixes #381

**fix(workspaces): favourites missing `inactive` class on startup**

Fixes #390