### PR TITLE
feat: enable use of markup in clock module formats

### DIFF
--- a/docs/modules/Clock.md
+++ b/docs/modules/Clock.md
@@ -10,8 +10,8 @@ Clicking on the widget opens a popup with the time and a calendar.
 
 | Name           | Type     | Default                            | Description                                                                         |
 |----------------|----------|------------------------------------|-------------------------------------------------------------------------------------|
-| `format`       | `string` | `%d/%m/%Y %H:%M`                   | Date/time format string.                                                            |
-| `format_popup` | `string` | `%H:%M:%S`                         | Date/time format string to display in the popup header.                             |
+| `format`       | `string` | `%d/%m/%Y %H:%M`                   | Date/time format string. Pango markup is supported.                                 |
+| `format_popup` | `string` | `%H:%M:%S`                         | Date/time format string to display in the popup header. Pango markup is supported.  |
 | `locale`       | `string` | `$LC_TIME` or `$LANG` or `'POSIX'` | Locale to use (eg `en_GB`). Defaults to the system language (reading from env var). |
 
 > Detail on available tokens can be found here: <https://docs.rs/chrono/latest/chrono/format/strftime/index.html>

--- a/src/modules/clock.rs
+++ b/src/modules/clock.rs
@@ -99,8 +99,10 @@ impl Module<Button> for ClockModule {
         info: &ModuleInfo,
     ) -> Result<ModuleParts<Button>> {
         let button = Button::new();
-        let label = Label::new(None);
-        label.set_angle(info.bar_position.get_angle());
+        let label = Label::builder()
+            .angle(info.bar_position.get_angle())
+            .use_markup(true)
+            .build();
         button.add(&label);
 
         let tx = context.tx.clone();
@@ -132,7 +134,10 @@ impl Module<Button> for ClockModule {
     ) -> Option<gtk::Box> {
         let container = gtk::Box::new(Orientation::Vertical, 0);
 
-        let clock = Label::builder().halign(Align::Center).build();
+        let clock = Label::builder()
+            .halign(Align::Center)
+            .use_markup(true)
+            .build();
         clock.add_class("calendar-clock");
 
         container.add(&clock);


### PR DESCRIPTION
hello! this PR makes a simple change to allow the use of pango markup in clock formats. the plain `label` module does this, so I figured it wouldn't be out of place.

I read in the contributing guidance to open an issue or discussion as best practice, but since this is so small and I wanted it for myself I figured I'd just go straight to PR and I can close or revise it as you like.

thanks for writing ironbar!