### PR TITLE
fix(logging): log file growing indefinitely

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,11 +153,14 @@ See the [Configuration Guide](https://github.com/JakeStanger/ironbar/wiki/config
 
 Ironbar can be launched using the `ironbar` binary.
 
-Log verbosity can be changed using `IRONBAR_LOG` or `IRONBAR_FILE_LOG`. You can use any of `error`, `warn`, `info`, `debug` or `trace`.
+The `IRONBAR_LOG` and `IRONBAR_FILE_LOG` environment variables can be set
+to change console and file log verbosity respectively.
+You can use any of `error`, `warn`, `info`, `debug` or `trace`.
 
-These default to `IRONBAR_LOG=info` and `IRONBAR_FILE_LOG=error`.
+These default to `IRONBAR_LOG=info` and `IRONBAR_FILE_LOG=warn`.
+Note that you cannot increase the file log verbosity above console verbosity.
 
-File output can be found at `~/.local/share/ironbar/error.log`.
+Log files can be found at `~/.local/share/ironbar/.log`.
 
 ## Status
 

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -4,6 +4,7 @@ use std::{env, panic};
 use strip_ansi_escapes::Writer;
 use tracing::error;
 use tracing_appender::non_blocking::{NonBlocking, WorkerGuard};
+use tracing_appender::rolling::Rotation;
 use tracing_error::ErrorLayer;
 use tracing_subscriber::fmt::{Layer, MakeWriter};
 use tracing_subscriber::prelude::*;
@@ -67,7 +68,13 @@ fn install_tracing() -> Result<WorkerGuard> {
 
     let log_path = data_dir().unwrap_or(env::current_dir()?).join("ironbar");
 
-    let appender = tracing_appender::rolling::never(log_path, "error.log");
+    let appender = tracing_appender::rolling::Builder::new()
+        .rotation(Rotation::DAILY)
+        .filename_prefix("ironbar")
+        .filename_suffix("log")
+        .max_log_files(3)
+        .build(log_path)?;
+
     let (file_writer, guard) = tracing_appender::non_blocking(appender);
 
     tracing_subscriber::registry()


### PR DESCRIPTION
Log files are now created on a daily rotation, keeping 3 days worth of logs. This also changes the log file names.

Fixes #453