### PR TITLE
fix(popup): re-position on resize due to content change

### DIFF
--- a/src/bar.rs
+++ b/src/bar.rs
@@ -10,7 +10,6 @@ use gtk::gdk::Monitor;
 use gtk::prelude::*;
 use gtk::{Application, ApplicationWindow, IconTheme, Orientation, Window, WindowType};
 use gtk_layer_shell::LayerShell;
-use std::cell::RefCell;
 use std::rc::Rc;
 use std::time::Duration;
 use tracing::{debug, info};
@@ -18,7 +17,7 @@ use tracing::{debug, info};
 #[derive(Debug, Clone)]
 enum Inner {
     New { config: Option<Config> },
-    Loaded { popup: Rc<RefCell<Popup>> },
+    Loaded { popup: Rc<Popup> },
 }
 
 #[derive(Debug, Clone)]
@@ -269,7 +268,7 @@ impl Bar {
 
         // popup ignores module location so can bodge this for now
         let popup = Popup::new(&info!(ModuleLocation::Left), config.popup_gap);
-        let popup = Rc::new(RefCell::new(popup));
+        let popup = Rc::new(popup);
 
         if let Some(modules) = config.start {
             let info = info!(ModuleLocation::Left);
@@ -315,7 +314,7 @@ impl Bar {
         &self.monitor_name
     }
 
-    pub fn popup(&self) -> Rc<RefCell<Popup>> {
+    pub fn popup(&self) -> Rc<Popup> {
         match &self.inner {
             Inner::New { .. } => {
                 panic!("Attempted to get popup of uninitialized bar. This is a serious bug!")
@@ -339,7 +338,7 @@ fn create_container(name: &str, orientation: Orientation) -> gtk::Box {
 
 #[derive(Debug)]
 struct BarLoadResult {
-    popup: Rc<RefCell<Popup>>,
+    popup: Rc<Popup>,
 }
 
 /// Adds modules into a provided GTK box,
@@ -349,7 +348,7 @@ fn add_modules(
     modules: Vec<ModuleConfig>,
     info: &ModuleInfo,
     ironbar: &Rc<Ironbar>,
-    popup: &Rc<RefCell<Popup>>,
+    popup: &Rc<Popup>,
 ) -> Result<()> {
     let orientation = info.bar_position.orientation();
 

--- a/src/bar.rs
+++ b/src/bar.rs
@@ -60,7 +60,7 @@ impl Bar {
         window.set_widget_name(&name);
 
         let position = config.position;
-        let orientation = position.get_orientation();
+        let orientation = position.orientation();
 
         let content = gtk::Box::builder()
             .orientation(orientation)
@@ -187,7 +187,7 @@ impl Bar {
         win.set_layer_shell_margin(gtk_layer_shell::Edge::Left, margin.left);
         win.set_layer_shell_margin(gtk_layer_shell::Edge::Right, margin.right);
 
-        let bar_orientation = position.get_orientation();
+        let bar_orientation = position.orientation();
 
         win.set_anchor(
             gtk_layer_shell::Edge::Top,
@@ -351,7 +351,7 @@ fn add_modules(
     ironbar: &Rc<Ironbar>,
     popup: &Rc<RefCell<Popup>>,
 ) -> Result<()> {
-    let orientation = info.bar_position.get_orientation();
+    let orientation = info.bar_position.orientation();
 
     macro_rules! add_module {
         ($module:expr, $id:expr) => {{

--- a/src/config/impl.rs
+++ b/src/config/impl.rs
@@ -38,7 +38,7 @@ impl<'de> Deserialize<'de> for MonitorConfig {
 impl BarPosition {
     /// Gets the orientation the bar and widgets should use
     /// based on this position.
-    pub fn get_orientation(self) -> Orientation {
+    pub fn orientation(self) -> Orientation {
         if self == Self::Top || self == Self::Bottom {
             Orientation::Horizontal
         } else {

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -167,13 +167,13 @@ impl Ipc {
                 match bar {
                     Some(bar) => {
                         let popup = bar.popup();
-                        let current_widget = popup.borrow().current_widget();
+                        let current_widget = popup.current_widget();
 
-                        popup.borrow_mut().hide();
+                        popup.hide();
 
                         let data = popup
-                            .borrow()
                             .cache
+                            .borrow()
                             .iter()
                             .find(|(_, value)| value.name == name)
                             .map(|(id, value)| (*id, value.content.buttons.first().cloned()));
@@ -181,7 +181,6 @@ impl Ipc {
                         match data {
                             Some((id, Some(button))) if current_widget != Some(id) => {
                                 let button_id = button.popup_id();
-                                let mut popup = popup.borrow_mut();
 
                                 if popup.is_visible() {
                                     popup.hide();
@@ -207,11 +206,11 @@ impl Ipc {
                         let popup = bar.popup();
 
                         // only one popup per bar, so hide if open for another widget
-                        popup.borrow_mut().hide();
+                        popup.hide();
 
                         let data = popup
-                            .borrow()
                             .cache
+                            .borrow()
                             .iter()
                             .find(|(_, value)| value.name == name)
                             .map(|(id, value)| (*id, value.content.buttons.first().cloned()));
@@ -219,7 +218,7 @@ impl Ipc {
                         match data {
                             Some((id, Some(button))) => {
                                 let button_id = button.popup_id();
-                                popup.borrow_mut().show(id, button_id);
+                                popup.show(id, button_id);
 
                                 Response::Ok
                             }
@@ -236,7 +235,7 @@ impl Ipc {
                 match bar {
                     Some(bar) => {
                         let popup = bar.popup();
-                        popup.borrow_mut().hide();
+                        popup.hide();
 
                         Response::Ok
                     }

--- a/src/modules/custom/mod.rs
+++ b/src/modules/custom/mod.rs
@@ -194,7 +194,7 @@ impl Module<gtk::Box> for CustomModule {
         context: WidgetContext<Self::SendMessage, Self::ReceiveMessage>,
         info: &ModuleInfo,
     ) -> Result<ModuleParts<gtk::Box>> {
-        let orientation = info.bar_position.get_orientation();
+        let orientation = info.bar_position.orientation();
         let container = gtk::Box::builder().orientation(orientation).build();
 
         let popup_buttons = Rc::new(RefCell::new(Vec::new()));
@@ -236,7 +236,7 @@ impl Module<gtk::Box> for CustomModule {
         if let Some(popup) = self.popup {
             let custom_context = CustomWidgetContext {
                 tx: &tx,
-                bar_orientation: info.bar_position.get_orientation(),
+                bar_orientation: info.bar_position.orientation(),
                 icon_theme: info.icon_theme,
                 popup_buttons: Rc::new(RefCell::new(vec![])),
             };

--- a/src/modules/focused.rs
+++ b/src/modules/focused.rs
@@ -113,7 +113,7 @@ impl Module<gtk::Box> for FocusedModule {
     ) -> Result<ModuleParts<gtk::Box>> {
         let icon_theme = info.icon_theme;
 
-        let container = gtk::Box::new(info.bar_position.get_orientation(), 5);
+        let container = gtk::Box::new(info.bar_position.orientation(), 5);
 
         let icon = gtk::Image::new();
         if self.show_icon {

--- a/src/modules/launcher/item.rs
+++ b/src/modules/launcher/item.rs
@@ -225,9 +225,7 @@ impl ItemButton {
 
                     try_send!(
                         tx,
-                        ModuleUpdateEvent::OpenPopupAt(
-                            button.geometry(bar_position.get_orientation())
-                        )
+                        ModuleUpdateEvent::OpenPopupAt(button.geometry(bar_position.orientation()))
                     );
                 } else {
                     try_send!(tx, ModuleUpdateEvent::ClosePopup);

--- a/src/modules/launcher/mod.rs
+++ b/src/modules/launcher/mod.rs
@@ -301,7 +301,7 @@ impl Module<gtk::Box> for LauncherModule {
     ) -> crate::Result<ModuleParts<gtk::Box>> {
         let icon_theme = info.icon_theme;
 
-        let container = gtk::Box::new(info.bar_position.get_orientation(), 0);
+        let container = gtk::Box::new(info.bar_position.orientation(), 0);
 
         {
             let container = container.clone();

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -1,4 +1,3 @@
-use std::cell::RefCell;
 use std::fmt::Debug;
 use std::rc::Rc;
 use std::sync::Arc;
@@ -215,7 +214,7 @@ pub fn create_module<TModule, TWidget, TSend, TRec>(
     ironbar: Rc<Ironbar>,
     name: Option<String>,
     info: &ModuleInfo,
-    popup: &Rc<RefCell<Popup>>,
+    popup: &Rc<Popup>,
 ) -> Result<ModuleParts<TWidget>>
 where
     TModule: Module<TWidget, SendMessage = TSend, ReceiveMessage = TRec>,
@@ -251,22 +250,12 @@ where
             .style_context()
             .add_class(&format!("popup-{module_name}"));
 
-        register_popup_content(popup, id, instance_name, popup_content);
+        popup.register_content(id, instance_name, popup_content);
     }
 
     setup_receiver(tx, ui_rx, popup.clone(), module_name, id);
 
     Ok(module_parts)
-}
-
-/// Registers the popup content with the popup.
-fn register_popup_content(
-    popup: &Rc<RefCell<Popup>>,
-    id: usize,
-    name: String,
-    popup_content: ModulePopupParts,
-) {
-    popup.borrow_mut().register_content(id, name, popup_content);
 }
 
 /// Sets up the bridge channel receiver
@@ -277,7 +266,7 @@ fn register_popup_content(
 fn setup_receiver<TSend>(
     tx: broadcast::Sender<TSend>,
     rx: mpsc::Receiver<ModuleUpdateEvent<TSend>>,
-    popup: Rc<RefCell<Popup>>,
+    popup: Rc<Popup>,
     name: &'static str,
     id: usize,
 ) where
@@ -294,7 +283,6 @@ fn setup_receiver<TSend>(
             }
             ModuleUpdateEvent::TogglePopup(button_id) => {
                 debug!("Toggling popup for {} [#{}]", name, id);
-                let mut popup = popup.borrow_mut();
                 if popup.is_visible() {
                     popup.hide();
                 } else {
@@ -309,8 +297,6 @@ fn setup_receiver<TSend>(
             }
             ModuleUpdateEvent::OpenPopup(button_id) => {
                 debug!("Opening popup for {} [#{}]", name, id);
-
-                let mut popup = popup.borrow_mut();
                 popup.hide();
                 popup.show(id, button_id);
 
@@ -324,7 +310,6 @@ fn setup_receiver<TSend>(
             ModuleUpdateEvent::OpenPopupAt(geometry) => {
                 debug!("Opening popup for {} [#{}]", name, id);
 
-                let mut popup = popup.borrow_mut();
                 popup.hide();
                 popup.show_at(id, geometry);
 
@@ -336,8 +321,6 @@ fn setup_receiver<TSend>(
             }
             ModuleUpdateEvent::ClosePopup => {
                 debug!("Closing popup for {} [#{}]", name, id);
-
-                let mut popup = popup.borrow_mut();
                 popup.hide();
             }
         }

--- a/src/modules/sysinfo.rs
+++ b/src/modules/sysinfo.rs
@@ -188,7 +188,7 @@ impl Module<gtk::Box> for SysInfoModule {
     ) -> Result<ModuleParts<gtk::Box>> {
         let re = Regex::new(r"\{([^}]+)}")?;
 
-        let container = gtk::Box::new(info.bar_position.get_orientation(), 10);
+        let container = gtk::Box::new(info.bar_position.orientation(), 10);
 
         let mut labels = Vec::new();
 

--- a/src/modules/tray/mod.rs
+++ b/src/modules/tray/mod.rs
@@ -89,7 +89,7 @@ impl Module<MenuBar> for TrayModule {
         let container = MenuBar::new();
 
         let direction = self.direction.unwrap_or(
-            if info.bar_position.get_orientation() == gtk::Orientation::Vertical {
+            if info.bar_position.orientation() == gtk::Orientation::Vertical {
                 PackDirection::Ttb
             } else {
                 PackDirection::Ltr

--- a/src/modules/workspaces.rs
+++ b/src/modules/workspaces.rs
@@ -189,7 +189,7 @@ impl Module<gtk::Box> for WorkspacesModule {
         context: WidgetContext<Self::SendMessage, Self::ReceiveMessage>,
         info: &ModuleInfo,
     ) -> Result<ModuleParts<gtk::Box>> {
-        let container = gtk::Box::new(info.bar_position.get_orientation(), 0);
+        let container = gtk::Box::new(info.bar_position.orientation(), 0);
 
         let name_map = self.name_map.clone().unwrap_or_default();
         let favs = self.favorites.clone();


### PR DESCRIPTION
Popups will now correctly re-anchor themselves to the button that opened them if the content resizes. 

This should also fix some long-standing issues where popups are occasionally opened in the wrong place first time they are opened.