### PR TITLE
Rewrite CI build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,18 +9,24 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  RUSTFLAGS: '-Dwarnings'
 
 jobs:
-  build:
+  rustfmt:
     runs-on: ubuntu-latest
-
+    name: 'Formatting'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+      - name: Check formatting
+        run: cargo fmt --check
+
+
+  clippy-base:
+    runs-on: ubuntu-latest
+    name: 'Clippy (Base features)'
+    steps:
+      - uses: actions/checkout@v4
 
       - uses: Swatinem/rust-cache@v2
         name: Cache dependencies
@@ -30,20 +36,45 @@ jobs:
           sudo apt-get update
           sudo apt-get install libgtk-3-dev libgtk-layer-shell-dev
 
-      - name: Check formatting
-        run: cargo fmt --check
+      - name: Clippy
+        run: cargo clippy --no-default-features --features config+json
+        env:
+          # Allow some warnings through as we'll never get it perfect in a zero-feature situation
+          RUSTFLAGS: '-A unused-imports -A unused-variables -A unused-mut -A dead-code'
 
-      - name: Clippy (base features)
-        uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --no-default-features --features config+json
 
-      - name: Clippy (all features)
-        uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features
+  clippy-all:
+    runs-on: ubuntu-latest
+    name: 'Clippy (All features)'
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: Swatinem/rust-cache@v2
+        name: Cache dependencies
+
+      - name: Install build deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install libgtk-3-dev libgtk-layer-shell-dev
+
+      - name: Clippy
+        run: cargo clippy --all-targets --all-features
+
+
+  build:
+    name: 'Build & Test'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: Swatinem/rust-cache@v2
+        name: Cache dependencies
+
+      - name: Install build deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install libgtk-3-dev libgtk-layer-shell-dev
 
       - name: Build
         run: cargo build --verbose
@@ -52,27 +83,3 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-
-
-
-  build-nix:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - uses: cachix/install-nix-action@v20
-        with:
-          install_url: https://nixos.org/nix/install
-          extra_nix_config: |
-            auto-optimise-store = true
-            experimental-features = nix-command flakes
-
-      - uses: cachix/cachix-action@v12
-        with:
-          name: jakestanger
-          signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
-
-      - uses: DeterminateSystems/magic-nix-cache-action@main
-
-      - run: nix build --print-build-logs

--- a/README.md
+++ b/README.md
@@ -127,7 +127,8 @@ A flake is included with the repo which can be used with Home Manager.
 
 </details>
 
-There is a Cachix cache available at `https://app.cachix.org/cache/jakestanger`.
+CI builds are automatically cached by Garnix.
+You can use their binary cache by following the steps [here](https://garnix.io/docs/caching).
 
 ### Source
 


### PR DESCRIPTION
Changes to CI build jobs to do away with the old Nix job now we have Garnix, and split up the main build job to hopefully make things easier to read (and a bit faster).