### PR TITLE
feat(launcher): item.name as fallback for app icon

### DIFF
--- a/src/modules/launcher/item.rs
+++ b/src/modules/launcher/item.rs
@@ -166,8 +166,12 @@ impl ItemButton {
 
         if appearance.show_icons {
             let gtk_image = gtk::Image::new();
-            let image =
-                ImageProvider::parse(&item.app_id.clone(), icon_theme, true, appearance.icon_size);
+            let input = if item.app_id.is_empty() {
+                item.name.clone()
+            } else {
+                item.app_id.clone()
+            };
+            let image = ImageProvider::parse(&input, icon_theme, true, appearance.icon_size);
             if let Some(image) = image {
                 button.set_image(Some(&gtk_image));
                 button.set_always_show_image(true);


### PR DESCRIPTION
When using spotify in wayland with hyprland, the spotify icon is not pulled up correctly by the launcher module:
`spotify --enable-features=UseOzonePlatform,WaylandWindowDecorations --ozone-platform=wayland`
The class/app_id is "" while the name/title is "Spotify Premium". This uses item.name as a fallback which ensure spotify icon shows up correctly under wayland. Spotify under X11 does not have this problem.

Refs: #228, #146