### PR TITLE
Fix(music): mpris - handle no active mpris player on launch & hide label when player list is empty.

### DIFF
--- a/src/clients/music/mod.rs
+++ b/src/clients/music/mod.rs
@@ -34,14 +34,15 @@ pub struct Track {
     pub cover_path: Option<String>,
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Default)]
 pub enum PlayerState {
+    #[default]
+    Stopped,
     Playing,
     Paused,
-    Stopped,
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Status {
     pub state: PlayerState,
     pub volume_percent: Option<u8>,


### PR DESCRIPTION
Sometimes, I see the NoActivePlayer DBusError when no music players are running.

```
2024-03-03T21:41:53.536515Z ERROR ironbar::logging: 48: The application panicked (crashed).
Message:  Failed to connect to D-Bus: DBusError(TransportError(D-Bus error: No player is being controlled by playerctld (com.github.altdesktop.playerctld.NoActivePlayer)))
Location: src/clients/music/mpris.rs:40
```

The first commit prevents the panic so the song shows when the player is started after ironbar was launched.

The second commit checks if all the players have been cleared out and sends None to hide the label in this case. With this change, the music label does not stay after the app is closed.

I tested by
1.start ironbar
2. then spotify,
3. then another player
4. and closed both
5. and restarted spotify.

The show/hide behavior is as expected: 1. none, 2. song1, 3. song2, 4. song2->song1->None, 5. song1


It's entirely possible I missed the actual mechanism to hide the label when no players active. Please let me know if there is a better way. Thank you!