### PR TITLE
refactor: split bar/top-level config structs

### DIFF
--- a/docs/Configuration guide.md
+++ b/docs/Configuration guide.md
@@ -271,26 +271,42 @@ Check [here](config) for an example config file for a fully configured bar in ea
 
 The following table lists each of the top-level bar config options:
 
-| Name               | Type                                   | Default                              | Description                                                                                                                |
-|--------------------|----------------------------------------|--------------------------------------|----------------------------------------------------------------------------------------------------------------------------|
-| `name`             | `string`                               | `bar-<n>`                            | A unique identifier for the bar, used for controlling it over IPC. If not set, uses a generated integer suffix.            |
-| `position`         | `top` or `bottom` or `left` or `right` | `bottom`                             | The bar's position on screen.                                                                                              |
-| `anchor_to_edges`  | `boolean`                              | `false`                              | Whether to anchor the bar to the edges of the screen. Setting to false centres the bar.                                    |
-| `height`           | `integer`                              | `42`                                 | The bar's height in pixels.                                                                                                |
-| `popup_gap`        | `integer`                              | `5`                                  | The gap between the bar and popup window.                                                                                  |
-| `margin.top`       | `integer`                              | `0`                                  | The margin on the top of the bar                                                                                           |
-| `margin.bottom`    | `integer`                              | `0`                                  | The margin on the bottom of the bar                                                                                        |
-| `margin.left`      | `integer`                              | `0`                                  | The margin on the left of the bar                                                                                          |
-| `margin.right`     | `integer`                              | `0`                                  | The margin on the right of the bar                                                                                         |
-| `icon_theme`       | `string`                               | `null`                               | Name of the GTK icon theme to use. Leave blank to use default.                                                             |
-| `ironvar_defaults` | `Map<string, string>`                  | `{}`                                 | Map of [ironvar](ironvars) keys against their default values.                                                              |
-| `start_hidden`     | `boolean`                              | `false`, or `true` if `autohide` set | Whether the bar should be hidden when the application starts. Enabled by default when `autohide` is set.                   |
-| `autohide`         | `integer`                              | `null`                               | The duration in milliseconds before the bar is hidden after the cursor leaves. Leave unset to disable auto-hide behaviour. |
-| `start`            | `Module[]`                             | `[]`                                 | Array of left or top modules.                                                                                              |
-| `center`           | `Module[]`                             | `[]`                                 | Array of center modules.                                                                                                   |
-| `end`              | `Module[]`                             | `[]`                                 | Array of right or bottom modules.                                                                                          |
+| Name               | Type                                    | Default | Description                                                   |
+|--------------------|-----------------------------------------|---------|---------------------------------------------------------------|
+| `ironvar_defaults` | `Map<string, string>`                   | `{}`    | Map of [ironvar](ironvars) keys against their default values. |
+| `monitors`         | `Map<string, BarConfig or BarConfig[]>` | `null`  | Map of monitor names against bar configs.                     |
+
+> [!TIP]
+> `monitors` is only required if you are following **2b** or **2c** (ie not the same bar across all monitors).
+
+> [!Note]
+> All bar-level options listed in the below section can also be defined at the top-level.
+
+# 3.2 Bar-level options
+
+The following table lists each of the bar-level bar config options:
+
+| Name              | Type                                   | Default                              | Description                                                                                                                |
+|-------------------|----------------------------------------|--------------------------------------|----------------------------------------------------------------------------------------------------------------------------|
+| `name`            | `string`                               | `bar-<n>`                            | A unique identifier for the bar, used for controlling it over IPC. If not set, uses a generated integer suffix.            |
+| `position`        | `top` or `bottom` or `left` or `right` | `bottom`                             | The bar's position on screen.                                                                                              |
+| `anchor_to_edges` | `boolean`                              | `false`                              | Whether to anchor the bar to the edges of the screen. Setting to false centres the bar.                                    |
+| `height`          | `integer`                              | `42`                                 | The bar's height in pixels.                                                                                                |
+| `popup_gap`       | `integer`                              | `5`                                  | The gap between the bar and popup window.                                                                                  |
+| `margin.top`      | `integer`                              | `0`                                  | The margin on the top of the bar                                                                                           |
+| `margin.bottom`   | `integer`                              | `0`                                  | The margin on the bottom of the bar                                                                                        |
+| `margin.left`     | `integer`                              | `0`                                  | The margin on the left of the bar                                                                                          |
+| `margin.right`    | `integer`                              | `0`                                  | The margin on the right of the bar                                                                                         |
+| `icon_theme`      | `string`                               | `null`                               | Name of the GTK icon theme to use. Leave blank to use default.                                                             |
+| `start_hidden`    | `boolean`                              | `false`, or `true` if `autohide` set | Whether the bar should be hidden when the application starts. Enabled by default when `autohide` is set.                   |
+| `autohide`        | `integer`                              | `null`                               | The duration in milliseconds before the bar is hidden after the cursor leaves. Leave unset to disable auto-hide behaviour. |
+| `start`           | `Module[]`                             | `[]`                                 | Array of left or top modules.                                                                                              |
+| `center`          | `Module[]`                             | `[]`                                 | Array of center modules.                                                                                                   |
+| `end`             | `Module[]`                             | `[]`                                 | Array of right or bottom modules.                                                                                          |
 
 ### 3.2 Module-level options
+
+Each module must include a `type` key.
 
 The following table lists each of the module-level options that are present on **all** modules.
 For details on available modules and each of their config options, check the sidebar.
@@ -299,18 +315,17 @@ For information on the `Script` type, and embedding scripts in strings, see [her
 
 #### Events
 
-| Name              | Type               | Default | Description                                                                                                        |
-|-------------------|--------------------|---------|--------------------------------------------------------------------------------------------------------------------|
-| `on_click_left`   | `Script [oneshot]` | `null`  | Runs the script when the module is left clicked.                                                                   |
-| `on_click_middle` | `Script [oneshot]` | `null`  | Runs the script when the module is middle clicked.                                                                 |
-| `on_click_right`  | `Script [oneshot]` | `null`  | Runs the script when the module is right clicked.                                                                  |
-| `on_scroll_up`    | `Script [oneshot]` | `null`  | Runs the script when the module is scroll up on.                                                                   |
-| `on_scroll_down`  | `Script [oneshot]` | `null`  | Runs the script when the module is scrolled down on.                                                               |
-| `on_mouse_enter`  | `Script [oneshot]` | `null`  | Runs the script when the module is hovered over.                                                                   |
-| `on_mouse_exit`   | `Script [oneshot]` | `null`  | Runs the script when the module is no longer hovered over.                                                         |
+| Name              | Type               | Default | Description                                                |
+|-------------------|--------------------|---------|------------------------------------------------------------|
+| `on_click_left`   | `Script [oneshot]` | `null`  | Runs the script when the module is left clicked.           |
+| `on_click_middle` | `Script [oneshot]` | `null`  | Runs the script when the module is middle clicked.         |
+| `on_click_right`  | `Script [oneshot]` | `null`  | Runs the script when the module is right clicked.          |
+| `on_scroll_up`    | `Script [oneshot]` | `null`  | Runs the script when the module is scroll up on.           |
+| `on_scroll_down`  | `Script [oneshot]` | `null`  | Runs the script when the module is scrolled down on.       |
+| `on_mouse_enter`  | `Script [oneshot]` | `null`  | Runs the script when the module is hovered over.           |
+| `on_mouse_exit`   | `Script [oneshot]` | `null`  | Runs the script when the module is no longer hovered over. |
 
 #### Visibility
-
 
 | Name                  | Type                                                  | Default       | Description                                                                                                        |
 |-----------------------|-------------------------------------------------------|---------------|--------------------------------------------------------------------------------------------------------------------|
@@ -320,10 +335,10 @@ For information on the `Script` type, and embedding scripts in strings, see [her
 
 #### Appearance
 
-| Name      | Type               | Default | Description                                                                       |
-|-----------|--------------------|---------|-----------------------------------------------------------------------------------|
-| `tooltip` | `string`           | `null`  | Shows this text on hover. Supports embedding scripts between `{{double braces}}`. |
-| `name`    | `string`           | `null`  | Sets the unique widget name, allowing you to style it using `#name`.              |
-| `class`   | `string`           | `null`  | Sets one or more CSS classes, allowing you to style it using `.class`.            |
+| Name      | Type     | Default | Description                                                                       |
+|-----------|----------|---------|-----------------------------------------------------------------------------------|
+| `tooltip` | `string` | `null`  | Shows this text on hover. Supports embedding scripts between `{{double braces}}`. |
+| `name`    | `string` | `null`  | Sets the unique widget name, allowing you to style it using `#name`.              |
+| `class`   | `string` | `null`  | Sets one or more CSS classes, allowing you to style it using `.class`.            |
 
 For more information on styling, please see the [styling guide](styling-guide).

--- a/src/bar.rs
+++ b/src/bar.rs
@@ -1,9 +1,9 @@
-use crate::config::{BarPosition, MarginConfig, ModuleConfig};
+use crate::config::{BarConfig, BarPosition, MarginConfig, ModuleConfig};
 use crate::modules::{
     create_module, set_widget_identifiers, wrap_widget, ModuleInfo, ModuleLocation,
 };
 use crate::popup::Popup;
-use crate::{Config, Ironbar};
+use crate::Ironbar;
 use color_eyre::Result;
 use glib::Propagation;
 use gtk::gdk::Monitor;
@@ -16,7 +16,7 @@ use tracing::{debug, info};
 
 #[derive(Debug, Clone)]
 enum Inner {
-    New { config: Option<Config> },
+    New { config: Option<BarConfig> },
     Loaded { popup: Rc<Popup> },
 }
 
@@ -43,7 +43,7 @@ impl Bar {
     pub fn new(
         app: &Application,
         monitor_name: String,
-        config: Config,
+        config: BarConfig,
         ironbar: Rc<Ironbar>,
     ) -> Self {
         let window = ApplicationWindow::builder()
@@ -245,7 +245,7 @@ impl Bar {
     }
 
     /// Loads the configured modules onto a bar.
-    fn load_modules(&self, config: Config, monitor: &Monitor) -> Result<BarLoadResult> {
+    fn load_modules(&self, config: BarConfig, monitor: &Monitor) -> Result<BarLoadResult> {
         let icon_theme = IconTheme::new();
         if let Some(ref theme) = config.icon_theme {
             icon_theme.set_custom_theme(Some(theme));
@@ -408,7 +408,7 @@ pub fn create_bar(
     app: &Application,
     monitor: &Monitor,
     monitor_name: String,
-    config: Config,
+    config: BarConfig,
     ironbar: Rc<Ironbar>,
 ) -> Result<Bar> {
     let bar = Bar::new(app, monitor_name, config, ironbar);

--- a/src/config/impl.rs
+++ b/src/config/impl.rs
@@ -1,4 +1,4 @@
-use super::{BarPosition, Config, MonitorConfig};
+use super::{BarConfig, BarPosition, MonitorConfig};
 use color_eyre::{Help, Report};
 use gtk::Orientation;
 use serde::{Deserialize, Deserializer};
@@ -13,11 +13,11 @@ impl<'de> Deserialize<'de> for MonitorConfig {
         let content =
             <serde::__private::de::Content as serde::Deserialize>::deserialize(deserializer)?;
 
-        match <Config as serde::Deserialize>::deserialize(
+        match <BarConfig as serde::Deserialize>::deserialize(
             serde::__private::de::ContentRefDeserializer::<D::Error>::new(&content),
         ) {
             Ok(config) => Ok(Self::Single(config)),
-            Err(outer) => match <Vec<Config> as serde::Deserialize>::deserialize(
+            Err(outer) => match <Vec<BarConfig> as serde::Deserialize>::deserialize(
                 serde::__private::de::ContentRefDeserializer::<D::Error>::new(&content),
             ) {
                 Ok(config) => Ok(Self::Multiple(config)),

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -64,10 +64,16 @@ pub enum ModuleConfig {
     Workspaces(Box<WorkspacesModule>),
 }
 
+#[derive(Debug, Deserialize, Clone)]
+pub enum BarEntryConfig {
+    Single(BarConfig),
+    Monitors(HashMap<String, MonitorConfig>),
+}
+
 #[derive(Debug, Clone)]
 pub enum MonitorConfig {
-    Single(Config),
-    Multiple(Vec<Config>),
+    Single(BarConfig),
+    Multiple(Vec<BarConfig>),
 }
 
 #[derive(Debug, Deserialize, Copy, Clone, PartialEq, Eq)]
@@ -98,7 +104,7 @@ pub struct MarginConfig {
 }
 
 #[derive(Debug, Deserialize, Clone)]
-pub struct Config {
+pub struct BarConfig {
     #[serde(default)]
     pub position: BarPosition,
     #[serde(default = "default_true")]
@@ -107,8 +113,6 @@ pub struct Config {
     pub height: i32,
     #[serde(default)]
     pub margin: MarginConfig,
-    #[serde(default = "default_popup_gap")]
-    pub popup_gap: i32,
     pub name: Option<String>,
 
     #[serde(default)]
@@ -119,16 +123,15 @@ pub struct Config {
     /// GTK icon theme to use.
     pub icon_theme: Option<String>,
 
-    pub ironvar_defaults: Option<HashMap<Box<str>, String>>,
-
     pub start: Option<Vec<ModuleConfig>>,
     pub center: Option<Vec<ModuleConfig>>,
     pub end: Option<Vec<ModuleConfig>>,
 
-    pub monitors: Option<HashMap<String, MonitorConfig>>,
+    #[serde(default = "default_popup_gap")]
+    pub popup_gap: i32,
 }
 
-impl Default for Config {
+impl Default for BarConfig {
     fn default() -> Self {
         cfg_if! {
             if #[cfg(feature = "clock")] {
@@ -155,18 +158,25 @@ impl Default for Config {
             name: None,
             start_hidden: None,
             autohide: None,
-            popup_gap: default_popup_gap(),
             icon_theme: None,
-            ironvar_defaults: None,
             start: Some(vec![ModuleConfig::Label(
                 LabelModule::new("ℹ️ Using default config".to_string()).into(),
             )]),
             center,
             end,
             anchor_to_edges: default_true(),
-            monitors: None,
+            popup_gap: default_popup_gap(),
         }
     }
+}
+
+#[derive(Debug, Deserialize, Clone, Default)]
+pub struct Config {
+    pub ironvar_defaults: Option<HashMap<Box<str>, String>>,
+
+    #[serde(flatten)]
+    pub bar: BarConfig,
+    pub monitors: Option<HashMap<String, MonitorConfig>>,
 }
 
 const fn default_bar_height() -> i32 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -331,7 +331,7 @@ fn load_output_bars(
         .expect("monitor to exist");
 
     let show_default_bar =
-        config.start.is_some() || config.center.is_some() || config.end.is_some();
+        config.bar.start.is_some() || config.bar.center.is_some() || config.bar.end.is_some();
 
     let bars = match config
         .monitors
@@ -363,7 +363,7 @@ fn load_output_bars(
             app,
             &monitor,
             monitor_name.to_string(),
-            config.clone(),
+            config.bar.clone(),
             ironbar.clone(),
         )?],
         None => vec![],


### PR DESCRIPTION
This allows for some options which are not actually bar-level to be separated, which makes some work moving forward a little easier and keeps things cleaner.