### PR TITLE
Fix #546: Convert from ARGB32 to RGBA32 formats for Pixmaps

### DIFF
--- a/src/modules/tray/icon.rs
+++ b/src/modules/tray/icon.rs
@@ -93,11 +93,11 @@ fn get_image_from_pixmap(item: &TrayMenu, size: u32) -> Result<Image> {
     let mut pixels = pixmap.pixels.to_vec();
 
     for i in (0..pixels.len()).step_by(4) {
-        let alpha = pixels[i]; 
-        pixels[i] = pixels[i+1];
-        pixels[i+1] = pixels[i+2];
-        pixels[i+2] = pixels[i+3];
-        pixels[i+3] = alpha;
+        let alpha = pixels[i];
+        pixels[i] = pixels[i + 1];
+        pixels[i + 1] = pixels[i + 2];
+        pixels[i + 2] = pixels[i + 3];
+        pixels[i + 3] = alpha;
     }
 
     let row_stride = pixmap.width * 4;


### PR DESCRIPTION
Simple change to swap the channel order of the incoming pixmap data from ARGB to RGBA before creating the pixbuf.

Using the same icon as the one I added in the issue, it now renders like this, which is much more accurate to the original.

![2024-04-21T19:12:29,362148653-04:00](https://github.com/JakeStanger/ironbar/assets/1231364/cdd9500a-e4c2-45a2-acc9-6ae35104da0e)

Also I'm still very new to rust, so if there's a cleaner way to do this please let me know.

Fixes #546 