### PR TITLE
Add reverse order for launcher items/favorites

### DIFF
--- a/docs/modules/Launcher.md
+++ b/docs/modules/Launcher.md
@@ -18,7 +18,7 @@ Optionally displays a launchable set of favourites.
 | `show_names` | `boolean`  | `false` | Whether to show app names on the button label. Names will still show on tooltips when set to false. |
 | `show_icons` | `boolean`  | `true`  | Whether to show app icons on the button.                                                            |
 | `icon_size`  | `integer`  | `32`    | Size to render icon at (image icons only).                                                          |
-
+| `reversed`   | `boolean`  | `false` | Whether to reverse the order of favorites/items                                                     |
 <details>
 <summary>JSON</summary>
 

--- a/docs/modules/Launcher.md
+++ b/docs/modules/Launcher.md
@@ -32,7 +32,8 @@ Optionally displays a launchable set of favourites.
         "discord"
       ],
       "show_names": false,
-      "show_icons": true
+      "show_icons": true,
+      "reversed": false
     }
   ]
 }
@@ -51,6 +52,7 @@ type = "launcher"
 favorites = ["firefox", "discord"]
 show_names = false
 show_icons = true
+reversed = false
 ```
 
 </details>
@@ -66,6 +68,7 @@ start:
       - discord
     show_names: false
     show_icons: true
+    reversed: false
 ```
 
 </details>
@@ -81,7 +84,7 @@ start:
       favorites = [ "firefox" "discord" ]
       show_names = false
       show_icons = true
-
+      reversed = false
     }
   ]
 }

--- a/src/modules/launcher/mod.rs
+++ b/src/modules/launcher/mod.rs
@@ -340,12 +340,13 @@ impl Module<gtk::Box> for LauncherModule {
                                 &tx,
                                 &controller_tx,
                             );
-                            
+
                             if self.reversed {
                                 container.pack_end(&button.button, false, false, 0);
                             } else {
                                 container.add(&button.button);
                             }
+
                             buttons.insert(item.app_id, button);
                         }
                     }

--- a/src/modules/launcher/mod.rs
+++ b/src/modules/launcher/mod.rs
@@ -33,6 +33,9 @@ pub struct LauncherModule {
     #[serde(default = "default_icon_size")]
     icon_size: i32,
 
+    #[serde(default = "crate::config::default_false")]
+    reversed: bool,
+
     #[serde(flatten)]
     pub common: Option<CommonConfig>,
 }
@@ -337,8 +340,12 @@ impl Module<gtk::Box> for LauncherModule {
                                 &tx,
                                 &controller_tx,
                             );
-
-                            container.add(&button.button);
+                            
+                            if self.reversed {
+                                container.pack_end(&button.button, false, false, 0);
+                            } else {
+                                container.add(&button.button);
+                            }
                             buttons.insert(item.app_id, button);
                         }
                     }


### PR DESCRIPTION
example json config

      {
        "type": "launcher",
        "favorites": [
          "firefox",
          "discord",
          "steam"
        ],
        "reversed": true,
        "show_names": false,
        "show_icons": true,
        "icon_size": 32
      }