### PR TITLE
fix(ci): Trigger Binary workflow on workflow_run, workflow_dispatch.

### DIFF
--- a/.github/workflows/binary.yml
+++ b/.github/workflows/binary.yml
@@ -1,21 +1,43 @@
-# .github/workflows/binary.yml
-
 name: Binary
 on:
+  workflow_run:
+    workflows: [Deploy]
+    types: [completed]
   release:
     types: [created]
+  workflow_dispatch:
+
 jobs:
+  get_last_release:
+    runs-on: ubuntu-latest
+    outputs:
+      latest_release_tag: ${{ steps.latest-release.outputs.LATEST_RELEASE_TAG }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Extract the latest release
+        id: latest-release
+        run: echo "LATEST_RELEASE_TAG=$(gh release ls --json isLatest,tagName -q '.[] | select(.isLatest == true) | .tagName')" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+
   build:
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     name: Build
     runs-on: ubuntu-latest
+    needs: get_last_release
     strategy:
       fail-fast: false
       matrix:
         platform:
           - {target: x86_64-unknown-linux-gnu, zipext: ".tar.gz"}
           - {target: aarch64-unknown-linux-gnu, zipext: ".tar.gz"}
+
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.get_last_release.outputs.latest_release_tag }}
+
       - uses: taiki-e/install-action@v2
         with:
           tool: cross
@@ -34,6 +56,13 @@ jobs:
         run: tar -zcvf ${{env.BINARY_NAME}}-${{github.ref_name}}-${{matrix.platform.target}}.tar.gz -C target/${{matrix.platform.target}}/release ${{env.BINARY_NAME}}
 
       - name: Upload to release
-        run: gh release upload ${GITHUB_REF#refs/*/} ${{env.BINARY_NAME}}-${{github.ref_name}}-${{matrix.platform.target}}${{matrix.platform.zipext}}
+        run: gh release upload ${{needs.get_last_release.outputs.latest_release_tag}} ${{env.BINARY_NAME}}-${{github.ref_name}}-${{matrix.platform.target}}${{matrix.platform.zipext}}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  on-failure:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'failure' }}
+    steps:
+      - run: echo 'The triggering workflow Deploy failed'
+      - run: exit 1


### PR DESCRIPTION
Please check the [releases](https://github.com/slowsage/ironbar/releases) and [actions](https://github.com/slowsage/ironbar/actions) log on fork's master branch to verify. [Master](https://github.com/slowsage/ironbar/commits/master/) is ahead of this commit.
Was pretty easy to add check and handle failures:
Here is the order of Binary runs in [actions](https://github.com/slowsage/ironbar/actions) log.
1. Deploy => binary succeeds. assets uploaded to v0.15.1
2. Deploy and binary failed.
3. workflow_dispatch - succeeds, uploads to v0.15.2
4. Manual release. succeeds, uploads to v0.15.3

Edit: The basic idea is to keep deploy.yml independent and bind to last release ref manually which automatically enabled `workflow_dispatch`.