### PR TITLE
ci(binary): use release tag instead of github.ref_name

### DIFF
--- a/.github/workflows/binary.yml
+++ b/.github/workflows/binary.yml
@@ -53,10 +53,10 @@ jobs:
 
       - name: Compress the built binary
         if: ${{ matrix.platform.zipext == '.tar.gz' }}
-        run: tar -zcvf ${{env.BINARY_NAME}}-${{github.ref_name}}-${{matrix.platform.target}}.tar.gz -C target/${{matrix.platform.target}}/release ${{env.BINARY_NAME}}
+        run: tar -zcvf ${{env.BINARY_NAME}}-${{needs.get_last_release.outputs.latest_release_tag}}-${{matrix.platform.target}}.tar.gz -C target/${{matrix.platform.target}}/release ${{env.BINARY_NAME}}
 
       - name: Upload to release
-        run: gh release upload ${{needs.get_last_release.outputs.latest_release_tag}} ${{env.BINARY_NAME}}-${{github.ref_name}}-${{matrix.platform.target}}${{matrix.platform.zipext}}
+        run: gh release upload ${{needs.get_last_release.outputs.latest_release_tag}} ${{env.BINARY_NAME}}-${{needs.get_last_release.outputs.latest_release_tag}}-${{matrix.platform.target}}${{matrix.platform.zipext}}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Sorry, one oversight: The zip file uses github.ref_name which resolves to master. This uses the release tag instead. Verified [here](https://github.com/slowsage/ironbar/releases/tag/v0.15.4).
You can run  again using `workflow_dispatch` to fix the name for `v0.15.0`.