### PR TITLE
fix(workspaces): add support for hyprland rename event

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1444,9 +1444,9 @@ dependencies = [
 
 [[package]]
 name = "hyprland"
-version = "0.4.0-alpha.1"
+version = "0.4.0-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54fdc60390459bd6da28ec708ee7a672b8f6680efb8f8f33cbe970da16f40a48"
+checksum = "d627cd06fb3389f2554b7a4bb21db8c0bfca8863e6e653702cc4c6dbf20d8276"
 dependencies = [
  "ahash",
  "derive_more",
@@ -2008,9 +2008,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,7 +148,7 @@ libpulse-binding = { version = "2.28.1", optional = true }
 
 # workspaces
 swayipc-async = { version = "2.0.1", optional = true }
-hyprland = { version = "0.4.0-alpha.1", features = ["silent"], optional = true }
+hyprland = { version = "0.4.0-alpha.2", features = ["silent"], optional = true }
 futures-util = { version = "0.3.30", optional = true }
 num-traits = "0.2.18"
 

--- a/src/clients/compositor/mod.rs
+++ b/src/clients/compositor/mod.rs
@@ -126,6 +126,12 @@ pub enum WorkspaceUpdate {
         old: Option<Workspace>,
         new: Workspace,
     },
+
+    Rename {
+        id: String,
+        name: String,
+    },
+
     /// An update was triggered by the compositor but this was not mapped by Ironbar.
     ///
     /// This is purely used for ergonomics within the compositor clients


### PR DESCRIPTION
Renaming workspaces on Hyprland will now work as expected.

This also refactors the workspace code to depend on IDs rather than names which should make it more robust against the same sort of issue in future.

Fixes #469

---

Draft until new hyprland-rs alpha releases