### PR TITLE
Add pango markup support to remaining locations

### DIFF
--- a/src/image/gtk.rs
+++ b/src/image/gtk.rs
@@ -44,7 +44,7 @@ pub fn new_icon_label(input: &str, icon_theme: &IconTheme, size: i32) -> gtk::Bo
         ImageProvider::parse(input, icon_theme, false, size)
             .map(|provider| provider.load_into_image(image));
     } else {
-        let label = Label::new(Some(input));
+        let label = Label::builder().use_markup(true).label(input).build();
         label.add_class("icon");
         label.add_class("text-icon");
 

--- a/src/modules/music/mod.rs
+++ b/src/modules/music/mod.rs
@@ -191,6 +191,7 @@ impl Module<Button> for MusicModule {
         let icon_pause = new_icon_label(&self.icons.pause, info.icon_theme, self.icon_size);
         let label = Label::new(None);
 
+        label.set_use_markup(true);
         label.set_angle(info.bar_position.get_angle());
 
         if let Some(truncate) = self.truncate {
@@ -544,7 +545,14 @@ impl IconLabel {
         let container = gtk::Box::new(Orientation::Horizontal, 5);
 
         let icon = new_icon_label(icon_input, icon_theme, 24);
-        let label = Label::new(label);
+
+        let mut builder = Label::builder().use_markup(true);
+
+        if let Some(label) = label {
+            builder = builder.label(label);
+        }
+
+        let label = builder.build();
 
         icon.add_class("icon-box");
         label.add_class("label");


### PR DESCRIPTION
Adds to `music` module formatting string, and all textual icon options.

Resolves #443 