### PR TITLE
Fix reload bug

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -353,7 +353,7 @@ fn load_output_bars(
 
     let index = lock!(map).iter().position(|n| n == monitor_name);
     let index = match index {
-        Some(index) => index - 1,
+        Some(index) => index,
         None => {
             lock!(map).push(monitor_name.clone());
             lock!(map).len() - 1


### PR DESCRIPTION
    let index = match index {
        Some(index) => index - 1,
        None => {
            lock!(map).push(monitor_name.clone());
            lock!(map).len() - 1
        }
    };

//This causes index to underflow
//Expected Output is something like 0, 1, etc
//But sometimes we go back around to 18446744073709551615

//Removing the index -1 here seems to work ok with multi monitor, and reload is not broken anymore

Fixes #598 