### PR TITLE
Fix Pango markup not escaped

### DIFF
--- a/src/dynamic_value/dynamic_string.rs
+++ b/src/dynamic_value/dynamic_string.rs
@@ -22,7 +22,7 @@ enum DynamicStringSegment {
 ///
 /// ```rs
 /// dynamic_string(&text, move |string| {
-///     label.set_markup(&string);
+///     label.set_markup_escaped(&string);
 /// });
 /// ```
 pub fn dynamic_string<F>(input: &str, mut f: F)

--- a/src/gtk_helpers.rs
+++ b/src/gtk_helpers.rs
@@ -1,6 +1,6 @@
-use glib::IsA;
+use glib::{markup_escape_text, IsA};
 use gtk::prelude::*;
-use gtk::{Orientation, Widget};
+use gtk::{Label, Orientation, Widget};
 
 /// Represents a widget's size
 /// and location relative to the bar's start edge.
@@ -73,5 +73,18 @@ impl<W: IsA<Widget>> IronbarGtkExt for W {
 
     fn set_tag<V: 'static>(&self, key: &str, value: V) {
         unsafe { self.set_data(key, value) }
+    }
+}
+
+pub trait IronbarLabelExt {
+    /// Sets a label's pango markup, escaping it in the process.
+    /// This should be used for any label values
+    /// which could contain special characters, for example `&`.
+    fn set_markup_escaped(&self, text: &str);
+}
+
+impl IronbarLabelExt for Label {
+    fn set_markup_escaped(&self, text: &str) {
+        self.set_markup(markup_escape_text(text).as_str())
     }
 }

--- a/src/modules/clock.rs
+++ b/src/modules/clock.rs
@@ -9,7 +9,7 @@ use tokio::sync::{broadcast, mpsc};
 use tokio::time::sleep;
 
 use crate::config::{CommonConfig, ModuleOrientation};
-use crate::gtk_helpers::IronbarGtkExt;
+use crate::gtk_helpers::{IronbarGtkExt, IronbarLabelExt};
 use crate::modules::{
     Module, ModuleInfo, ModuleParts, ModulePopup, ModuleUpdateEvent, PopupButton, WidgetContext,
 };
@@ -143,7 +143,7 @@ impl Module<Button> for ClockModule {
         let rx = context.subscribe();
         glib_recv!(rx, date => {
             let date_string = format!("{}", date.format_localized(&format, locale));
-            label.set_label(&date_string);
+            label.set_markup_escaped(&date_string);
         });
 
         let popup = self

--- a/src/modules/custom/button.rs
+++ b/src/modules/custom/button.rs
@@ -4,6 +4,7 @@ use serde::Deserialize;
 
 use crate::config::ModuleOrientation;
 use crate::dynamic_value::dynamic_string;
+use crate::gtk_helpers::IronbarLabelExt;
 use crate::modules::PopupButton;
 use crate::{build, try_send};
 
@@ -75,7 +76,7 @@ impl CustomWidget for ButtonWidget {
             button.add(&label);
 
             dynamic_string(&text, move |string| {
-                label.set_markup(&string);
+                label.set_markup_escaped(&string);
             });
         }
 

--- a/src/modules/custom/label.rs
+++ b/src/modules/custom/label.rs
@@ -5,6 +5,7 @@ use serde::Deserialize;
 use crate::build;
 use crate::config::ModuleOrientation;
 use crate::dynamic_value::dynamic_string;
+use crate::gtk_helpers::IronbarLabelExt;
 
 use super::{CustomWidget, CustomWidgetContext};
 
@@ -50,7 +51,7 @@ impl CustomWidget for LabelWidget {
         {
             let label = label.clone();
             dynamic_string(&self.label, move |string| {
-                label.set_markup(&string);
+                label.set_markup_escaped(&string);
             });
         }
 

--- a/src/modules/focused.rs
+++ b/src/modules/focused.rs
@@ -165,7 +165,7 @@ impl Module<gtk::Box> for FocusedModule {
 
                     if self.show_title {
                         label.show();
-                        label.set_label(&name);
+                        label.set_text(&name);
                     }
                 } else {
                     icon.hide();

--- a/src/modules/label.rs
+++ b/src/modules/label.rs
@@ -1,5 +1,6 @@
 use crate::config::CommonConfig;
 use crate::dynamic_value::dynamic_string;
+use crate::gtk_helpers::IronbarLabelExt;
 use crate::modules::{Module, ModuleInfo, ModuleParts, ModuleUpdateEvent, WidgetContext};
 use crate::{glib_recv, module_impl, try_send};
 use color_eyre::Result;
@@ -61,7 +62,7 @@ impl Module<Label> for LabelModule {
 
         {
             let label = label.clone();
-            glib_recv!(context.subscribe(), string => label.set_markup(&string));
+            glib_recv!(context.subscribe(), string => label.set_markup_escaped(&string));
         }
 
         Ok(ModuleParts {

--- a/src/modules/music/mod.rs
+++ b/src/modules/music/mod.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use color_eyre::Result;
-use glib::{Propagation, PropertySet};
+use glib::{markup_escape_text, Propagation, PropertySet};
 use gtk::prelude::*;
 use gtk::{Button, IconTheme, Label, Orientation, Scale};
 use regex::Regex;
@@ -16,7 +16,7 @@ use crate::clients::music::{
     self, MusicClient, PlayerState, PlayerUpdate, ProgressTick, Status, Track,
 };
 use crate::clients::Clients;
-use crate::gtk_helpers::IronbarGtkExt;
+use crate::gtk_helpers::{IronbarGtkExt, IronbarLabelExt};
 use crate::image::{new_icon_button, new_icon_label, ImageProvider};
 use crate::modules::PopupButton;
 use crate::modules::{
@@ -222,7 +222,7 @@ impl Module<Button> for MusicModule {
                 };
 
                 if let Some(event) = event.take() {
-                    label.set_label(&event.display_string);
+                    label.set_markup_escaped(&event.display_string);
 
                     button.show();
 
@@ -549,7 +549,7 @@ impl IconLabel {
         let mut builder = Label::builder().use_markup(true);
 
         if let Some(label) = label {
-            builder = builder.label(label);
+            builder = builder.label(markup_escape_text(label));
         }
 
         let label = builder.build();

--- a/src/modules/music/mod.rs
+++ b/src/modules/music/mod.rs
@@ -473,7 +473,7 @@ impl Module<Button> for MusicModule {
                         if let (Some(elapsed), Some(duration)) =
                             (progress_tick.elapsed, progress_tick.duration)
                         {
-                            progress_label.set_label(&format!(
+                            progress_label.set_text(&format!(
                                 "{}/{}",
                                 format_time(elapsed),
                                 format_time(duration)

--- a/src/modules/notifications.rs
+++ b/src/modules/notifications.rs
@@ -209,7 +209,7 @@ impl Module<Overlay> for NotificationsModule {
                 let icon = self.icons.icon(ev);
                 button.set_label(icon);
 
-                label.set_label(&ev.count.to_string());
+                label.set_text(&ev.count.to_string());
                 label.set_visible(self.show_count && ev.count > 0);
             });
         }

--- a/src/modules/script.rs
+++ b/src/modules/script.rs
@@ -1,4 +1,5 @@
 use crate::config::CommonConfig;
+use crate::gtk_helpers::IronbarLabelExt;
 use crate::modules::{Module, ModuleInfo, ModuleParts, ModuleUpdateEvent, WidgetContext};
 use crate::script::{OutputStream, Script, ScriptMode};
 use crate::{glib_recv, module_impl, spawn, try_send};
@@ -103,7 +104,7 @@ impl Module<Label> for ScriptModule {
 
         {
             let label = label.clone();
-            glib_recv!(context.subscribe(), s => label.set_markup(s.as_str()));
+            glib_recv!(context.subscribe(), s => label.set_markup_escaped(s.as_str()));
         }
 
         Ok(ModuleParts {

--- a/src/modules/sysinfo.rs
+++ b/src/modules/sysinfo.rs
@@ -1,5 +1,5 @@
 use crate::config::{CommonConfig, ModuleOrientation};
-use crate::gtk_helpers::IronbarGtkExt;
+use crate::gtk_helpers::{IronbarGtkExt, IronbarLabelExt};
 use crate::modules::{Module, ModuleInfo, ModuleParts, ModuleUpdateEvent, WidgetContext};
 use crate::{glib_recv, module_impl, send_async, spawn};
 use color_eyre::Result;
@@ -266,7 +266,7 @@ impl Module<gtk::Box> for SysInfoModule {
                             .to_string()
                     });
 
-                    label.set_markup(format_compiled.as_ref());
+                    label.set_markup_escaped(format_compiled.as_ref());
                 }
             });
         }

--- a/src/modules/tray/interface.rs
+++ b/src/modules/tray/interface.rs
@@ -124,7 +124,7 @@ impl TrayMenu {
                 label.show();
                 label
             })
-            .set_label(text);
+            .set_text(text);
     }
 
     /// Shows the label, using its current text.

--- a/src/modules/upower.rs
+++ b/src/modules/upower.rs
@@ -9,7 +9,7 @@ use zbus;
 use zbus::fdo::PropertiesProxy;
 
 use crate::config::CommonConfig;
-use crate::gtk_helpers::IronbarGtkExt;
+use crate::gtk_helpers::{IronbarGtkExt, IronbarLabelExt};
 use crate::image::ImageProvider;
 use crate::modules::PopupButton;
 use crate::modules::{
@@ -212,7 +212,7 @@ impl Module<gtk::Button> for UpowerModule {
             ImageProvider::parse(&icon_name, &icon_theme, false, self.icon_size)
                     .map(|provider| provider.load_into_image(icon.clone()));
 
-            label.set_markup(format.as_ref());
+            label.set_markup_escaped(format.as_ref());
         });
 
         let rx = context.subscribe();
@@ -263,7 +263,7 @@ impl Module<gtk::Button> for UpowerModule {
                 _ => String::new(),
             };
 
-            label.set_markup(&format);
+            label.set_markup_escaped(&format);
         });
 
         container.show_all();

--- a/src/modules/volume.rs
+++ b/src/modules/volume.rs
@@ -432,7 +432,7 @@ impl Module<Button> for VolumeModule {
                     }
                     Event::UpdateInput(info) => {
                         if let Some(ui) = inputs.get(&info.index) {
-                            ui.label.set_label(&info.name);
+                            ui.label.set_text(&info.name);
                             ui.slider.set_value(info.volume);
                             ui.slider.set_sensitive(info.can_set_volume);
                             ui.btn_mute.set_label(if info.muted { &self.icons.muted } else { self.icons.volume_icon(info.volume) });


### PR DESCRIPTION
Fixes issues where eg song title could contain an `&`, which would not display and log a GTK warning.