### PR TITLE
docs: add fedora copr package to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,15 @@ A flake is included with the repo which can be used with Home Manager.
 CI builds are automatically cached by Garnix.
 You can use their binary cache by following the steps [here](https://garnix.io/docs/caching).
 
+### Fedora
+
+[fedora package](https://copr.fedorainfracloud.org/coprs/victorvintorez/tilingtools/packages/)
+
+``` sh
+dnf copr enable victorvintorez/tilingtools
+dnf install ironbar
+```
+
 ### Void Linux
 
 [void package](https://github.com/void-linux/void-packages/tree/master/srcpkgs/ironbar)


### PR DESCRIPTION
Adds Fedora COPR package install instructions.
COPR: https://copr.fedorainfracloud.org/coprs/victorvintorez/tilingtools/
Build File: https://github.com/victorvintorez/Fedora-Packages/blob/master/ironbar/ironbar.spec

Automatic builds on new releases is intended but not implemented yet.