### PR TITLE
feat: Add home-manager option to read style.css file

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -162,7 +162,7 @@
             };
 
             style = lib.mkOption {
-              type = lib.types.lines;
+              type = lib.types.either (lib.types.lines) (lib.types.path);
               default = "";
               description = "The stylesheet to apply to ironbar.";
             };
@@ -189,8 +189,12 @@
                 source = jsonFormat.generate "ironbar-config" cfg.config;
               };
 
-              "ironbar/style.css" =
-                lib.mkIf (cfg.style != "") { text = cfg.style; };
+              "ironbar/style.css" = lib.mkIf (cfg.style != "") (
+                if builtins.isPath cfg.style || lib.isStorePath cfg.style then
+                  { source = cfg.style; }
+                else
+                  { text = cfg.style; }
+              );
             };
 
             systemd.user.services.ironbar = lib.mkIf cfg.systemd {


### PR DESCRIPTION
Adds the option to import a style.css file for the home-manager `programs.ironbar.style` option, instead of only accepting strings.

Resolves #655

