### PR TITLE
Feat: sway-mode module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,8 +76,10 @@ volume = ["libpulse-binding"]
 
 workspaces = ["futures-lite"]
 "workspaces+all" = ["workspaces", "workspaces+sway", "workspaces+hyprland"]
-"workspaces+sway" = ["workspaces", "swayipc-async"]
+"workspaces+sway" = ["workspaces", "sway"]
 "workspaces+hyprland" = ["workspaces", "hyprland"]
+
+sway = ["swayipc-async"]
 
 schema = ["dep:schemars"]
 

--- a/docs/_Sidebar.md
+++ b/docs/_Sidebar.md
@@ -35,6 +35,7 @@
 - [Network Manager](network-manager)
 - [Notifications](notifications)
 - [Script](script)
+- [Sway-mode](sway-mode)
 - [Sys_Info](sys-info)
 - [Tray](tray)
 - [Upower](upower)

--- a/docs/modules/Sway-mode.md
+++ b/docs/modules/Sway-mode.md
@@ -1,0 +1,74 @@
+Displays the current sway mode.
+
+## Configuration
+
+> Type: `sway-mode`
+
+| Name                  | Type                                        | Default | Description                                                                                                                                           |
+| --------------------- | ------------------------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `truncate`            | `'start'` or `'middle'` or `'end'` or `Map` | `null`  | The location of the ellipses and where to truncate text from. Leave null to avoid truncating. Use the long-hand `Map` version if specifying a length. |
+| `truncate.mode`       | `'start'` or `'middle'` or `'end'`          | `null`  | The location of the ellipses and where to truncate text from. Leave null to avoid truncating.                                                         |
+| `truncate.length`     | `integer`                                   | `null`  | The fixed width (in chars) of the widget. Leave blank to let GTK automatically handle.                                                                |
+| `truncate.max_length` | `integer`                                   | `null`  | The maximum number of characters before truncating. Leave blank to let GTK automatically handle.                                                      |
+
+<details>
+<summary>JSON</summary>
+
+```json
+{
+  "end": [
+    {
+      "type": "sway-mode",
+      "truncate": "start"
+    }
+  ]
+}
+```
+
+</details>
+
+<details>
+<summary>TOML</summary>
+
+```toml
+[[end]]
+type = "sway-mode"
+truncate = "start"
+```
+
+</details>
+
+<details>
+<summary>YAML</summary>
+
+```yaml
+end:
+  - type: "sway-mode"
+    truncate: "start"
+```
+
+</details>
+
+<details>
+<summary>Corn</summary>
+
+```corn
+{
+  end = [
+    {
+      type = "sway-mode"
+      truncate = "start"
+    }
+  ]
+}
+```
+
+</details>
+
+## Styling
+
+| Selector | Description  |
+| -------- | ------------ |
+| `.label` | Label widget |
+
+For more information on styling, please see the [styling guide](styling-guide).

--- a/docs/modules/Sway-mode.md
+++ b/docs/modules/Sway-mode.md
@@ -1,4 +1,8 @@
-Displays the current sway mode.
+Displays the current sway mode in a label. If the current sway mode is
+"default", nothing is displayed.
+
+> [!NOTE]
+> This module only works under the [Sway](https://swaywm.org/) compositor.
 
 ## Configuration
 
@@ -67,8 +71,8 @@ end:
 
 ## Styling
 
-| Selector | Description  |
-| -------- | ------------ |
-| `.label` | Label widget |
+| Selector     | Description            |
+| ------------ | ---------------------- |
+| `.sway_mode` | Sway mode label widget |
 
 For more information on styling, please see the [styling guide](styling-guide).

--- a/src/clients/compositor/sway.rs
+++ b/src/clients/compositor/sway.rs
@@ -59,8 +59,9 @@ impl Client {
         }
 
         // Only the task and self have a reference to listeners, and we just abort the task. This
-        // is the only reference to listeners, so we can safely unwrap.
-        let listeners_mut = Arc::get_mut(listeners).unwrap();
+        // is the only reference to listeners, so we can safely get a mutable reference.
+        let listeners_mut = Arc::get_mut(listeners)
+            .ok_or_else(|| Report::msg("Failed to get mutable reference to listeners"))?;
 
         listeners_mut.push((event_type, f));
 

--- a/src/clients/compositor/sway.rs
+++ b/src/clients/compositor/sway.rs
@@ -1,121 +1,15 @@
 use super::{Visibility, Workspace, WorkspaceClient, WorkspaceUpdate};
-use crate::{await_sync, send, spawn};
-use color_eyre::{Report, Result};
-use futures_lite::StreamExt;
-use std::sync::Arc;
-use swayipc_async::{Connection, Event, EventType, Node, WorkspaceChange, WorkspaceEvent};
+use crate::{await_sync, send};
+use color_eyre::Result;
+use swayipc_async::{Node, WorkspaceChange, WorkspaceEvent};
 use tokio::sync::broadcast::{channel, Receiver};
-use tokio::sync::Mutex;
-use tracing::{info, trace};
 
-type SyncFn<T> = dyn Fn(&T) + Sync + Send;
-
-struct TaskState {
-    join_handle: Option<tokio::task::JoinHandle<Result<()>>>,
-    // could have been a `HashMap<EventType, Vec<Box<dyn Fn(&Event) + Sync + Send>>>`, but we don't
-    // expect enough listeners to justify the constant overhead of a hashmap.
-    listeners: Arc<Vec<(EventType, Box<SyncFn<Event>>)>>,
-}
-
-pub struct Client {
-    client: Arc<Mutex<Connection>>,
-    task_state: Mutex<TaskState>,
-}
-
-impl std::fmt::Debug for Client {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Client")
-            .field("client", &"Connection")
-            .field("task_state", &format_args!("<...>"))
-            .finish()
-    }
-}
-
-impl Client {
-    pub(crate) async fn new() -> Result<Self> {
-        // Avoid using `arc_mut!` here because we need tokio Mutex.
-        let client = Arc::new(Mutex::new(Connection::new().await?));
-        info!("Sway IPC subscription client connected");
-
-        Ok(Self {
-            client,
-            task_state: Mutex::new(TaskState {
-                listeners: Arc::new(Vec::new()),
-                join_handle: None,
-            }),
-        })
-    }
-
-    pub async fn add_listener<T: SwayIpcEvent>(
-        &self,
-        f: impl Fn(&T) + Sync + Send + 'static,
-    ) -> Result<()> {
-        self.add_listener_type(
-            T::EVENT_TYPE,
-            Box::new(move |event| {
-                let event = T::from_event(event).unwrap();
-                f(event)
-            }),
-        )
-        .await
-    }
-
-    pub async fn add_listener_type(
-        &self,
-        event_type: EventType,
-        f: Box<SyncFn<Event>>,
-    ) -> Result<()> {
-        // abort current running task
-        let TaskState {
-            join_handle,
-            listeners,
-        } = &mut *self.task_state.lock().await;
-
-        if let Some(handle) = join_handle.take() {
-            handle.abort();
-            let _ = handle.await;
-        }
-
-        // Only the task and self have a reference to listeners, and we just abort the task. This
-        // is the only reference to listeners, so we can safely get a mutable reference.
-        let listeners_mut = Arc::get_mut(listeners)
-            .ok_or_else(|| Report::msg("Failed to get mutable reference to listeners"))?;
-
-        listeners_mut.push((event_type, f));
-
-        // create new client as subscription takes ownership
-        let client = Connection::new().await?;
-
-        let event_types = listeners.iter().map(|(t, _)| *t).collect::<Vec<_>>();
-        let listeners = listeners.clone();
-
-        let handle = spawn(async move {
-            let mut events = client.subscribe(&event_types).await?;
-
-            while let Some(event) = events.next().await {
-                trace!("event: {:?}", event);
-                let event = event?;
-                let ty = sway_event_to_event_type(&event);
-                for (t, f) in listeners.iter() {
-                    if *t == ty {
-                        f(&event);
-                    }
-                }
-            }
-
-            Ok::<(), Report>(())
-        });
-
-        *join_handle = Some(handle);
-
-        Ok(())
-    }
-}
+use crate::clients::sway::Client;
 
 impl WorkspaceClient for Client {
     fn focus(&self, id: String) -> Result<()> {
         await_sync(async move {
-            let mut client = self.client.lock().await;
+            let mut client = self.connection().lock().await;
             client.run_command(format!("workspace {id}")).await
         })?;
         Ok(())
@@ -124,7 +18,7 @@ impl WorkspaceClient for Client {
     fn subscribe_workspace_change(&self) -> Receiver<WorkspaceUpdate> {
         let (tx, rx) = channel(16);
 
-        let client = self.client.clone();
+        let client = self.connection().clone();
 
         await_sync(async {
             let mut client = client.lock().await;
@@ -219,69 +113,3 @@ impl From<WorkspaceEvent> for WorkspaceUpdate {
         }
     }
 }
-
-fn sway_event_to_event_type(event: &Event) -> EventType {
-    match event {
-        Event::Workspace(_) => EventType::Workspace,
-        Event::Mode(_) => EventType::Mode,
-        Event::Window(_) => EventType::Window,
-        Event::BarConfigUpdate(_) => EventType::BarConfigUpdate,
-        Event::Binding(_) => EventType::Binding,
-        Event::Shutdown(_) => EventType::Shutdown,
-        Event::Tick(_) => EventType::Tick,
-        Event::BarStateUpdate(_) => EventType::BarStateUpdate,
-        Event::Input(_) => EventType::Input,
-        _ => todo!(),
-    }
-}
-
-pub trait SwayIpcEvent {
-    const EVENT_TYPE: EventType;
-    fn from_event(e: &Event) -> Option<&Self>;
-}
-macro_rules! sway_ipc_event_impl {
-    (@ $($t:tt)*) => { $($t)* };
-    ($t:ty, $v:expr, $($m:tt)*) => {
-        sway_ipc_event_impl! {@
-            impl SwayIpcEvent for $t {
-                const EVENT_TYPE: EventType = $v;
-                fn from_event(e: &Event) -> Option<&Self> {
-                    match e {
-                        $($m)* (x) => Some(x),
-                        _ => None,
-                    }
-                }
-            }
-        }
-    };
-}
-
-sway_ipc_event_impl!(
-    swayipc_async::WorkspaceEvent,
-    EventType::Workspace,
-    Event::Workspace
-);
-sway_ipc_event_impl!(swayipc_async::ModeEvent, EventType::Mode, Event::Mode);
-sway_ipc_event_impl!(swayipc_async::WindowEvent, EventType::Window, Event::Window);
-sway_ipc_event_impl!(
-    swayipc_async::BarConfig,
-    EventType::BarConfigUpdate,
-    Event::BarConfigUpdate
-);
-sway_ipc_event_impl!(
-    swayipc_async::BindingEvent,
-    EventType::Binding,
-    Event::Binding
-);
-sway_ipc_event_impl!(
-    swayipc_async::ShutdownEvent,
-    EventType::Shutdown,
-    Event::Shutdown
-);
-sway_ipc_event_impl!(swayipc_async::TickEvent, EventType::Tick, Event::Tick);
-sway_ipc_event_impl!(
-    swayipc_async::BarStateUpdateEvent,
-    EventType::BarStateUpdate,
-    Event::BarStateUpdate
-);
-sway_ipc_event_impl!(swayipc_async::InputEvent, EventType::Input, Event::Input);

--- a/src/clients/mod.rs
+++ b/src/clients/mod.rs
@@ -31,6 +31,8 @@ pub struct Clients {
     wayland: Option<Arc<wayland::Client>>,
     #[cfg(feature = "workspaces")]
     workspaces: Option<Arc<dyn compositor::WorkspaceClient>>,
+    #[cfg(feature = "sway")]
+    sway: Option<Arc<compositor::sway::Client>>,
     #[cfg(feature = "clipboard")]
     clipboard: Option<Arc<clipboard::Client>>,
     #[cfg(feature = "cairo")]
@@ -76,8 +78,23 @@ impl Clients {
         let client = match &self.workspaces {
             Some(workspaces) => workspaces.clone(),
             None => {
-                let client = compositor::Compositor::create_workspace_client()?;
+                let client = compositor::Compositor::create_workspace_client(self)?;
                 self.workspaces.replace(client.clone());
+                client
+            }
+        };
+
+        Ok(client)
+    }
+
+    #[cfg(feature = "sway")]
+    pub fn sway(&mut self) -> ClientResult<compositor::sway::Client> {
+        let client = match &self.sway {
+            Some(client) => client.clone(),
+            None => {
+                let client = await_sync(async { compositor::sway::Client::new().await })?;
+                let client = Arc::new(client);
+                self.sway.replace(client.clone());
                 client
             }
         };

--- a/src/clients/mod.rs
+++ b/src/clients/mod.rs
@@ -14,6 +14,8 @@ pub mod lua;
 pub mod music;
 #[cfg(feature = "network_manager")]
 pub mod networkmanager;
+#[cfg(feature = "sway")]
+pub mod sway;
 #[cfg(feature = "notifications")]
 pub mod swaync;
 #[cfg(feature = "tray")]
@@ -32,7 +34,7 @@ pub struct Clients {
     #[cfg(feature = "workspaces")]
     workspaces: Option<Arc<dyn compositor::WorkspaceClient>>,
     #[cfg(feature = "sway")]
-    sway: Option<Arc<compositor::sway::Client>>,
+    sway: Option<Arc<sway::Client>>,
     #[cfg(feature = "clipboard")]
     clipboard: Option<Arc<clipboard::Client>>,
     #[cfg(feature = "cairo")]
@@ -88,11 +90,11 @@ impl Clients {
     }
 
     #[cfg(feature = "sway")]
-    pub fn sway(&mut self) -> ClientResult<compositor::sway::Client> {
+    pub fn sway(&mut self) -> ClientResult<sway::Client> {
         let client = match &self.sway {
             Some(client) => client.clone(),
             None => {
-                let client = await_sync(async { compositor::sway::Client::new().await })?;
+                let client = await_sync(async { sway::Client::new().await })?;
                 let client = Arc::new(client);
                 self.sway.replace(client.clone());
                 client

--- a/src/clients/sway.rs
+++ b/src/clients/sway.rs
@@ -55,7 +55,7 @@ impl Client {
         self.add_listener_type(
             T::EVENT_TYPE,
             Box::new(move |event| {
-                let event = T::from_event(event).unwrap();
+                let event = T::from_event(event).expect("event type mismatch");
                 f(event)
             }),
         )

--- a/src/clients/sway.rs
+++ b/src/clients/sway.rs
@@ -1,0 +1,181 @@
+use crate::spawn;
+use color_eyre::{Report, Result};
+use futures_lite::StreamExt;
+use std::sync::Arc;
+use swayipc_async::{Connection, Event, EventType};
+use tokio::sync::Mutex;
+use tracing::{info, trace};
+
+type SyncFn<T> = dyn Fn(&T) + Sync + Send;
+
+struct TaskState {
+    join_handle: Option<tokio::task::JoinHandle<Result<()>>>,
+    // could have been a `HashMap<EventType, Vec<Box<dyn Fn(&Event) + Sync + Send>>>`, but we don't
+    // expect enough listeners to justify the constant overhead of a hashmap.
+    listeners: Arc<Vec<(EventType, Box<SyncFn<Event>>)>>,
+}
+
+pub struct Client {
+    connection: Arc<Mutex<Connection>>,
+    task_state: Mutex<TaskState>,
+}
+
+impl std::fmt::Debug for Client {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Client")
+            .field("client", &"Connection")
+            .field("task_state", &format_args!("<...>"))
+            .finish()
+    }
+}
+
+impl Client {
+    pub(crate) async fn new() -> Result<Self> {
+        // Avoid using `arc_mut!` here because we need tokio Mutex.
+        let client = Arc::new(Mutex::new(Connection::new().await?));
+        info!("Sway IPC subscription client connected");
+
+        Ok(Self {
+            connection: client,
+            task_state: Mutex::new(TaskState {
+                listeners: Arc::new(Vec::new()),
+                join_handle: None,
+            }),
+        })
+    }
+
+    pub fn connection(&self) -> &Arc<Mutex<Connection>> {
+        &self.connection
+    }
+
+    pub async fn add_listener<T: SwayIpcEvent>(
+        &self,
+        f: impl Fn(&T) + Sync + Send + 'static,
+    ) -> Result<()> {
+        self.add_listener_type(
+            T::EVENT_TYPE,
+            Box::new(move |event| {
+                let event = T::from_event(event).unwrap();
+                f(event)
+            }),
+        )
+        .await
+    }
+
+    pub async fn add_listener_type(
+        &self,
+        event_type: EventType,
+        f: Box<SyncFn<Event>>,
+    ) -> Result<()> {
+        // abort current running task
+        let TaskState {
+            join_handle,
+            listeners,
+        } = &mut *self.task_state.lock().await;
+
+        if let Some(handle) = join_handle.take() {
+            handle.abort();
+            let _ = handle.await;
+        }
+
+        // Only the task and self have a reference to listeners, and we just abort the task. This
+        // is the only reference to listeners, so we can safely get a mutable reference.
+        let listeners_mut = Arc::get_mut(listeners)
+            .ok_or_else(|| Report::msg("Failed to get mutable reference to listeners"))?;
+
+        listeners_mut.push((event_type, f));
+
+        // create new client as subscription takes ownership
+        let client = Connection::new().await?;
+
+        let event_types = listeners.iter().map(|(t, _)| *t).collect::<Vec<_>>();
+        let listeners = listeners.clone();
+
+        let handle = spawn(async move {
+            let mut events = client.subscribe(&event_types).await?;
+
+            while let Some(event) = events.next().await {
+                trace!("event: {:?}", event);
+                let event = event?;
+                let ty = sway_event_to_event_type(&event);
+                for (t, f) in listeners.iter() {
+                    if *t == ty {
+                        f(&event);
+                    }
+                }
+            }
+
+            Ok::<(), Report>(())
+        });
+
+        *join_handle = Some(handle);
+
+        Ok(())
+    }
+}
+
+fn sway_event_to_event_type(event: &Event) -> EventType {
+    match event {
+        Event::Workspace(_) => EventType::Workspace,
+        Event::Mode(_) => EventType::Mode,
+        Event::Window(_) => EventType::Window,
+        Event::BarConfigUpdate(_) => EventType::BarConfigUpdate,
+        Event::Binding(_) => EventType::Binding,
+        Event::Shutdown(_) => EventType::Shutdown,
+        Event::Tick(_) => EventType::Tick,
+        Event::BarStateUpdate(_) => EventType::BarStateUpdate,
+        Event::Input(_) => EventType::Input,
+        _ => todo!(),
+    }
+}
+
+pub trait SwayIpcEvent {
+    const EVENT_TYPE: EventType;
+    fn from_event(e: &Event) -> Option<&Self>;
+}
+macro_rules! sway_ipc_event_impl {
+    (@ $($t:tt)*) => { $($t)* };
+    ($t:ty, $v:expr, $($m:tt)*) => {
+        sway_ipc_event_impl! {@
+            impl SwayIpcEvent for $t {
+                const EVENT_TYPE: EventType = $v;
+                fn from_event(e: &Event) -> Option<&Self> {
+                    match e {
+                        $($m)* (x) => Some(x),
+                        _ => None,
+                    }
+                }
+            }
+        }
+    };
+}
+
+sway_ipc_event_impl!(
+    swayipc_async::WorkspaceEvent,
+    EventType::Workspace,
+    Event::Workspace
+);
+sway_ipc_event_impl!(swayipc_async::ModeEvent, EventType::Mode, Event::Mode);
+sway_ipc_event_impl!(swayipc_async::WindowEvent, EventType::Window, Event::Window);
+sway_ipc_event_impl!(
+    swayipc_async::BarConfig,
+    EventType::BarConfigUpdate,
+    Event::BarConfigUpdate
+);
+sway_ipc_event_impl!(
+    swayipc_async::BindingEvent,
+    EventType::Binding,
+    Event::Binding
+);
+sway_ipc_event_impl!(
+    swayipc_async::ShutdownEvent,
+    EventType::Shutdown,
+    Event::Shutdown
+);
+sway_ipc_event_impl!(swayipc_async::TickEvent, EventType::Tick, Event::Tick);
+sway_ipc_event_impl!(
+    swayipc_async::BarStateUpdateEvent,
+    EventType::BarStateUpdate,
+    Event::BarStateUpdate
+);
+sway_ipc_event_impl!(swayipc_async::InputEvent, EventType::Input, Event::Input);

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -21,6 +21,8 @@ use crate::modules::networkmanager::NetworkManagerModule;
 #[cfg(feature = "notifications")]
 use crate::modules::notifications::NotificationsModule;
 use crate::modules::script::ScriptModule;
+#[cfg(feature = "sway")]
+use crate::modules::sway::mode::SwayModeModule;
 #[cfg(feature = "sys_info")]
 use crate::modules::sysinfo::SysInfoModule;
 #[cfg(feature = "tray")]
@@ -69,6 +71,8 @@ pub enum ModuleConfig {
     Script(Box<ScriptModule>),
     #[cfg(feature = "sys_info")]
     SysInfo(Box<SysInfoModule>),
+    #[cfg(feature = "sway")]
+    SwayMode(Box<SwayModeModule>),
     #[cfg(feature = "tray")]
     Tray(Box<TrayModule>),
     #[cfg(feature = "upower")]
@@ -114,6 +118,8 @@ impl ModuleConfig {
             Self::Script(module) => create!(module),
             #[cfg(feature = "sys_info")]
             Self::SysInfo(module) => create!(module),
+            #[cfg(feature = "sway")]
+            Self::SwayMode(module) => create!(module),
             #[cfg(feature = "tray")]
             Self::Tray(module) => create!(module),
             #[cfg(feature = "upower")]

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -41,6 +41,8 @@ pub mod networkmanager;
 #[cfg(feature = "notifications")]
 pub mod notifications;
 pub mod script;
+#[cfg(feature = "sway")]
+pub mod sway;
 #[cfg(feature = "sys_info")]
 pub mod sysinfo;
 #[cfg(feature = "tray")]

--- a/src/modules/sway/mod.rs
+++ b/src/modules/sway/mod.rs
@@ -1,0 +1,1 @@
+pub mod mode;

--- a/src/modules/sway/mode.rs
+++ b/src/modules/sway/mode.rs
@@ -1,6 +1,6 @@
 use crate::config::{CommonConfig, TruncateMode};
 use crate::modules::{Module, ModuleInfo, ModuleParts, ModuleUpdateEvent, WidgetContext};
-use crate::{await_sync, glib_recv, module_impl};
+use crate::{await_sync, glib_recv, module_impl, try_send};
 use color_eyre::{Report, Result};
 use gtk::prelude::*;
 use gtk::Label;
@@ -48,7 +48,7 @@ impl Module<Label> for SwayModeModule {
                         let Event::Mode(mode) = event else {
                             unreachable!()
                         };
-                        let _ = await_sync(tx.send(ModuleUpdateEvent::Update(mode.clone())));
+                        try_send!(tx, ModuleUpdateEvent::Update(mode.clone()));
                     }),
                 )
                 .await?;

--- a/src/modules/sway/mode.rs
+++ b/src/modules/sway/mode.rs
@@ -1,0 +1,92 @@
+use crate::config::{CommonConfig, TruncateMode};
+use crate::modules::{Module, ModuleInfo, ModuleParts, ModuleUpdateEvent, WidgetContext};
+use crate::{glib_recv, module_impl, spawn};
+use color_eyre::{Report, Result};
+use futures_lite::StreamExt;
+use gtk::prelude::*;
+use gtk::Label;
+use serde::Deserialize;
+use swayipc_async::{Connection, Event, EventType, ModeEvent};
+use tokio::sync::mpsc;
+use tracing::{info, trace};
+
+#[derive(Debug, Deserialize, Clone)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct SwayModeModule {
+    // -- Common --
+    /// See [truncate options](module-level-options#truncate-mode).
+    ///
+    /// **Default**: `null`
+    pub truncate: Option<TruncateMode>,
+
+    /// See [common options](module-level-options#common-options).
+    #[serde(flatten)]
+    pub common: Option<CommonConfig>,
+}
+
+impl Module<Label> for SwayModeModule {
+    type SendMessage = ModeEvent;
+    type ReceiveMessage = ();
+
+    module_impl!("sway_mode");
+
+    fn spawn_controller(
+        &self,
+        _info: &ModuleInfo,
+        context: &WidgetContext<Self::SendMessage, Self::ReceiveMessage>,
+        _rx: mpsc::Receiver<Self::ReceiveMessage>,
+    ) -> Result<()> {
+        info!("Sway Mode module started");
+        let tx = context.tx.clone();
+
+        spawn(async move {
+            let client = Connection::new().await?;
+
+            let event_types = [EventType::Mode];
+            let mut events = client.subscribe(event_types).await?;
+
+            while let Some(event) = events.next().await {
+                trace!("event: {:?}", event);
+                if let Event::Mode(mode) = event? {
+                    tx.send(ModuleUpdateEvent::Update(mode)).await?
+                };
+            }
+
+            Ok::<(), Report>(())
+        });
+
+        Ok(())
+    }
+
+    fn into_widget(
+        self,
+        context: WidgetContext<Self::SendMessage, Self::ReceiveMessage>,
+        _info: &ModuleInfo,
+    ) -> Result<ModuleParts<Label>> {
+        let label = Label::new(None);
+
+        {
+            let label = label.clone();
+
+            if let Some(truncate) = self.truncate {
+                truncate.truncate_label(&label);
+            }
+
+            let on_mode = move |mode: ModeEvent| {
+                label.set_use_markup(mode.pango_markup);
+                if mode.change != "default" {
+                    label.set_markup(&mode.change)
+                } else {
+                    label.set_markup("");
+                }
+            };
+
+            glib_recv!(context.subscribe(), mode => on_mode(mode));
+        }
+
+        Ok(ModuleParts {
+            widget: label,
+            popup: None,
+        })
+    }
+}


### PR DESCRIPTION
Add a new module, similar to the waybar "sway/module" module. It shows the current mode under sway. For that, it needs to communicate with the Sway IPC. In this PR, the module is called "sway-mode" because "sway/mode" didn't work in my YAML config file (it would probably work if I surrounded it with quotes, but I didn't test).

This PR has two commits: the first one implements the module using a new sway connection. The second one refactors the sway `Client`, under `clients::compositor::sway`, to allow dynamically registering events, instead of only handling Workspace update ones. This second commit avoid creating a new socket for each module that needs to communicate with the Sway IPC, not sure if that is a problem to begin with.