### PR TITLE
Update flake.nix to match adwaita-icon-theme being moved to top-level

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -125,7 +125,7 @@
               glib
               glib-networking
               shared-mime-info
-              gnome.adwaita-icon-theme
+              adwaita-icon-theme
               hicolor-icon-theme
               gsettings-desktop-schemas
               libxkbcommon


### PR DESCRIPTION
The icon theme was moved in the nixpkgs repo and this fixes a warning message that change causes