### PR TITLE
fix(popup): incorrect pos when resolution changes

### DIFF
--- a/src/bar.rs
+++ b/src/bar.rs
@@ -273,7 +273,12 @@ impl Bar {
         }
 
         // popup ignores module location so can bodge this for now
-        let popup = Popup::new(&info!(ModuleLocation::Left), output_size, config.popup_gap);
+        let popup = Popup::new(
+            self.ironbar.clone(),
+            &info!(ModuleLocation::Left),
+            output_size,
+            config.popup_gap,
+        );
         let popup = Rc::new(popup);
 
         if let Some(modules) = config.start {

--- a/src/clients/wayland/wl_output.rs
+++ b/src/clients/wayland/wl_output.rs
@@ -12,7 +12,7 @@ pub struct OutputEvent {
     pub event_type: OutputEventType,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OutputEventType {
     New,
     Update,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -86,6 +86,8 @@ macro_rules! try_send {
 /// ```
 #[macro_export]
 macro_rules! glib_recv {
+    ($rx:expr, $func:ident) => { glib_recv!($rx, ev => $func(ev)) };
+
     ($rx:expr, $val:ident => $expr:expr) => {{
         glib::spawn_future_local(async move {
             // re-delcare in case ie `context.subscribe()` is passed directly
@@ -122,6 +124,8 @@ macro_rules! glib_recv {
 /// ```
 #[macro_export]
 macro_rules! glib_recv_mpsc {
+    ($rx:expr, $func:ident) => { glib_recv_mpsc!($rx, ev => $func(ev)) };
+
     ($rx:expr, $val:ident => $expr:expr) => {{
         glib::spawn_future_local(async move {
             // re-delcare in case ie `context.subscribe()` is passed directly


### PR DESCRIPTION
Popups will now instantly reposition themselves to be correctly placed on resolution change. This includes orientation and scale changes.

Fixes #610