### PR TITLE
fix(workspaces): prevent crash when clicking current workspace

### DIFF
--- a/src/modules/workspaces.rs
+++ b/src/modules/workspaces.rs
@@ -228,7 +228,7 @@ impl Module<gtk::Box> for WorkspacesModule {
 
             while let Some(name) = rx.recv().await {
                 if let Err(e) = client.focus(name.clone()) {
-                    warn!("Couln't focus workspace '{name}': {e}");
+                    warn!("Couldn't focus workspace '{name}': {e:#}");
                 };
             }
 

--- a/src/modules/workspaces.rs
+++ b/src/modules/workspaces.rs
@@ -151,9 +151,7 @@ fn create_button(
     {
         let tx = tx.clone();
         let name = name.to_string();
-        button.connect_clicked(move |_item| {
-            try_send!(tx, name.clone());
-        });
+        button.connect_clicked(move |_item| try_send!(tx, name.clone()));
     }
 
     button
@@ -229,7 +227,9 @@ impl Module<gtk::Box> for WorkspacesModule {
             trace!("Setting up UI event handler");
 
             while let Some(name) = rx.recv().await {
-                client.focus(name)?;
+                if let Err(e) = client.focus(name.clone()) {
+                    warn!("Couln't focus workspace '{name}': {e}");
+                };
             }
 
             Ok::<(), Report>(())

--- a/src/modules/workspaces.rs
+++ b/src/modules/workspaces.rs
@@ -151,7 +151,9 @@ fn create_button(
     {
         let tx = tx.clone();
         let name = name.to_string();
-        button.connect_clicked(move |_item| try_send!(tx, name.clone()));
+        button.connect_clicked(move |_item| {
+            try_send!(tx, name.clone());
+        });
     }
 
     button


### PR DESCRIPTION
Should solve https://github.com/JakeStanger/ironbar/issues/731 by printing a warning instead of stopping the receiving loop when focusing a workspace.