### PR TITLE
feat: add `.urgent` workspace css class

### DIFF
--- a/docs/modules/Workspaces.md
+++ b/docs/modules/Workspaces.md
@@ -98,15 +98,16 @@ end:
 
 ## Styling
 
-| Selector                       | Description                          |
-|--------------------------------|--------------------------------------|
-| `.workspaces`                  | Workspaces widget box                |
-| `.workspaces .item`            | Workspace button                     |
-| `.workspaces .item.focused`    | Workspace button (workspace focused) |
+| Selector                       | Description                                             |
+| ------------------------------ | ------------------------------------------------------- |
+| `.workspaces`                  | Workspaces widget box                                   |
+| `.workspaces .item`            | Workspace button                                        |
+| `.workspaces .item.focused`    | Workspace button (workspace focused)                    |
 | `.workspaces .item.visible`    | Workspace button (workspace visible, including focused) |
-| `.workspaces .item.inactive`   | Workspace button (favourite, not currently open)
-| `.workspaces .item .icon`      | Workspace button icon (any type)     |
-| `.workspaces .item .text-icon` | Workspace button icon (textual only) |
-| `.workspaces .item .image`     | Workspace button icon (image only)   |
+| `.workspaces .item.urgent`     | Workspace button (workspace contains urgent window)     |
+| `.workspaces .item.inactive`   | Workspace button (favourite, not currently open)        |
+| `.workspaces .item .icon`      | Workspace button icon (any type)                        |
+| `.workspaces .item .text-icon` | Workspace button icon (textual only)                    |
+| `.workspaces .item .image`     | Workspace button icon (image only)                      |
 
 For more information on styling, please see the [styling guide](styling-guide).

--- a/examples/style.css
+++ b/examples/style.css
@@ -201,6 +201,10 @@ scale trough {
     background-color: @color_bg_dark;
 }
 
+.workspaces .item.urgent {
+    background-color: @color_urgent;
+}
+
 .workspaces .item:hover {
     box-shadow: inset 0 -3px;
 }

--- a/src/clients/compositor/mod.rs
+++ b/src/clients/compositor/mod.rs
@@ -135,6 +135,12 @@ pub enum WorkspaceUpdate {
         name: String,
     },
 
+    /// The urgent state of a node changed.
+    Urgent {
+        id: i64,
+        urgent: bool,
+    },
+
     /// An update was triggered by the compositor but this was not mapped by Ironbar.
     ///
     /// This is purely used for ergonomics within the compositor clients

--- a/src/clients/compositor/sway.rs
+++ b/src/clients/compositor/sway.rs
@@ -109,6 +109,16 @@ impl From<WorkspaceEvent> for WorkspaceUpdate {
             WorkspaceChange::Move => {
                 Self::Move(event.current.expect("Missing current workspace").into())
             }
+            WorkspaceChange::Urgent => {
+                if let Some(node) = event.current {
+                    Self::Urgent {
+                        id: node.id,
+                        urgent: node.urgent,
+                    }
+                } else {
+                    Self::Unknown
+                }
+            }
             _ => Self::Unknown,
         }
     }

--- a/src/modules/workspaces.rs
+++ b/src/modules/workspaces.rs
@@ -413,6 +413,16 @@ impl Module<gtk::Box> for WorkspacesModule {
                             }
                         }
                     }
+                    WorkspaceUpdate::Urgent { id, urgent } => {
+                        let button = button_map.get(&id);
+                        if let Some(item) = button {
+                            if urgent {
+                                item.add_class("urgent");
+                            } else {
+                                item.style_context().remove_class("urgent");
+                            }
+                        }
+                    }
                     WorkspaceUpdate::Unknown => warn!("Received unknown type workspace event")
                 };
             });


### PR DESCRIPTION
Allow highlighting a workspace which contains a window that triggered a urgent event, i.e., requests attention. In my case, I see it happens when I clink a link and it opens in a new tab on firefox, and when displaying a `BEL` character in some terminal emulators (at least in alacritty).

You can test it by running

```sh
sleep 1 && tput bel
```

in alacritty, and switching to another workspaces before the sleep expires.

I implemented it for both Sway and Hyprland. Sway keep track of a `urgent` flag for each client, and notify ironbar about changes. Hyprland or the other hand only contains a urgent event that triggers once, so I clean the urgent state of a workspace whenever it is focused.