### PR TITLE
feat: Minimize focused window option for launcher

### DIFF
--- a/docs/modules/Launcher.md
+++ b/docs/modules/Launcher.md
@@ -19,6 +19,7 @@ Optionally displays a launchable set of favourites.
 | `show_icons`                | `boolean`                                   | `true`   | Whether to show app icons on the button.                                                                                 |
 | `icon_size`                 | `integer`                                   | `32`     | Size to render icon at (image icons only).                                                                               |
 | `reversed`                  | `boolean`                                   | `false`  | Whether to reverse the order of favorites/items                                                                          |
+| `minimize_focused`   | `boolean`  | `true`  | Whether to minimize a focused window when its icon is clicked. Only minimizes single windows.       |
 | `truncate.mode`             | `'start'` or `'middle'` or `'end'` or `off` | `end`    | The location of the ellipses and where to truncate text from. Applies to application names when `show_names` is enabled. |
 | `truncate.length`           | `integer`                                   | `null`   | The fixed width (in chars) of the widget. Leave blank to let GTK automatically handle.                                   |
 | `truncate.max_length`       | `integer`                                   | `null`   | The maximum number of characters before truncating. Leave blank to let GTK automatically handle.                         |

--- a/src/clients/wayland/mod.rs
+++ b/src/clients/wayland/mod.rs
@@ -76,6 +76,8 @@ pub enum Request {
     ToplevelInfoAll,
     #[cfg(feature = "launcher")]
     ToplevelFocus(usize),
+    #[cfg(feature = "launcher")]
+    ToplevelMinimize(usize),
 
     #[cfg(feature = "clipboard")]
     CopyToClipboard(ClipboardItem),
@@ -346,6 +348,19 @@ impl Environment {
                 if let Some(handle) = handle {
                     let seat = env.default_seat();
                     handle.focus(&seat);
+                }
+
+                send!(env.response_tx, Response::Ok);
+            }
+            #[cfg(feature = "launcher")]
+            Msg(Request::ToplevelMinimize(id)) => {
+                let handle = env
+                    .handles
+                    .iter()
+                    .find(|handle| handle.info().map_or(false, |info| info.id == id));
+
+                if let Some(handle) = handle {
+                    handle.minimize();
                 }
 
                 send!(env.response_tx, Response::Ok);

--- a/src/clients/wayland/wlr_foreign_toplevel/handle.rs
+++ b/src/clients/wayland/wlr_foreign_toplevel/handle.rs
@@ -33,6 +33,11 @@ impl ToplevelHandle {
         trace!("Activating handle");
         self.handle.activate(seat);
     }
+
+    pub fn minimize(&self) {
+        trace!("Minimizing handle");
+        self.handle.set_minimized();
+    }
 }
 
 #[derive(Debug, Default)]

--- a/src/clients/wayland/wlr_foreign_toplevel/mod.rs
+++ b/src/clients/wayland/wlr_foreign_toplevel/mod.rs
@@ -36,6 +36,15 @@ impl Client {
         }
     }
 
+    /// Minimizes the toplevel with the provided ID.
+    #[cfg(feature = "launcher")]
+    pub fn toplevel_minimize(&self, handle_id: usize) {
+        match self.send_request(Request::ToplevelMinimize(handle_id)) {
+            Response::Ok => (),
+            _ => unreachable!(),
+        }
+    }
+
     /// Subscribes to events from toplevels.
     pub fn subscribe_toplevels(&self) -> broadcast::Receiver<ToplevelEvent> {
         self.toplevel_channel.0.subscribe()


### PR DESCRIPTION
This PR adds a new config option `minimize_focused` to the launcher module, which when set to true will minimize the currently focused window if its icon is clicked. If there is more than a single window open of that particular application the normal focus behavior will occur.

I haven't written much rust before, but hopefully it's relatively problem free!

Resolves  #658 