### PR TITLE
sway: support workspace rename events

### DIFF
--- a/src/clients/compositor/sway.rs
+++ b/src/clients/compositor/sway.rs
@@ -109,6 +109,16 @@ impl From<WorkspaceEvent> for WorkspaceUpdate {
             WorkspaceChange::Move => {
                 Self::Move(event.current.expect("Missing current workspace").into())
             }
+            WorkspaceChange::Rename => {
+                if let Some(node) = event.current {
+                    Self::Rename {
+                        id: node.id,
+                        name: node.name.unwrap_or_default(),
+                    }
+                } else {
+                    Self::Unknown
+                }
+            }
             WorkspaceChange::Urgent => {
                 if let Some(node) = event.current {
                     Self::Urgent {

--- a/src/modules/workspaces.rs
+++ b/src/modules/workspaces.rs
@@ -164,7 +164,15 @@ fn reorder_workspaces(container: &gtk::Box) {
     let mut buttons = container
         .children()
         .into_iter()
-        .map(|child| (child.widget_name().to_string(), child))
+        .map(|child| {
+            let label = child
+                .downcast_ref::<Button>()
+                .and_then(|button| button.label())
+                .unwrap_or_else(|| child.widget_name())
+                .to_string();
+
+            (label, child)
+        })
         .collect::<Vec<_>>();
 
     buttons.sort_by(|(label_a, _), (label_b, _a)| {
@@ -345,6 +353,10 @@ impl Module<gtk::Box> for WorkspacesModule {
                         if let Some(btn) = button_map.get(&id) {
                             let name = name_map.get(&name).unwrap_or(&name);
                             btn.set_label(name);
+                        }
+
+                        if self.sort == SortOrder::Alphanumeric {
+                            reorder_workspaces(&container);
                         }
                     }
                     WorkspaceUpdate::Add(workspace) => {


### PR DESCRIPTION
Simple enough to propagate the event of the rename.
However I'm not sure how to fix the order on rename, it doesn't seem to work if I just add
```rust
if self.sort == SortOrder::Alphanumeric {
    reorder_workspaces(&container);
}
```