### PR TITLE
Remove nixpkgs override for crane

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,6 @@
 
     crane = {
       url = "github:ipetkov/crane";
-      inputs.nixpkgs.follows = "nixpkgs";
     };
 
     naersk.url = "github:nix-community/naersk";


### PR DESCRIPTION
There's no nixpkgs import in the crane flake.