### PR TITLE
feat: justify property for clock and custom label

### DIFF
--- a/docs/modules/Clock.md
+++ b/docs/modules/Clock.md
@@ -14,6 +14,7 @@ Clicking on the widget opens a popup with the time and a calendar.
 | `format_popup` | `string`                                                   | `%H:%M:%S`                         | Date/time format string to display in the popup header. Pango markup is supported.  |
 | `locale`       | `string`                                                   | `$LC_TIME` or `$LANG` or `'POSIX'` | Locale to use (eg `en_GB`). Defaults to the system language (reading from env var). |
 | `orientation`  | `'horizontal'` or `'vertical'` (shorthand: `'h'` or `'v'`) | `'horizontal'`                     | Orientation of the time on the clock button.                                        |
+| `justify`      | `'left'`', `'right'`, `'center'`, or `'fill'`              | `'left'`                           | Justification (alignment) of the date/time shown on the bar.                        |
 
 > Detail on available tokens can be found here: <https://docs.rs/chrono/latest/chrono/format/strftime/index.html>
 

--- a/docs/modules/Custom.md
+++ b/docs/modules/Custom.md
@@ -54,10 +54,11 @@ A text label. Pango markup is supported.
 
 > Type `label`
 
-| Name    | Type                                            | Default | Description                                                         |
-|---------|-------------------------------------------------|---------|---------------------------------------------------------------------|
-| `label` | [Dynamic String](dynamic-values#dynamic-string) | `null`  | Widget text label. Pango markup and embedded scripts are supported. |
-| `orientation` | `'horizontal'` or `'vertical'` (shorthand: `'h'` or `'v'`) | `'horizontal'` | Orientation of the label.                                                                                                      |
+| Name          | Type                                                       | Default        | Description                                                          |
+|---------------|------------------------------------------------------------|----------------|----------------------------------------------------------------------|
+| `label`       | [Dynamic String](dynamic-values#dynamic-string)            | `null`         | Widget text label. Pango markup and embedded scripts are supported.  |
+| `orientation` | `'horizontal'` or `'vertical'` (shorthand: `'h'` or `'v'`) | `'horizontal'` | Orientation of the label text.                                       |
+| `justify`     | `'left'`, `'right'`, `'center'`, or `'fill'`               | `'left'`       | Justification (alignment) of the label text.                         |
 
 #### Button
 

--- a/src/config/common.rs
+++ b/src/config/common.rs
@@ -206,7 +206,7 @@ pub enum ModuleJustification {
     Left,
     Right,
     Center,
-    Fill
+    Fill,
 }
 
 impl From<ModuleJustification> for Justification {
@@ -215,7 +215,7 @@ impl From<ModuleJustification> for Justification {
             ModuleJustification::Left => Self::Left,
             ModuleJustification::Right => Self::Right,
             ModuleJustification::Center => Self::Center,
-            ModuleJustification::Fill => Self::Fill
+            ModuleJustification::Fill => Self::Fill,
         }
     }
 }

--- a/src/config/common.rs
+++ b/src/config/common.rs
@@ -3,7 +3,7 @@ use crate::script::{Script, ScriptInput};
 use glib::Propagation;
 use gtk::gdk::ScrollDirection;
 use gtk::prelude::*;
-use gtk::{EventBox, Orientation, Revealer, RevealerTransitionType};
+use gtk::{EventBox, Justification, Orientation, Revealer, RevealerTransitionType};
 use serde::Deserialize;
 use tracing::trace;
 
@@ -194,6 +194,28 @@ impl From<ModuleOrientation> for Orientation {
         match o {
             ModuleOrientation::Horizontal => Self::Horizontal,
             ModuleOrientation::Vertical => Self::Vertical,
+        }
+    }
+}
+
+#[derive(Debug, Default, Deserialize, Clone, Copy)]
+#[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub enum ModuleJustification {
+    #[default]
+    Left,
+    Right,
+    Center,
+    Fill
+}
+
+impl From<ModuleJustification> for Justification {
+    fn from(o: ModuleJustification) -> Self {
+        match o {
+            ModuleJustification::Left => Self::Left,
+            ModuleJustification::Right => Self::Right,
+            ModuleJustification::Center => Self::Center,
+            ModuleJustification::Fill => Self::Fill
         }
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -45,7 +45,7 @@ use std::collections::HashMap;
 #[cfg(feature = "schema")]
 use schemars::JsonSchema;
 
-pub use self::common::{CommonConfig, ModuleOrientation, TransitionType};
+pub use self::common::{CommonConfig, ModuleJustification, ModuleOrientation, TransitionType};
 pub use self::truncate::{EllipsizeMode, TruncateMode};
 
 #[derive(Debug, Deserialize, Clone)]

--- a/src/modules/clock.rs
+++ b/src/modules/clock.rs
@@ -58,10 +58,6 @@ pub struct ClockModule {
     #[serde(default)]
     orientation: ModuleOrientation,
 
-    /// See [common options](module-level-options#common-options).
-    #[serde(flatten)]
-    pub common: Option<CommonConfig>,
-
     /// The justification (alignment) of the date/time shown on the bar.
     ///
     /// **Valid options**: `left`, `right`, `center`, `fill`
@@ -69,6 +65,10 @@ pub struct ClockModule {
     /// **Default**: `left`
     #[serde(default)]
     justify: ModuleJustification,
+
+    /// See [common options](module-level-options#common-options).
+    #[serde(flatten)]
+    pub common: Option<CommonConfig>,
 }
 
 impl Default for ClockModule {

--- a/src/modules/clock.rs
+++ b/src/modules/clock.rs
@@ -68,7 +68,7 @@ pub struct ClockModule {
     /// <br>
     /// **Default**: `left`
     #[serde(default)]
-    justify: ModuleJustification
+    justify: ModuleJustification,
 }
 
 impl Default for ClockModule {
@@ -79,7 +79,7 @@ impl Default for ClockModule {
             locale: default_locale(),
             orientation: ModuleOrientation::Horizontal,
             common: Some(CommonConfig::default()),
-            justify: ModuleJustification::Left
+            justify: ModuleJustification::Left,
         }
     }
 }

--- a/src/modules/clock.rs
+++ b/src/modules/clock.rs
@@ -8,7 +8,7 @@ use serde::Deserialize;
 use tokio::sync::{broadcast, mpsc};
 use tokio::time::sleep;
 
-use crate::config::{CommonConfig, ModuleOrientation};
+use crate::config::{CommonConfig, ModuleJustification, ModuleOrientation};
 use crate::gtk_helpers::IronbarGtkExt;
 use crate::modules::{
     Module, ModuleInfo, ModuleParts, ModulePopup, ModuleUpdateEvent, PopupButton, WidgetContext,
@@ -61,6 +61,14 @@ pub struct ClockModule {
     /// See [common options](module-level-options#common-options).
     #[serde(flatten)]
     pub common: Option<CommonConfig>,
+
+    /// The justification (alignment) of the date/time shown on the bar.
+    ///
+    /// **Valid options**: `left`, `right`, `center`, `fill`
+    /// <br>
+    /// **Default**: `left`
+    #[serde(default)]
+    justify: ModuleJustification
 }
 
 impl Default for ClockModule {
@@ -71,6 +79,7 @@ impl Default for ClockModule {
             locale: default_locale(),
             orientation: ModuleOrientation::Horizontal,
             common: Some(CommonConfig::default()),
+            justify: ModuleJustification::Left
         }
     }
 }
@@ -129,6 +138,7 @@ impl Module<Button> for ClockModule {
         let label = Label::builder()
             .angle(self.orientation.to_angle())
             .use_markup(true)
+            .justify(self.justify.into())
             .build();
         button.add(&label);
 

--- a/src/modules/custom/label.rs
+++ b/src/modules/custom/label.rs
@@ -43,7 +43,7 @@ pub struct LabelWidget {
     /// <br>
     /// **Default**: `left`
     #[serde(default)]
-    justify: ModuleJustification
+    justify: ModuleJustification,
 }
 
 impl CustomWidget for LabelWidget {

--- a/src/modules/custom/label.rs
+++ b/src/modules/custom/label.rs
@@ -4,7 +4,7 @@ use serde::Deserialize;
 
 use super::{CustomWidget, CustomWidgetContext};
 use crate::build;
-use crate::config::ModuleOrientation;
+use crate::config::{ModuleJustification, ModuleOrientation};
 use crate::dynamic_value::dynamic_string;
 use crate::gtk_helpers::IronbarLabelExt;
 
@@ -36,6 +36,14 @@ pub struct LabelWidget {
     /// **Default**: `horizontal`
     #[serde(default)]
     orientation: ModuleOrientation,
+
+    /// The justification (alignment) of the label text.
+    ///
+    /// **Valid options**: `left`, `right`, `center`, `fill`
+    /// <br>
+    /// **Default**: `left`
+    #[serde(default)]
+    justify: ModuleJustification
 }
 
 impl CustomWidget for LabelWidget {
@@ -45,6 +53,7 @@ impl CustomWidget for LabelWidget {
         let label = build!(self, Self::Widget);
 
         label.set_angle(self.orientation.to_angle());
+        label.set_justify(self.justify.into());
         label.set_use_markup(true);
 
         {


### PR DESCRIPTION
Provides a way for the user to align text in these modules. Particularly useful with multi-line text. Equivalent to this would be CSS's ``text-align`` property (which, for God knows what reason, GTK CSS does not provide).

These seemed to be the best fitting modules to add this property to, but I'm open to adding it to more if there are any others that seem deserving of it to someone else.