### PR TITLE
feat: keyboard layout module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ default = [
     "focused",
     "http",
     "ipc",
-    "keys",
+    "keys+all",
     "launcher",
     "music+all",
     "network_manager",
@@ -57,6 +57,9 @@ clock = ["chrono"]
 focused = []
 
 keys = ["dep:input", "dep:evdev-rs", "dep:libc", "dep:nix"]
+"keys+all" = ["keys", "keys+sway", "keys+hyprland"]
+"keys+sway" = ["keys", "sway"]
+"keys+hyprland" = ["keys", "hyprland"]
 
 launcher = []
 
@@ -161,10 +164,6 @@ upower_dbus = { version = "0.3.2", optional = true }
 # volume
 libpulse-binding = { version = "2.28.2", optional = true }
 
-# workspaces
-swayipc-async = { version = "2.0.1", optional = true }
-hyprland = { version = "0.4.0-alpha.3", features = ["silent"], optional = true }
-
 # shared
 futures-lite = { version = "2.5.0", optional = true } # network_manager, upower, workspaces
 nix = { version = "0.29.0", optional = true, features = ["event", "fs", "poll"] } # clipboard, input
@@ -172,6 +171,8 @@ regex = { version = "1.11.1", default-features = false, features = [
   "std",
 ], optional = true } # music, sys_info
 zbus = { version = "3.15.2", default-features = false, features = ["tokio"], optional = true } # network_manager, notifications, upower
+swayipc-async = { version = "2.0.1", optional = true } # workspaces, keys
+hyprland = { version = "0.4.0-alpha.3", features = ["silent"], optional = true } # workspaces, keys
 
 # schema
 schemars = { version = "0.8.21", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ default = [
     "focused",
     "http",
     "ipc",
-    "keys+all",
+    "keyboard+all",
     "launcher",
     "music+all",
     "network_manager",
@@ -56,10 +56,10 @@ clock = ["chrono"]
 
 focused = []
 
-keys = ["dep:input", "dep:evdev-rs", "dep:libc", "dep:nix"]
-"keys+all" = ["keys", "keys+sway", "keys+hyprland"]
-"keys+sway" = ["keys", "sway"]
-"keys+hyprland" = ["keys", "hyprland"]
+keyboard = ["dep:input", "dep:evdev-rs", "dep:libc", "dep:nix"]
+"keyboard+all" = ["keyboard", "keyboard+sway", "keyboard+hyprland"]
+"keyboard+sway" = ["keyboard", "sway"]
+"keyboard+hyprland" = ["keyboard", "hyprland"]
 
 launcher = []
 
@@ -140,7 +140,7 @@ cairo-rs = { version = "0.18.5", optional = true, features = ["png"] }
 # clock
 chrono = { version = "0.4.39", optional = true, default-features = false, features = ["clock", "unstable-locales"] }
 
-# keys
+# keyboard
 input = { version = "0.9.1", optional = true }
 evdev-rs = { version = "0.6.1", optional = true }
 libc = { version = "0.2.164", optional = true }
@@ -171,8 +171,8 @@ regex = { version = "1.11.1", default-features = false, features = [
   "std",
 ], optional = true } # music, sys_info
 zbus = { version = "3.15.2", default-features = false, features = ["tokio"], optional = true } # network_manager, notifications, upower
-swayipc-async = { version = "2.0.1", optional = true } # workspaces, keys
-hyprland = { version = "0.4.0-alpha.3", features = ["silent"], optional = true } # workspaces, keys
+swayipc-async = { version = "2.0.1", optional = true } # workspaces, keyboard
+hyprland = { version = "0.4.0-alpha.3", features = ["silent"], optional = true } # workspaces, keyboard
 
 # schema
 schemars = { version = "0.8.21", optional = true }

--- a/docs/Compiling.md
+++ b/docs/Compiling.md
@@ -26,7 +26,7 @@ pacman -S openssl
 pacman -S libdbusmenu-gtk3
 # for volume support
 pacman -S libpulse
-# for keys support
+# for keyboard support
 pacman -S libinput
 # for lua/cairo support
 pacman -S luajit lua51-lgi
@@ -42,7 +42,7 @@ apt install libssl-dev
 apt install libdbusmenu-gtk3-dev
 # for volume support
 apt install libpulse-dev
-# for keys support
+# for keyboard support
 apt install libinput-dev
 # for lua/cairo support
 apt install luajit-dev lua-lgi
@@ -58,7 +58,7 @@ dnf install openssl-devel
 dnf install libdbusmenu-gtk3-devel
 # for volume support
 dnf install pulseaudio-libs-devel
-# for keys support
+# for keyboard support
 dnf install libinput-devel
 # for lua/cairo support
 dnf install luajit-devel lua-lgi
@@ -101,10 +101,10 @@ cargo build --release --no-default-features \
 | clipboard           | Enables the `clipboard` module.                                                   |
 | clock               | Enables the `clock` module.                                                       |
 | focused             | Enables the `focused` module.                                                     |
-| keys                | Enables the `keys` module without keyboard layout support.                        |
-| keys+all            | Enables the `keys` module with keyboard layout support for all compositors.       |
-| keys+sway           | Enables the `keys` module with keyboard layout support for Sway.                  |
-| keys+hyprland       | Enables the `keys` module with keyboard layout support for Hyprland.              |
+| keyboard            | Enables the `keyboard` module without keyboard layout support.                    |
+| keyboard+all        | Enables the `keyboard` module with keyboard layout support for all compositors.   |
+| keyboard+sway       | Enables the `keyboard` module with keyboard layout support for Sway.              |
+| keyboard+hyprland   | Enables the `keyboard` module with keyboard layout support for Hyprland.          |
 | launcher            | Enables the `launcher` module.                                                    |
 | music+all           | Enables the `music` module with support for all player types.                     |
 | music+mpris         | Enables the `music` module with MPRIS support.                                    |

--- a/docs/Compiling.md
+++ b/docs/Compiling.md
@@ -85,7 +85,7 @@ cargo build --release --no-default-features \
 > ⚠ Make sure you enable at least one `config` feature otherwise you will not be able to start the bar!
 
 | Feature             | Description                                                                       |
-|---------------------|-----------------------------------------------------------------------------------|
+| ------------------- | --------------------------------------------------------------------------------- |
 | **Core**            |                                                                                   |
 | http                | Enables HTTP features. Currently this includes the ability to load remote images. |
 | ipc                 | Enables the IPC server.                                                           |
@@ -101,6 +101,10 @@ cargo build --release --no-default-features \
 | clipboard           | Enables the `clipboard` module.                                                   |
 | clock               | Enables the `clock` module.                                                       |
 | focused             | Enables the `focused` module.                                                     |
+| keys                | Enables the `keys` module without keyboard layout support.                        |
+| keys+all            | Enables the `keys` module with keyboard layout support for all compositors.       |
+| keys+sway           | Enables the `keys` module with keyboard layout support for Sway.                  |
+| keys+hyprland       | Enables the `keys` module with keyboard layout support for Hyprland.              |
 | launcher            | Enables the `launcher` module.                                                    |
 | music+all           | Enables the `music` module with support for all player types.                     |
 | music+mpris         | Enables the `music` module with MPRIS support.                                    |

--- a/docs/_Sidebar.md
+++ b/docs/_Sidebar.md
@@ -29,7 +29,7 @@
 - [Clock](clock)
 - [Custom](custom)
 - [Focused](focused)
-- [Keys](keys)
+- [Keyboard](keyboard)
 - [Label](label)
 - [Launcher](launcher)
 - [Music](music)

--- a/docs/modules/Keyboard.md
+++ b/docs/modules/Keyboard.md
@@ -6,11 +6,11 @@
 
 Displays the toggle state of the capslock, num lock and scroll lock keys, and the current keyboard layout.
 
-![Screenshot of keys widget](https://f.jstanger.dev/github/ironbar/keys.png)
+![Screenshot of keyboard widget](https://f.jstanger.dev/github/ironbar/keys.png)
 
 ## Configuration
 
-> Type: `keys`
+> Type: `keyboard`
 
 | Name               | Type                           | Default | Description                                                                                                               |
 | ------------------ | ------------------------------ | ------- | ------------------------------------------------------------------------------------------------------------------------- |
@@ -34,7 +34,7 @@ Displays the toggle state of the capslock, num lock and scroll lock keys, and th
 {
   "end": [
     {
-      "type": "keys",
+      "type": "keyboard",
       "show_scroll": false,
       "icons": {
         "caps_on": "󰪛",
@@ -55,7 +55,7 @@ Displays the toggle state of the capslock, num lock and scroll lock keys, and th
 
 ```toml
 [[end]]
-type = "keys"
+type = "keyboard"
 show_scroll = false
 
 [end.icons]
@@ -73,7 +73,7 @@ Ukrainian = "🇺🇦"
 
 ```yaml
 end:
-  - type: keys
+  - type: keyboard
     show_scroll: false
     icons:
       caps_on: 󰪛
@@ -92,7 +92,7 @@ end:
 {
 end = [ 
         { 
-            type = "keys" 
+            type = "keyboard" 
             show_scroll = false 
             icons.caps_on = "󰪛" 
             icons.layout_map.'English (US)' = "🇺🇸"
@@ -106,16 +106,16 @@ end = [
 
 ## Styling
 
-| Selector               | Description                                |
-| ---------------------- | ------------------------------------------ |
-| `.keys`                | Keys box container widget.                 |
-| `.keys .key`           | Individual key indicator container widget. |
-| `.keys .key.enabled`   | Key indicator where key is toggled on.     |
-| `.keys .key.caps`      | Capslock key indicator.                    |
-| `.keys .key.num`       | Num lock key indicator.                    |
-| `.keys .key.scroll`    | Scroll lock key indicator.                 |
-| `.keys .key.image`     | Key indicator image icon.                  |
-| `.keys .key.text-icon` | Key indicator textual icon.                |
-| `.keys .layout`        | Keyboard layout indicator.                 |
+| Selector                   | Description                                |
+| -------------------------- | ------------------------------------------ |
+| `.keyboard`                | Keys box container widget.                 |
+| `.keyboard .key`           | Individual key indicator container widget. |
+| `.keyboard .key.enabled`   | Key indicator where key is toggled on.     |
+| `.keyboard .key.caps`      | Capslock key indicator.                    |
+| `.keyboard .key.num`       | Num lock key indicator.                    |
+| `.keyboard .key.scroll`    | Scroll lock key indicator.                 |
+| `.keyboard .key.image`     | Key indicator image icon.                  |
+| `.keyboard .key.text-icon` | Key indicator textual icon.                |
+| `.keyboard .layout`        | Keyboard layout indicator.                 |
 
 For more information on styling, please see the [styling guide](styling-guide).

--- a/docs/modules/Keys.md
+++ b/docs/modules/Keys.md
@@ -1,27 +1,31 @@
 > [!NOTE]
 > This module requires your user is in the `input` group.
 
-Displays the toggle state of the capslock, num lock and scroll lock keys.
+> [!IMPORTANT]
+> The keyboard layout feature is only available on Sway and Hyprland.
 
-![Screenshot of clock widget with popup open](https://f.jstanger.dev/github/ironbar/keys.png)
+Displays the toggle state of the capslock, num lock and scroll lock keys, and the current keyboard layout.
+
+![Screenshot of keys widget](https://f.jstanger.dev/github/ironbar/keys.png)
 
 ## Configuration
 
 > Type: `keys`
 
-| Name               | Type                        | Default | Description                                      |
-|--------------------|-----------------------------|---------|--------------------------------------------------|
-| `show_caps`        | `boolean`                   | `true`  | Whether to show capslock indicator.              |
-| `show_num`         | `boolean`                   | `true`  | Whether to show num lock indicator.              |
-| `show_scroll`      | `boolean`                   | `true`  | Whether to show scroll lock indicator.           |
-| `icon_size`        | `integer`                   | `32`    | Size to render icon at (image icons only).       |
-| `icons.caps_on`    | `string` or [image](images) | `󰪛`    | Icon to show for enabled capslock indicator.     |
-| `icons.caps_off`   | `string` or [image](images) | `''`    | Icon to show for disabled capslock indicator.    |
-| `icons.num_on`     | `string` or [image](images) | ``     | Icon to show for enabled num lock indicator.     |
-| `icons.num_off`    | `string` or [image](images) | `''`    | Icon to show for disabled num lock indicator.    |
-| `icons.scroll_on`  | `string` or [image](images) | ``     | Icon to show for enabled scroll lock indicator.  |
-| `icons.scroll_off` | `string` or [image](images) | `''`    | Icon to show for disabled scroll lock indicator. |
-| `seat`             | `string`                    | `seat0` | ID of the Wayland seat to attach to.             |
+| Name               | Type                           | Default | Description                                                                                                               |
+| ------------------ | ------------------------------ | ------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `show_caps`        | `boolean`                      | `true`  | Whether to show capslock indicator.                                                                                       |
+| `show_num`         | `boolean`                      | `true`  | Whether to show num lock indicator.                                                                                       |
+| `show_scroll`      | `boolean`                      | `true`  | Whether to show scroll lock indicator.                                                                                    |
+| `icon_size`        | `integer`                      | `32`    | Size to render icon at (image icons only).                                                                                |
+| `icons.caps_on`    | `string` or [image](images)    | `󰪛`     | Icon to show for enabled capslock indicator.                                                                              |
+| `icons.caps_off`   | `string` or [image](images)    | `''`    | Icon to show for disabled capslock indicator.                                                                             |
+| `icons.num_on`     | `string` or [image](images)    | ``     | Icon to show for enabled num lock indicator.                                                                              |
+| `icons.num_off`    | `string` or [image](images)    | `''`    | Icon to show for disabled num lock indicator.                                                                             |
+| `icons.scroll_on`  | `string` or [image](images)    | ``     | Icon to show for enabled scroll lock indicator.                                                                           |
+| `icons.scroll_off` | `string` or [image](images)    | `''`    | Icon to show for disabled scroll lock indicator.                                                                          |
+| `icons.layout_map` | `Map<string, string or image>` | `{}`    | Map of icons or labels to show for a particular keyboard layout. Layouts use their actual name if not present in the map. |
+| `seat`             | `string`                       | `seat0` | ID of the Wayland seat to attach to.                                                                                      |
 
 <details>
 <summary>JSON</summary>
@@ -33,7 +37,11 @@ Displays the toggle state of the capslock, num lock and scroll lock keys.
       "type": "keys",
       "show_scroll": false,
       "icons": {
-        "caps_on": "󰪛"
+        "caps_on": "󰪛",
+        "layout_map": {
+          "English (US)": "🇺🇸",
+          "Ukrainian": "🇺🇦"
+        }
       }
     }
   ]
@@ -52,6 +60,10 @@ show_scroll = false
 
 [end.icons]
 caps_on = "󰪛"
+
+[end.icons.layout_map]
+"English (US)" = "🇺🇸"
+Ukrainian = "🇺🇦"
 ```
 
 </details>
@@ -65,6 +77,10 @@ end:
     show_scroll: false
     icons:
       caps_on: 󰪛
+      layout_map:
+        "English (US)": 🇺🇸
+        Ukrainian: 🇺🇦
+
 ```
 
 </details>
@@ -79,6 +95,8 @@ end = [
             type = "keys" 
             show_scroll = false 
             icons.caps_on = "󰪛" 
+            icons.layout_map.'English (US)' = "🇺🇸"
+            icons.layout_map.Ukrainian = "🇺🇦"
         }
     ]
 }
@@ -89,7 +107,7 @@ end = [
 ## Styling
 
 | Selector               | Description                                |
-|------------------------|--------------------------------------------|
+| ---------------------- | ------------------------------------------ |
 | `.keys`                | Keys box container widget.                 |
 | `.keys .key`           | Individual key indicator container widget. |
 | `.keys .key.enabled`   | Key indicator where key is toggled on.     |
@@ -98,5 +116,6 @@ end = [
 | `.keys .key.scroll`    | Scroll lock key indicator.                 |
 | `.keys .key.image`     | Key indicator image icon.                  |
 | `.keys .key.text-icon` | Key indicator textual icon.                |
+| `.keys .layout`        | Keyboard layout indicator.                 |
 
 For more information on styling, please see the [styling guide](styling-guide).

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -64,7 +64,7 @@
       ++ lib.optionals (hasFeature "tray") [ libdbusmenu-gtk3 ]
       ++ lib.optionals (hasFeature "volume")[ libpulseaudio ]
       ++ lib.optionals (hasFeature "cairo") [ luajit ]
-      ++ lib.optionals (hasFeature "keys") [ libinput libevdev ];
+      ++ lib.optionals (hasFeature "keyboard") [ libinput libevdev ];
 
     propagatedBuildInputs = [ gtk3 ];
 

--- a/src/clients/compositor/mod.rs
+++ b/src/clients/compositor/mod.rs
@@ -60,11 +60,11 @@ impl Compositor {
         let current = Self::get_current();
         debug!("Getting keyboard_layout client for: {current}");
         match current {
-            #[cfg(feature = "keys+sway")]
+            #[cfg(feature = "keyboard+sway")]
             Self::Sway => clients
                 .sway()
                 .map(|client| client as Arc<dyn KeyboardLayoutClient + Send + Sync>),
-            #[cfg(feature = "keys+hyprland")]
+            #[cfg(feature = "keyboard+hyprland")]
             Self::Hyprland => clients
                 .hyprland()
                 .map(|client| client as Arc<dyn KeyboardLayoutClient + Send + Sync>),

--- a/src/clients/mod.rs
+++ b/src/clients/mod.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 pub mod clipboard;
 #[cfg(feature = "workspaces")]
 pub mod compositor;
-#[cfg(feature = "keys")]
+#[cfg(feature = "keyboard")]
 pub mod libinput;
 #[cfg(feature = "cairo")]
 pub mod lua;
@@ -42,9 +42,9 @@ pub struct Clients {
     hyprland: Option<Arc<compositor::hyprland::Client>>,
     #[cfg(feature = "clipboard")]
     clipboard: Option<Arc<clipboard::Client>>,
-    #[cfg(feature = "keys")]
+    #[cfg(feature = "keyboard")]
     libinput: HashMap<Box<str>, Arc<libinput::Client>>,
-    #[cfg(any(feature = "keys+sway", feature = "keys+hyprland"))]
+    #[cfg(any(feature = "keyboard+sway", feature = "keyboard+hyprland"))]
     keyboard_layout: Option<Arc<dyn compositor::KeyboardLayoutClient>>,
     #[cfg(feature = "cairo")]
     lua: Option<Rc<lua::LuaEngine>>,
@@ -97,7 +97,7 @@ impl Clients {
         Ok(client)
     }
 
-    #[cfg(any(feature = "keys+sway", feature = "keys+hyprland"))]
+    #[cfg(any(feature = "keyboard+sway", feature = "keyboard+hyprland"))]
     pub fn keyboard_layout(&mut self) -> ClientResult<dyn compositor::KeyboardLayoutClient> {
         let client = if let Some(keyboard_layout) = &self.keyboard_layout {
             keyboard_layout.clone()
@@ -144,7 +144,7 @@ impl Clients {
             .clone()
     }
 
-    #[cfg(feature = "keys")]
+    #[cfg(feature = "keyboard")]
     pub fn libinput(&mut self, seat: &str) -> Arc<libinput::Client> {
         self.libinput
             .entry(seat.into())

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -11,8 +11,8 @@ use crate::modules::clock::ClockModule;
 use crate::modules::custom::CustomModule;
 #[cfg(feature = "focused")]
 use crate::modules::focused::FocusedModule;
-#[cfg(feature = "keys")]
-use crate::modules::keys::KeysModule;
+#[cfg(feature = "keyboard")]
+use crate::modules::keyboard::KeyboardModule;
 use crate::modules::label::LabelModule;
 #[cfg(feature = "launcher")]
 use crate::modules::launcher::LauncherModule;
@@ -61,8 +61,8 @@ pub enum ModuleConfig {
     Custom(Box<CustomModule>),
     #[cfg(feature = "focused")]
     Focused(Box<FocusedModule>),
-    #[cfg(feature = "keys")]
-    Keys(Box<KeysModule>),
+    #[cfg(feature = "keyboard")]
+    Keyboard(Box<KeyboardModule>),
     Label(Box<LabelModule>),
     #[cfg(feature = "launcher")]
     Launcher(Box<LauncherModule>),
@@ -110,8 +110,8 @@ impl ModuleConfig {
             Self::Custom(module) => create!(module),
             #[cfg(feature = "focused")]
             Self::Focused(module) => create!(module),
-            #[cfg(feature = "keys")]
-            Self::Keys(module) => create!(module),
+            #[cfg(feature = "keyboard")]
+            Self::Keyboard(module) => create!(module),
             Self::Label(module) => create!(module),
             #[cfg(feature = "launcher")]
             Self::Launcher(module) => create!(module),

--- a/src/image/gtk.rs
+++ b/src/image/gtk.rs
@@ -31,7 +31,7 @@ pub fn new_icon_button(input: &str, icon_theme: &IconTheme, size: i32) -> Button
     button
 }
 
-#[cfg(any(feature = "music", feature = "keys"))]
+#[cfg(any(feature = "music", feature = "keyboard"))]
 pub struct IconLabel {
     container: gtk::Box,
     label: Label,
@@ -41,7 +41,7 @@ pub struct IconLabel {
     size: i32,
 }
 
-#[cfg(any(feature = "music", feature = "keys"))]
+#[cfg(any(feature = "music", feature = "keyboard"))]
 impl IconLabel {
     pub fn new(input: &str, icon_theme: &IconTheme, size: i32) -> Self {
         let container = gtk::Box::new(Orientation::Horizontal, 0);

--- a/src/modules/keyboard.rs
+++ b/src/modules/keyboard.rs
@@ -17,7 +17,7 @@ use crate::{glib_recv, module_impl, module_update, send_async, spawn, try_send};
 
 #[derive(Debug, Deserialize, Clone)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-pub struct KeysModule {
+pub struct KeyboardModule {
     /// Whether to show capslock indicator.
     ///
     /// **Default**: `true`
@@ -116,7 +116,7 @@ struct Icons {
     ///
     /// ```corn
     /// {
-    ///   type = "keys"
+    ///   type = "keyboard"
     ///   show_layout = true
     ///   icons.layout_map.'English (US)' = "EN"
     ///   icons.layout_map.Ukrainian = "UA"
@@ -161,16 +161,16 @@ fn default_icon_scroll() -> String {
 }
 
 #[derive(Debug, Clone)]
-pub enum KeysUpdate {
+pub enum KeyboardUpdate {
     Key(KeyEvent),
     Layout(KeyboardLayoutUpdate),
 }
 
-impl Module<gtk::Box> for KeysModule {
-    type SendMessage = KeysUpdate;
+impl Module<gtk::Box> for KeyboardModule {
+    type SendMessage = KeyboardUpdate;
     type ReceiveMessage = ();
 
-    module_impl!("keys");
+    module_impl!("keyboard");
 
     fn spawn_controller(
         &self,
@@ -191,11 +191,11 @@ impl Module<gtk::Box> for KeysModule {
                                 key,
                                 state: client.get_state(key),
                             };
-                            module_update!(tx, KeysUpdate::Key(event));
+                            module_update!(tx, KeyboardUpdate::Key(event));
                         }
                     }
                     Event::Key(ev) => {
-                        module_update!(tx, KeysUpdate::Key(ev));
+                        module_update!(tx, KeyboardUpdate::Key(ev));
                     }
                 }
             }
@@ -212,7 +212,7 @@ impl Module<gtk::Box> for KeysModule {
 
                 while let Ok(payload) = srx.recv().await {
                     debug!("Received update: {payload:?}");
-                    module_update!(tx, KeysUpdate::Layout(payload));
+                    module_update!(tx, KeyboardUpdate::Layout(payload));
                 }
             });
         }
@@ -277,8 +277,8 @@ impl Module<gtk::Box> for KeysModule {
         }
 
         let icons = self.icons;
-        let handle_event = move |ev: KeysUpdate| match ev {
-            KeysUpdate::Key(ev) => {
+        let handle_event = move |ev: KeyboardUpdate| match ev {
+            KeyboardUpdate::Key(ev) => {
                 let parts = match (ev.key, ev.state) {
                     (Key::Caps, true) if self.show_caps => Some((&caps, icons.caps_on.as_str())),
                     (Key::Caps, false) if self.show_caps => Some((&caps, icons.caps_off.as_str())),
@@ -303,7 +303,7 @@ impl Module<gtk::Box> for KeysModule {
                     }
                 }
             }
-            KeysUpdate::Layout(KeyboardLayoutUpdate(language)) => {
+            KeyboardUpdate::Layout(KeyboardLayoutUpdate(language)) => {
                 let text = icons.layout_map.get(&language).unwrap_or(&language);
                 layout.set_label(Some(text));
             }

--- a/src/modules/keys.rs
+++ b/src/modules/keys.rs
@@ -1,14 +1,19 @@
+use std::collections::HashMap;
+
+use color_eyre::eyre::Report;
 use color_eyre::Result;
-use gtk::prelude::*;
+use gtk::{prelude::*, Button};
 use serde::Deserialize;
 use tokio::sync::mpsc;
+use tracing::{debug, trace};
 
-use super::{Module, ModuleInfo, ModuleParts, ModuleUpdateEvent, WidgetContext};
+use super::{Module, ModuleInfo, ModuleParts, WidgetContext};
+use crate::clients::compositor::{self, KeyboardLayoutUpdate};
 use crate::clients::libinput::{Event, Key, KeyEvent};
 use crate::config::CommonConfig;
 use crate::gtk_helpers::IronbarGtkExt;
 use crate::image::IconLabel;
-use crate::{glib_recv, module_impl, module_update, send_async, spawn};
+use crate::{glib_recv, module_impl, module_update, send_async, spawn, try_send};
 
 #[derive(Debug, Deserialize, Clone)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
@@ -30,6 +35,12 @@ pub struct KeysModule {
     ///  **Default**: `true`
     #[serde(default = "crate::config::default_true")]
     show_scroll: bool,
+
+    /// Whether to show the current keyboard layout.
+    ///
+    ///  **Default**: `true`
+    #[serde(default = "crate::config::default_true")]
+    show_layout: bool,
 
     /// Size to render the icons at, in pixels (image icons only).
     ///
@@ -93,6 +104,26 @@ struct Icons {
     /// **Default**: `""`
     #[serde(default)]
     scroll_off: String,
+
+    /// Map of icons or labels to show for a particular keyboard layout.
+    ///
+    /// If a layout is not present in the map,
+    /// it will fall back to using its actual name.
+    ///
+    /// **Default**: `{}`
+    ///
+    /// # Example
+    ///
+    /// ```corn
+    /// {
+    ///   type = "keys"
+    ///   show_layout = true
+    ///   icons.layout_map.'English (US)' = "EN"
+    ///   icons.layout_map.Ukrainian = "UA"
+    /// }
+    /// ```
+    #[serde(default)]
+    layout_map: HashMap<String, String>,
 }
 
 impl Default for Icons {
@@ -104,6 +135,7 @@ impl Default for Icons {
             num_off: String::new(),
             scroll_on: default_icon_scroll(),
             scroll_off: String::new(),
+            layout_map: HashMap::new(),
         }
     }
 }
@@ -128,8 +160,14 @@ fn default_icon_scroll() -> String {
     String::from("")
 }
 
+#[derive(Debug, Clone)]
+pub enum KeysUpdate {
+    Key(KeyEvent),
+    Layout(KeyboardLayoutUpdate),
+}
+
 impl Module<gtk::Box> for KeysModule {
-    type SendMessage = KeyEvent;
+    type SendMessage = KeysUpdate;
     type ReceiveMessage = ();
 
     module_impl!("keys");
@@ -138,7 +176,7 @@ impl Module<gtk::Box> for KeysModule {
         &self,
         _info: &ModuleInfo,
         context: &WidgetContext<Self::SendMessage, Self::ReceiveMessage>,
-        _rx: mpsc::Receiver<Self::ReceiveMessage>,
+        mut rx: mpsc::Receiver<Self::ReceiveMessage>,
     ) -> Result<()> {
         let client = context.ironbar.clients.borrow_mut().libinput(&self.seat);
 
@@ -149,20 +187,45 @@ impl Module<gtk::Box> for KeysModule {
                 match ev {
                     Event::Device => {
                         for key in [Key::Caps, Key::Num, Key::Scroll] {
-                            module_update!(
-                                tx,
-                                KeyEvent {
-                                    key: Key::Caps,
-                                    state: client.get_state(key)
-                                }
-                            );
+                            let event = KeyEvent {
+                                key,
+                                state: client.get_state(key),
+                            };
+                            module_update!(tx, KeysUpdate::Key(event));
                         }
                     }
                     Event::Key(ev) => {
-                        send_async!(tx, ModuleUpdateEvent::Update(ev));
+                        module_update!(tx, KeysUpdate::Key(ev));
                     }
                 }
             }
+        });
+
+        let client = context.try_client::<dyn compositor::KeyboardLayoutClient>()?;
+        {
+            let client = client.clone();
+            let tx = context.tx.clone();
+            spawn(async move {
+                let mut srx = client.subscribe();
+
+                trace!("Set up keyboard_layout subscription");
+
+                while let Ok(payload) = srx.recv().await {
+                    debug!("Received update: {payload:?}");
+                    module_update!(tx, KeysUpdate::Layout(payload));
+                }
+            });
+        }
+
+        // Change keyboard layout
+        spawn(async move {
+            trace!("Setting up keyboard_layout UI event handler");
+
+            while let Some(()) = rx.recv().await {
+                client.set_next_active();
+            }
+
+            Ok::<(), Report>(())
         });
 
         Ok(())
@@ -173,11 +236,15 @@ impl Module<gtk::Box> for KeysModule {
         context: WidgetContext<Self::SendMessage, Self::ReceiveMessage>,
         info: &ModuleInfo,
     ) -> Result<ModuleParts<gtk::Box>> {
-        let container = gtk::Box::new(info.bar_position.orientation(), 5);
+        let container = gtk::Box::new(info.bar_position.orientation(), 0);
 
         let caps = IconLabel::new(&self.icons.caps_off, info.icon_theme, self.icon_size);
         let num = IconLabel::new(&self.icons.num_off, info.icon_theme, self.icon_size);
         let scroll = IconLabel::new(&self.icons.scroll_off, info.icon_theme, self.icon_size);
+
+        let layout_button = Button::new();
+        let layout = IconLabel::new("", info.icon_theme, self.icon_size);
+        layout_button.add(&*layout);
 
         if self.show_caps {
             caps.add_class("key");
@@ -197,30 +264,48 @@ impl Module<gtk::Box> for KeysModule {
             container.add(&*scroll);
         }
 
+        if self.show_layout {
+            layout.add_class("layout");
+            container.add(&layout_button);
+        }
+
+        {
+            let tx = context.controller_tx.clone();
+            layout_button.connect_clicked(move |_| {
+                try_send!(tx, ());
+            });
+        }
+
         let icons = self.icons;
-        let handle_event = move |ev: KeyEvent| {
-            let parts = match (ev.key, ev.state) {
-                (Key::Caps, true) if self.show_caps => Some((&caps, icons.caps_on.as_str())),
-                (Key::Caps, false) if self.show_caps => Some((&caps, icons.caps_off.as_str())),
-                (Key::Num, true) if self.show_num => Some((&num, icons.num_on.as_str())),
-                (Key::Num, false) if self.show_num => Some((&num, icons.num_off.as_str())),
-                (Key::Scroll, true) if self.show_scroll => {
-                    Some((&scroll, icons.scroll_on.as_str()))
-                }
-                (Key::Scroll, false) if self.show_scroll => {
-                    Some((&scroll, icons.scroll_off.as_str()))
-                }
-                _ => None,
-            };
+        let handle_event = move |ev: KeysUpdate| match ev {
+            KeysUpdate::Key(ev) => {
+                let parts = match (ev.key, ev.state) {
+                    (Key::Caps, true) if self.show_caps => Some((&caps, icons.caps_on.as_str())),
+                    (Key::Caps, false) if self.show_caps => Some((&caps, icons.caps_off.as_str())),
+                    (Key::Num, true) if self.show_num => Some((&num, icons.num_on.as_str())),
+                    (Key::Num, false) if self.show_num => Some((&num, icons.num_off.as_str())),
+                    (Key::Scroll, true) if self.show_scroll => {
+                        Some((&scroll, icons.scroll_on.as_str()))
+                    }
+                    (Key::Scroll, false) if self.show_scroll => {
+                        Some((&scroll, icons.scroll_off.as_str()))
+                    }
+                    _ => None,
+                };
 
-            if let Some((label, input)) = parts {
-                label.set_label(Some(input));
+                if let Some((label, input)) = parts {
+                    label.set_label(Some(input));
 
-                if ev.state {
-                    label.add_class("enabled");
-                } else {
-                    label.remove_class("enabled");
+                    if ev.state {
+                        label.add_class("enabled");
+                    } else {
+                        label.remove_class("enabled");
+                    }
                 }
+            }
+            KeysUpdate::Layout(KeyboardLayoutUpdate(language)) => {
+                let text = icons.layout_map.get(&language).unwrap_or(&language);
+                layout.set_label(Some(text));
             }
         };
 

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -31,8 +31,8 @@ pub mod clock;
 pub mod custom;
 #[cfg(feature = "focused")]
 pub mod focused;
-#[cfg(feature = "keys")]
-pub mod keys;
+#[cfg(feature = "keyboard")]
+pub mod keyboard;
 pub mod label;
 #[cfg(feature = "launcher")]
 pub mod launcher;

--- a/src/modules/workspaces/mod.rs
+++ b/src/modules/workspaces/mod.rs
@@ -196,7 +196,7 @@ impl Module<gtk::Box> for WorkspacesModule {
         let client = context.ironbar.clients.borrow_mut().workspaces()?;
         // Subscribe & send events
         spawn(async move {
-            let mut srx = client.subscribe_workspace_change();
+            let mut srx = client.subscribe();
 
             trace!("Set up workspace subscription");
 
@@ -213,9 +213,7 @@ impl Module<gtk::Box> for WorkspacesModule {
             trace!("Setting up UI event handler");
 
             while let Some(name) = rx.recv().await {
-                if let Err(e) = client.focus(name.clone()) {
-                    warn!("Couldn't focus workspace '{name}': {e:#}");
-                };
+                client.focus(name.clone());
             }
 
             Ok::<(), Report>(())


### PR DESCRIPTION
Displays the current keyboard layout. Clicking switches to the next layout. Supports images. See `docs/` for details.

Resolves https://github.com/JakeStanger/ironbar/issues/575.

Current concerns:
1. `keyboard_layout` is a clear name, but maybe it's too verbose?
2. Is it okay to add yet another channel in `hyprland::Client`?
3. Maybe I should rename `layout_map` to `name_map` to be consistent with workspaces module?