### PR TITLE
feat: rename sway_mode to bindmode and add Hyprland support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,6 +100,9 @@ jobs:
           - config+toml
           - config+corn
           - config+ron
+          - bindmode+all
+          - bindmode+sway
+          - bindmode+hyprland
           - cairo
           - clipboard
           - clock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ default = [
     "focused",
     "http",
     "ipc",
+    "bindmode+all",
     "keyboard+all",
     "launcher",
     "label",
@@ -37,6 +38,11 @@ cli = ["ipc"]
 ipc = ["dep:serde_json", "dep:clap"]
 
 http = ["dep:reqwest"]
+
+bindmode = []
+"bindmode+all" = ["bindmode+sway", "bindmode+hyprland"]
+"bindmode+sway" = ["bindmode", "sway"]
+"bindmode+hyprland" = ["bindmode", "hyprland"]
 
 "config+all" = [
     "config+json",

--- a/docs/GTK4.md
+++ b/docs/GTK4.md
@@ -29,6 +29,7 @@ A full list of feature flags can be found [here](Compiling#features).
 
 | Module          | Status | Notes                                                                                                                                    |
 |-----------------|--------|------------------------------------------------------------------------------------------------------------------------------------------|
+| Bindmode        | ❌      |                                                                                                                                          |
 | Cairo           | ✅      |                                                                                                                                          |
 | Clipboard       | ✅      |                                                                                                                                          |
 | Clock           | ✅      |                                                                                                                                          |
@@ -41,7 +42,6 @@ A full list of feature flags can be found [here](Compiling#features).
 | Network Manager | ❌      |                                                                                                                                          |
 | Notifications   | ✅      |                                                                                                                                          |
 | Script          | ✅      |                                                                                                                                          |
-| Sway Mode       | ❌      |                                                                                                                                          |
 | SysInfo         | ✅      |                                                                                                                                          |
 | Tray            | ❌      | GTK4 removes widgets required to move the tray. No `libdbusmenu-gtk4` either. will need to manually re-create menus with custom widgets. |
 | UPower          | ❌      |                                                                                                                                          |

--- a/docs/_Sidebar.md
+++ b/docs/_Sidebar.md
@@ -25,6 +25,7 @@
 
 # Modules
 
+- [Bindmode](bindmode)
 - [Cairo](cairo)
 - [Clipboard](clipboard)
 - [Clock](clock)
@@ -37,7 +38,6 @@
 - [Network Manager](network-manager)
 - [Notifications](notifications)
 - [Script](script)
-- [Sway-mode](sway-mode)
 - [Sys_Info](sys-info)
 - [Tray](tray)
 - [Upower](upower)

--- a/docs/modules/Bindmode.md
+++ b/docs/modules/Bindmode.md
@@ -1,12 +1,12 @@
-Displays the current sway mode in a label. If the current sway mode is
-"default", nothing is displayed.
+> [!IMPORTANT]
+> This module is currently only available on Sway and Hyprland.
 
-> [!NOTE]
-> This module only works under the [Sway](https://swaywm.org/) compositor.
+Displays Sway's current binding mode or [Hyprland's current submap](https://wiki.hyprland.org/Configuring/Binds/#submaps)
+in a label. Nothing is displayed if no binding mode is active.
 
 ## Configuration
 
-> Type: `sway-mode`
+> Type: `bindmode`
 
 | Name                  | Type                                        | Default | Description                                                                                                                                           |
 | --------------------- | ------------------------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -22,7 +22,7 @@ Displays the current sway mode in a label. If the current sway mode is
 {
   "end": [
     {
-      "type": "sway-mode",
+      "type": "bindmode",
       "truncate": "start"
     }
   ]
@@ -36,7 +36,7 @@ Displays the current sway mode in a label. If the current sway mode is
 
 ```toml
 [[end]]
-type = "sway-mode"
+type = "bindmode"
 truncate = "start"
 ```
 
@@ -47,7 +47,7 @@ truncate = "start"
 
 ```yaml
 end:
-  - type: "sway-mode"
+  - type: "bindmode"
     truncate: "start"
 ```
 
@@ -60,7 +60,7 @@ end:
 {
   end = [
     {
-      type = "sway-mode"
+      type = "bindmode"
       truncate = "start"
     }
   ]
@@ -71,8 +71,8 @@ end:
 
 ## Styling
 
-| Selector     | Description            |
-| ------------ | ---------------------- |
-| `.sway_mode` | Sway mode label widget |
+| Selector    | Description            |
+| ----------- | ---------------------- |
+| `.bindmode` | Bind mode label widget |
 
 For more information on styling, please see the [styling guide](styling-guide).

--- a/src/clients/compositor/mod.rs
+++ b/src/clients/compositor/mod.rs
@@ -66,6 +66,30 @@ impl Compositor {
         }
     }
 
+    #[cfg(feature = "bindmode")]
+    pub fn create_bindmode_client(
+        clients: &mut super::Clients,
+    ) -> ClientResult<dyn BindModeClient + Send + Sync> {
+        let current = Self::get_current();
+        debug!("Getting keyboard_layout client for: {current}");
+        match current {
+            #[cfg(feature = "bindmode+sway")]
+            Self::Sway => clients
+                .sway()
+                .map(|client| client as Arc<dyn BindModeClient + Send + Sync>),
+            #[cfg(feature = "bindmode+hyprland")]
+            Self::Hyprland => Ok(clients.hyprland()),
+            #[cfg(feature = "niri")]
+            Self::Niri => Err(Report::msg("Unsupported compositor")
+                .note("Currently bindmode is only supported by Sway and Hyprland")),
+            Self::Unsupported => Err(Report::msg("Unsupported compositor")
+                .note("Currently bindmode is only supported by Sway and Hyprland")),
+            #[allow(unreachable_patterns)]
+            _ => Err(Report::msg("Unsupported compositor")
+                .note("Bindmode feature is disabled for this compositor")),
+        }
+    }
+
     #[cfg(feature = "keyboard")]
     pub fn create_keyboard_layout_client(
         clients: &mut super::Clients,
@@ -195,6 +219,14 @@ pub enum WorkspaceUpdate {
     Unknown,
 }
 
+#[derive(Clone, Debug)]
+pub struct BindModeUpdate {
+    /// The binding mode that became active.
+    pub name: String,
+    /// Whether the mode should be parsed as pango markup.
+    pub pango_markup: bool,
+}
+
 #[cfg(feature = "workspaces")]
 pub trait WorkspaceClient: Debug + Send + Sync {
     /// Requests the workspace with this id is focused.
@@ -218,3 +250,12 @@ pub trait KeyboardLayoutClient: Debug + Send + Sync {
 
 #[cfg(feature = "keyboard")]
 register_fallible_client!(dyn KeyboardLayoutClient, keyboard_layout);
+
+#[cfg(feature = "bindmode")]
+pub trait BindModeClient: Debug + Send + Sync {
+    /// Add a callback for bindmode updates.
+    fn subscribe(&self) -> Result<broadcast::Receiver<BindModeUpdate>>;
+}
+
+#[cfg(feature = "bindmode")]
+register_fallible_client!(dyn BindModeClient, bindmode);

--- a/src/clients/compositor/mod.rs
+++ b/src/clients/compositor/mod.rs
@@ -74,9 +74,7 @@ impl Compositor {
         debug!("Getting keyboard_layout client for: {current}");
         match current {
             #[cfg(feature = "bindmode+sway")]
-            Self::Sway => clients
-                .sway()
-                .map(|client| client as Arc<dyn BindModeClient + Send + Sync>),
+            Self::Sway => Ok(clients.sway()?),
             #[cfg(feature = "bindmode+hyprland")]
             Self::Hyprland => Ok(clients.hyprland()),
             #[cfg(feature = "niri")]
@@ -98,9 +96,7 @@ impl Compositor {
         debug!("Getting keyboard_layout client for: {current}");
         match current {
             #[cfg(feature = "keyboard+sway")]
-            Self::Sway => clients
-                .sway()
-                .map(|client| client as Arc<dyn KeyboardLayoutClient + Send + Sync>),
+            Self::Sway => Ok(clients.sway()?),
             #[cfg(feature = "keyboard+hyprland")]
             Self::Hyprland => Ok(clients.hyprland()),
             #[cfg(feature = "niri")]
@@ -126,9 +122,7 @@ impl Compositor {
         debug!("Getting workspace client for: {current}");
         match current {
             #[cfg(feature = "workspaces+sway")]
-            Self::Sway => clients
-                .sway()
-                .map(|client| client as Arc<dyn WorkspaceClient + Send + Sync>),
+            Self::Sway => Ok(clients.sway()?),
             #[cfg(feature = "workspaces+hyprland")]
             Self::Hyprland => Ok(clients.hyprland()),
             #[cfg(feature = "workspaces+niri")]

--- a/src/clients/mod.rs
+++ b/src/clients/mod.rs
@@ -7,7 +7,12 @@ use std::sync::Arc;
 
 #[cfg(feature = "clipboard")]
 pub mod clipboard;
-#[cfg(any(feature = "keyboard", feature = "workspaces", feature = "hyprland"))]
+#[cfg(any(
+    feature = "bindmode",
+    feature = "hyprland",
+    feature = "keyboard",
+    feature = "workspaces",
+))]
 pub mod compositor;
 #[cfg(feature = "keyboard")]
 pub mod libinput;
@@ -42,6 +47,8 @@ pub struct Clients {
     sway: Option<Arc<sway::Client>>,
     #[cfg(feature = "hyprland")]
     hyprland: Option<Arc<compositor::hyprland::Client>>,
+    #[cfg(feature = "bindmode")]
+    bindmode: Option<Arc<dyn compositor::BindModeClient>>,
     #[cfg(feature = "clipboard")]
     clipboard: Option<Arc<clipboard::Client>>,
     #[cfg(feature = "keyboard")]
@@ -108,6 +115,19 @@ impl Clients {
         } else {
             let client = compositor::Compositor::create_keyboard_layout_client(self)?;
             self.keyboard_layout.replace(client.clone());
+            client
+        };
+
+        Ok(client)
+    }
+
+    #[cfg(feature = "bindmode")]
+    pub fn bindmode(&mut self) -> ClientResult<dyn compositor::BindModeClient> {
+        let client = if let Some(client) = &self.bindmode {
+            client.clone()
+        } else {
+            let client = compositor::Compositor::create_bindmode_client(self)?;
+            self.bindmode.replace(client.clone());
             client
         };
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3,6 +3,8 @@ mod r#impl;
 mod layout;
 mod truncate;
 
+#[cfg(any(feature = "bindmode"))]
+use crate::modules::bindmode::Bindmode;
 #[cfg(feature = "cairo")]
 use crate::modules::cairo::CairoModule;
 #[cfg(feature = "clipboard")]
@@ -27,8 +29,6 @@ use crate::modules::networkmanager::NetworkManagerModule;
 use crate::modules::notifications::NotificationsModule;
 #[cfg(feature = "script")]
 use crate::modules::script::ScriptModule;
-#[cfg(feature = "sway")]
-use crate::modules::sway::mode::SwayModeModule;
 #[cfg(feature = "sys_info")]
 use crate::modules::sysinfo::SysInfoModule;
 #[cfg(feature = "tray")]
@@ -57,6 +57,8 @@ pub use self::truncate::{EllipsizeMode, TruncateMode};
 #[serde(tag = "type", rename_all = "snake_case")]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 pub enum ModuleConfig {
+    #[cfg(feature = "bindmode")]
+    Bindmode(Box<Bindmode>),
     #[cfg(feature = "cairo")]
     Cairo(Box<CairoModule>),
     #[cfg(feature = "clipboard")]
@@ -83,8 +85,6 @@ pub enum ModuleConfig {
     Script(Box<ScriptModule>),
     #[cfg(feature = "sys_info")]
     SysInfo(Box<SysInfoModule>),
-    #[cfg(feature = "sway")]
-    SwayMode(Box<SwayModeModule>),
     #[cfg(feature = "tray")]
     Tray(Box<TrayModule>),
     #[cfg(feature = "upower")]
@@ -109,6 +109,8 @@ impl ModuleConfig {
         }
 
         match self {
+            #[cfg(feature = "bindmode")]
+            Self::Bindmode(module) => create!(module),
             #[cfg(feature = "cairo")]
             Self::Cairo(module) => create!(module),
             #[cfg(feature = "clipboard")]
@@ -135,8 +137,6 @@ impl ModuleConfig {
             Self::Script(module) => create!(module),
             #[cfg(feature = "sys_info")]
             Self::SysInfo(module) => create!(module),
-            #[cfg(feature = "sway")]
-            Self::SwayMode(module) => create!(module),
             #[cfg(feature = "tray")]
             Self::Tray(module) => create!(module),
             #[cfg(feature = "upower")]

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -17,6 +17,8 @@ use crate::gtk_helpers::{IronbarGtkExt, WidgetGeometry};
 use crate::popup::Popup;
 use crate::{Ironbar, glib_recv_mpsc, send};
 
+#[cfg(feature = "bindmode")]
+pub mod bindmode;
 #[cfg(feature = "cairo")]
 pub mod cairo;
 #[cfg(feature = "clipboard")]
@@ -50,8 +52,6 @@ pub mod notifications;
 
 #[cfg(feature = "script")]
 pub mod script;
-#[cfg(feature = "sway")]
-pub mod sway;
 #[cfg(feature = "sys_info")]
 pub mod sysinfo;
 #[cfg(feature = "tray")]

--- a/src/modules/sway/mod.rs
+++ b/src/modules/sway/mod.rs
@@ -1,1 +1,0 @@
-pub mod mode;


### PR DESCRIPTION
I am currently migrating from sway to Hyprland, and so I added support for Hyprland in the sway_mode module. Because the module is no longer sway-only, I decided to rename to a more generic name. This feature does not have a consistent name across window managers, i3/Sway [calls it binding mode](https://i3wm.org/docs/userguide.html#binding_modes), while Hyprland calls it [Keybind submaps](https://wiki.hyprland.org/Configuring/Binds/#submaps). But "bindmode" appears to be a good enough name.

I made "sway_mode" be a alias for "bindmode" to avoid breaking configs that use the previous name, but I can remove that if you prefer.