### PR TITLE
refactor: upgrade to zbus v5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,49 +105,14 @@ dependencies = [
 
 [[package]]
 name = "async-broadcast"
-version = "0.5.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c48ccdbf6ca6b121e0f586cbc0e73ae440e56c67c30fa0873b4e110d9c26d2b"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
 dependencies = [
- "event-listener",
+ "event-listener 5.4.0",
+ "event-listener-strategy",
  "futures-core",
-]
-
-[[package]]
-name = "async-channel"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf46fee83e5ccffc220104713af3292ff9bc7c64c7de289f66dae8e38d826833"
-dependencies = [
- "concurrent-queue",
- "event-listener",
- "futures-core",
-]
-
-[[package]]
-name = "async-executor"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fa3dc5f2a8564f07759c008b9109dc0d39de92a88d5588b8a5036d286383afb"
-dependencies = [
- "async-lock",
- "async-task",
- "concurrent-queue",
- "fastrand 1.9.0",
- "futures-lite 1.13.0",
- "slab",
-]
-
-[[package]]
-name = "async-fs"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "279cf904654eeebfa37ac9bb1598880884924aab82e290aa65c9e77a0e142e06"
-dependencies = [
- "async-lock",
- "autocfg",
- "blocking",
- "futures-lite 1.13.0",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -176,7 +141,7 @@ version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa24f727524730b077666307f2734b4a1a1c57acb79193127dcc8914d5242dd7"
 dependencies = [
- "event-listener",
+ "event-listener 2.5.3",
 ]
 
 [[package]]
@@ -190,48 +155,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-process"
-version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9d28b1d97e08915212e2e45310d47854eafa69600756fc735fb788f75199c9"
-dependencies = [
- "async-io",
- "async-lock",
- "autocfg",
- "blocking",
- "cfg-if",
- "event-listener",
- "futures-lite 1.13.0",
- "rustix 0.37.27",
- "signal-hook",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "async-recursion"
-version = "1.0.4"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e97ce7de6cf12de5d7226c73f5ba9811622f4db3a5b91b55c53e987e5f91cba"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
- "quote 1.0.35",
+ "quote 1.0.38",
  "syn 2.0.92",
 ]
 
 [[package]]
-name = "async-task"
-version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc7ab41815b3c653ccd2978ec3255c81349336702dfdf62ee6f7069b12a3aae"
-
-[[package]]
 name = "async-trait"
-version = "0.1.68"
+version = "0.1.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
+checksum = "644dd749086bf3771a2fbc5f256fdb982d53f011c7d5d560304eafeecebce79d"
 dependencies = [
  "proc-macro2",
- "quote 1.0.35",
+ "quote 1.0.38",
  "syn 2.0.92",
 ]
 
@@ -257,12 +198,6 @@ dependencies = [
  "libc",
  "system-deps",
 ]
-
-[[package]]
-name = "atomic-waker"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1181e1e0d1fce796a03db1ae795d67167da795f9cf4a39c37589e85ef57f26d3"
 
 [[package]]
 name = "autocfg"
@@ -322,21 +257,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "blocking"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77231a1c8f801696fc0123ec6150ce92cffb8e164a02afb9c8ddee0e9b65ad65"
-dependencies = [
- "async-channel",
- "async-lock",
- "async-task",
- "atomic-waker",
- "fastrand 1.9.0",
- "futures-lite 1.13.0",
- "log",
-]
-
-[[package]]
 name = "bstr"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -351,12 +271,6 @@ name = "bumpalo"
 version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
-
-[[package]]
-name = "byteorder"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
@@ -494,7 +408,7 @@ checksum = "54b755194d6389280185988721fffba69495eed5ee9feeee9a599b53db80318c"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
- "quote 1.0.35",
+ "quote 1.0.38",
  "syn 2.0.92",
 ]
 
@@ -539,9 +453,9 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "concurrent-queue"
-version = "2.2.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62ec6771ecfa0762d24683ee5a32ad78487a3d3afdc0fb8cae19d2c5deb50b7c"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -659,7 +573,7 @@ dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
- "quote 1.0.35",
+ "quote 1.0.38",
  "strsim 0.10.0",
  "syn 1.0.109",
 ]
@@ -671,7 +585,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
 dependencies = [
  "darling_core",
- "quote 1.0.35",
+ "quote 1.0.38",
  "syn 1.0.109",
 ]
 
@@ -724,17 +638,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derivative"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
-dependencies = [
- "proc-macro2",
- "quote 1.0.35",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "derive_is_enum_variant"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -752,15 +655,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
  "proc-macro2",
- "quote 1.0.35",
+ "quote 1.0.38",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "digest"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -842,21 +745,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
+name = "endi"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3d8a32ae18130a3c84dd492d4215c3d913c3b07c6b63c2eb3eb7ff1101ab7bf"
+
+[[package]]
 name = "enum-kinds"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e40a16955681d469ab3da85aaa6b42ff656b3c67b52e1d8d3dd36afe97fd462"
 dependencies = [
  "proc-macro2",
- "quote 1.0.35",
+ "quote 1.0.38",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "enumflags2"
-version = "0.7.7"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c041f5090df68b32bcd905365fd51769c8b9d553fe87fde0b683534f10c01bd2"
+checksum = "ba2f4b465f5318854c6f8dd686ede6c0a9dc67d4b1ac241cf0eb51521a309147"
 dependencies = [
  "enumflags2_derive",
  "serde",
@@ -864,12 +773,12 @@ dependencies = [
 
 [[package]]
 name = "enumflags2_derive"
-version = "0.7.7"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e9a1f9f7d83e59740248a6e14ecf93929ade55027844dfcea78beafccc15745"
+checksum = "fc4caf64a58d7a6d65ab00639b046ff54399a39f5f2554728895ace4b297cd79"
 dependencies = [
  "proc-macro2",
- "quote 1.0.35",
+ "quote 1.0.38",
  "syn 2.0.92",
 ]
 
@@ -917,6 +826,27 @@ name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3e4e0dd3673c1139bf041f3008816d9cf2946bbfac2945c09e523b8d7b05b2"
+dependencies = [
+ "event-listener 5.4.0",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "eyre"
@@ -1012,7 +942,7 @@ checksum = "55a5e644a80e6d96b2b4910fa7993301d7b7926c045b475b62202b20a36ce69e"
 dependencies = [
  "darling",
  "proc-macro2",
- "quote 1.0.35",
+ "quote 1.0.38",
  "syn 1.0.109",
 ]
 
@@ -1099,7 +1029,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
- "quote 1.0.35",
+ "quote 1.0.38",
  "syn 2.0.92",
 ]
 
@@ -1224,7 +1154,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "913dce4c5f06c2ea40fc178c06f777ac89fc6b1383e90c254fafb1abe4ba3c82"
 dependencies = [
  "proc-macro2",
- "quote 1.0.35",
+ "quote 1.0.38",
  "syn 2.0.92",
  "uuid",
 ]
@@ -1311,7 +1241,7 @@ dependencies = [
  "proc-macro-crate 2.0.0",
  "proc-macro-error",
  "proc-macro2",
- "quote 1.0.35",
+ "quote 1.0.38",
  "syn 2.0.92",
 ]
 
@@ -1412,7 +1342,7 @@ dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro-error",
  "proc-macro2",
- "quote 1.0.35",
+ "quote 1.0.38",
  "syn 2.0.92",
 ]
 
@@ -1620,7 +1550,7 @@ version = "0.4.0-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd8ce4c182ce77e485918f49262425ee51a2746fe97f14084869aeff2fbc38e"
 dependencies = [
- "quote 1.0.35",
+ "quote 1.0.38",
  "syn 2.0.92",
 ]
 
@@ -1790,7 +1720,6 @@ dependencies = [
  "tracing-error",
  "tracing-subscriber",
  "universal-config",
- "upower_dbus",
  "walkdir",
  "wayland-client",
  "wayland-protocols-wlr",
@@ -2000,6 +1929,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2148,6 +2086,7 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+ "memoffset 0.9.1",
 ]
 
 [[package]]
@@ -2216,7 +2155,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
 dependencies = [
  "proc-macro2",
- "quote 1.0.35",
+ "quote 1.0.38",
  "syn 1.0.109",
 ]
 
@@ -2276,7 +2215,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
- "quote 1.0.35",
+ "quote 1.0.38",
  "syn 2.0.92",
 ]
 
@@ -2398,7 +2337,7 @@ dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
- "quote 1.0.35",
+ "quote 1.0.38",
  "syn 2.0.92",
 ]
 
@@ -2429,15 +2368,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
- "quote 1.0.35",
+ "quote 1.0.38",
  "syn 2.0.92",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.12"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12cc1b0bf1727a77a54b6654e7b5f1af8604923edc8b81885f8ec92f9e3f0a05"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "pin-utils"
@@ -2488,12 +2427,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
-
-[[package]]
 name = "proc-macro-crate"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2513,6 +2446,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
+dependencies = [
+ "toml_edit 0.22.23",
+]
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2520,7 +2462,7 @@ checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
- "quote 1.0.35",
+ "quote 1.0.38",
  "syn 1.0.109",
  "version_check",
 ]
@@ -2532,7 +2474,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
  "proc-macro2",
- "quote 1.0.35",
+ "quote 1.0.38",
  "version_check",
 ]
 
@@ -2568,41 +2510,11 @@ checksum = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom",
 ]
 
 [[package]]
@@ -2910,7 +2822,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1eee588578aff73f856ab961cd2f79e36bc45d7ded33a7562adba4667aecc0e"
 dependencies = [
  "proc-macro2",
- "quote 1.0.35",
+ "quote 1.0.38",
  "serde_derive_internals",
  "syn 2.0.92",
 ]
@@ -2972,7 +2884,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
- "quote 1.0.35",
+ "quote 1.0.38",
  "syn 2.0.92",
 ]
 
@@ -2983,7 +2895,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330f01ce65a3a5fe59a60c82f3c9a024b573b8a6e875bd233fe5f934e71d54e3"
 dependencies = [
  "proc-macro2",
- "quote 1.0.35",
+ "quote 1.0.38",
  "syn 2.0.92",
 ]
 
@@ -3001,20 +2913,20 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.12"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcec881020c684085e55a25f7fd888954d56609ef363479dc5a1305eb0d40cab"
+checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
- "quote 1.0.35",
+ "quote 1.0.38",
  "syn 2.0.92",
 ]
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.5"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
 dependencies = [
  "serde",
 ]
@@ -3045,17 +2957,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
-]
-
-[[package]]
 name = "sha2"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3073,16 +2974,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
 dependencies = [
  "lazy_static",
-]
-
-[[package]]
-name = "signal-hook"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
-dependencies = [
- "libc",
- "signal-hook-registry",
 ]
 
 [[package]]
@@ -3236,7 +3127,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
- "quote 1.0.35",
+ "quote 1.0.38",
  "unicode-ident",
 ]
 
@@ -3247,7 +3138,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70ae51629bf965c5c098cc9e87908a3df5301051a9e087d6f9bef5c9771ed126"
 dependencies = [
  "proc-macro2",
- "quote 1.0.35",
+ "quote 1.0.38",
  "unicode-ident",
 ]
 
@@ -3299,11 +3190,12 @@ dependencies = [
 
 [[package]]
 name = "system-tray"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf82d5346e9fcc9df02b40b1257facba789147c80905f1cb08e382af28bf28c"
+checksum = "c3397841ed755bf361606a845779e0f7333d35fb4e39627ef6f656d7cdad4c73"
 dependencies = [
  "dbusmenu-gtk3-sys",
+ "futures-lite 2.6.0",
  "gtk",
  "serde",
  "thiserror 2.0.9",
@@ -3350,7 +3242,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
- "quote 1.0.35",
+ "quote 1.0.38",
  "syn 2.0.92",
 ]
 
@@ -3361,7 +3253,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b50fa271071aae2e6ee85f842e2e28ba8cd2c5fb67f11fcb1fd70b276f9e7d4"
 dependencies = [
  "proc-macro2",
- "quote 1.0.35",
+ "quote 1.0.38",
  "syn 2.0.92",
 ]
 
@@ -3446,7 +3338,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
- "quote 1.0.35",
+ "quote 1.0.38",
  "syn 2.0.92",
 ]
 
@@ -3506,14 +3398,14 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.9",
+ "toml_edit 0.22.23",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.5"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
 dependencies = [
  "serde",
 ]
@@ -3544,15 +3436,15 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.9"
+version = "0.22.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e40bb779c5187258fd7aad0eb68cb8706a0a81fa712fbea808ab43c4b8374c4"
+checksum = "02a8b472d1a3d7c18e2d61a489aee3453fd9031c33e4f55bd533f4a7adca1bee"
 dependencies = [
  "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.5",
+ "winnow 0.7.1",
 ]
 
 [[package]]
@@ -3612,7 +3504,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
- "quote 1.0.35",
+ "quote 1.0.38",
  "syn 2.0.92",
 ]
 
@@ -3697,10 +3589,11 @@ dependencies = [
 
 [[package]]
 name = "uds_windows"
-version = "1.0.2"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce65604324d3cce9b966701489fbd0cf318cb1f7bd9dd07ac9a4ee6fb791930d"
+checksum = "89daebc3e6fd160ac4aa9fc8b3bf71e1f74fbf92367ae71fb83a037e8bf164b9"
 dependencies = [
+ "memoffset 0.9.1",
  "tempfile",
  "winapi",
 ]
@@ -3766,17 +3659,6 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
-
-[[package]]
-name = "upower_dbus"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0b1d77de98ab2e5187f5fa2b045b8c4eecfc49e5ccd07f16f4c89f008116f8c"
-dependencies = [
- "serde",
- "serde_repr",
- "zbus",
-]
 
 [[package]]
 name = "url"
@@ -3845,7 +3727,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d257817081c7dffcdbab24b9e62d2def62e2ff7d00b1c20062551e6cccc145ff"
 dependencies = [
  "proc-macro2",
- "quote 1.0.35",
+ "quote 1.0.38",
 ]
 
 [[package]]
@@ -3901,7 +3783,7 @@ dependencies = [
  "log",
  "once_cell",
  "proc-macro2",
- "quote 1.0.35",
+ "quote 1.0.38",
  "syn 2.0.92",
  "wasm-bindgen-shared",
 ]
@@ -3924,7 +3806,7 @@ version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
 dependencies = [
- "quote 1.0.35",
+ "quote 1.0.38",
  "wasm-bindgen-macro-support",
 ]
 
@@ -3935,7 +3817,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
- "quote 1.0.35",
+ "quote 1.0.38",
  "syn 2.0.92",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
@@ -4028,7 +3910,7 @@ checksum = "fb8e28403665c9f9513202b7e1ed71ec56fde5c107816843fb14057910b2c09c"
 dependencies = [
  "proc-macro2",
  "quick-xml",
- "quote 1.0.35",
+ "quote 1.0.38",
 ]
 
 [[package]]
@@ -4362,9 +4244,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.6.5"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dffa400e67ed5a4dd237983829e66475f0a4a26938c4b04c21baede6262215b8"
+checksum = "86e376c75f4f43f44db463cf729e0d3acbf954d13e22c51e26e4c264b4ab545f"
 dependencies = [
  "memchr",
 ]
@@ -4380,12 +4262,12 @@ dependencies = [
 
 [[package]]
 name = "xdg-home"
-version = "1.0.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2769203cd13a0c6015d515be729c526d041e9cf2c0cc478d57faee85f40c6dcd"
+checksum = "ec1cdab258fb55c0da61328dc52c8764709b249011b2cad0454c72f0bf10a1f6"
 dependencies = [
- "nix 0.26.4",
- "winapi",
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4396,40 +4278,28 @@ checksum = "054a8e68b76250b253f671d1268cb7f1ae089ec35e195b2efb2a4e9a836d0621"
 
 [[package]]
 name = "zbus"
-version = "3.15.2"
+version = "5.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "675d170b632a6ad49804c8cf2105d7c31eddd3312555cffd4b740e08e97c25e6"
+checksum = "59c333f648ea1b647bc95dc1d34807c8e25ed7a6feff3394034dc4776054b236"
 dependencies = [
  "async-broadcast",
- "async-executor",
- "async-fs",
- "async-io",
- "async-lock",
- "async-process",
  "async-recursion",
- "async-task",
  "async-trait",
- "blocking",
- "byteorder",
- "derivative",
  "enumflags2",
- "event-listener",
+ "event-listener 5.4.0",
  "futures-core",
- "futures-sink",
- "futures-util",
+ "futures-lite 2.6.0",
  "hex",
- "nix 0.26.4",
- "once_cell",
+ "nix 0.29.0",
  "ordered-stream",
- "rand",
  "serde",
  "serde_repr",
- "sha1",
  "static_assertions",
  "tokio",
  "tracing",
  "uds_windows",
- "winapi",
+ "windows-sys 0.59.0",
+ "winnow 0.7.1",
  "xdg-home",
  "zbus_macros",
  "zbus_names",
@@ -4438,26 +4308,28 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "3.15.2"
+version = "5.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7131497b0f887e8061b430c530240063d33bf9455fa34438f388a245da69e0a5"
+checksum = "f325ad10eb0d0a3eb060203494c3b7ec3162a01a59db75d2deee100339709fc0"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 3.2.0",
  "proc-macro2",
- "quote 1.0.35",
- "regex",
- "syn 1.0.109",
+ "quote 1.0.38",
+ "syn 2.0.92",
+ "zbus_names",
+ "zvariant",
  "zvariant_utils",
 ]
 
 [[package]]
 name = "zbus_names"
-version = "2.6.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb80bb776dbda6e23d705cf0123c3b95df99c4ebeaec6c2599d4a5419902b4a9"
+checksum = "7be68e64bf6ce8db94f63e72f0c7eb9a60d733f7e0499e628dfab0f84d6bcb97"
 dependencies = [
  "serde",
  "static_assertions",
+ "winnow 0.7.1",
  "zvariant",
 ]
 
@@ -4469,38 +4341,42 @@ checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
 name = "zvariant"
-version = "3.15.0"
+version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44b291bee0d960c53170780af148dca5fa260a63cdd24f1962fa82e03e53338c"
+checksum = "b2df9ee044893fcffbdc25de30546edef3e32341466811ca18421e3cd6c5a3ac"
 dependencies = [
- "byteorder",
+ "endi",
  "enumflags2",
- "libc",
  "serde",
  "static_assertions",
+ "winnow 0.7.1",
  "zvariant_derive",
+ "zvariant_utils",
 ]
 
 [[package]]
 name = "zvariant_derive"
-version = "3.15.0"
+version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "934d7a7dfc310d6ee06c87ffe88ef4eca7d3e37bb251dece2ef93da8f17d8ecd"
+checksum = "74170caa85b8b84cc4935f2d56a57c7a15ea6185ccdd7eadb57e6edd90f94b2f"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 3.2.0",
  "proc-macro2",
- "quote 1.0.35",
- "syn 1.0.109",
+ "quote 1.0.38",
+ "syn 2.0.92",
  "zvariant_utils",
 ]
 
 [[package]]
 name = "zvariant_utils"
-version = "1.0.1"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7234f0d811589db492d16893e3f21e8e2fd282e6d01b0cddee310322062cc200"
+checksum = "e16edfee43e5d7b553b77872d99bc36afdda75c223ca7ad5e3fbecd82ca5fc34"
 dependencies = [
  "proc-macro2",
- "quote 1.0.35",
- "syn 1.0.109",
+ "quote 1.0.38",
+ "serde",
+ "static_assertions",
+ "syn 2.0.92",
+ "winnow 0.7.1",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ sys_info = ["sysinfo", "regex"]
 
 tray = ["system-tray"]
 
-upower = ["upower_dbus", "zbus", "futures-lite"]
+upower = ["zbus", "futures-lite"]
 
 volume = ["libpulse-binding"]
 
@@ -156,10 +156,7 @@ futures-signals = { version = "0.3.34", optional = true }
 sysinfo = { version = "0.29.11", optional = true }
 
 # tray
-system-tray = { version = "0.6.0", features = ["dbusmenu-gtk3"], optional = true }
-
-# upower
-upower_dbus = { version = "0.3.2", optional = true }
+system-tray = { version = "0.7.0", features = ["dbusmenu-gtk3"], optional = true }
 
 # volume
 libpulse-binding = { version = "2.28.2", optional = true }
@@ -170,7 +167,7 @@ nix = { version = "0.29.0", optional = true, features = ["event", "fs", "poll"] 
 regex = { version = "1.11.1", default-features = false, features = [
   "std",
 ], optional = true } # music, sys_info
-zbus = { version = "3.15.2", default-features = false, features = ["tokio"], optional = true } # network_manager, notifications, upower
+zbus = { version = "5.5.0", default-features = false, features = ["tokio"], optional = true } # network_manager, notifications, upower
 swayipc-async = { version = "2.0.1", optional = true } # workspaces, keyboard
 hyprland = { version = "0.4.0-alpha.3", features = ["silent"], optional = true } # workspaces, keyboard
 

--- a/src/clients/mod.rs
+++ b/src/clients/mod.rs
@@ -165,7 +165,7 @@ impl Clients {
         if let Some(client) = &self.network_manager {
             Ok(client.clone())
         } else {
-            let client = networkmanager::create_client()?;
+            let client = await_sync(async move { networkmanager::create_client().await })?;
             self.network_manager = Some(client.clone());
             Ok(client)
         }

--- a/src/clients/swaync/dbus.rs
+++ b/src/clients/swaync/dbus.rs
@@ -20,12 +20,14 @@
 //! [Writing a client proxy]: https://dbus2.github.io/zbus/client.html
 //! [D-Bus standard interfaces]: https://dbus.freedesktop.org/doc/dbus-specification.html#standard-interfaces,
 
-#[zbus::dbus_proxy(
+use zbus::proxy;
+
+#[proxy(
     interface = "org.erikreider.swaync.cc",
     default_service = "org.erikreider.swaync.cc",
     default_path = "/org/erikreider/swaync/cc"
 )]
-trait SwayNc {
+pub trait SwayNc {
     /// AddInhibitor method
     fn add_inhibitor(&self, application_id: &str) -> zbus::Result<bool>;
 
@@ -90,11 +92,11 @@ trait SwayNc {
     fn toggle_visibility(&self) -> zbus::Result<()>;
 
     /// Subscribe signal
-    #[dbus_proxy(signal)]
+    #[zbus(signal)]
     fn subscribe(&self, count: u32, dnd: bool, cc_open: bool) -> zbus::Result<()>;
 
     /// SubscribeV2 signal
-    #[dbus_proxy(signal)]
+    #[zbus(signal)]
     fn subscribe_v2(
         &self,
         count: u32,
@@ -104,8 +106,8 @@ trait SwayNc {
     ) -> zbus::Result<()>;
 
     /// Inhibited property
-    #[dbus_proxy(property)]
+    #[zbus(property)]
     fn inhibited(&self) -> zbus::Result<bool>;
-    #[dbus_proxy(property)]
+    #[zbus(property)]
     fn set_inhibited(&self, value: bool) -> zbus::Result<()>;
 }

--- a/src/clients/swaync/mod.rs
+++ b/src/clients/swaync/mod.rs
@@ -54,7 +54,11 @@ impl Client {
 
             spawn(async move {
                 while let Some(ev) = stream.next().await {
-                    let ev = ev.body::<Event>().expect("to deserialize");
+                    let ev = ev
+                        .message()
+                        .body()
+                        .deserialize::<Event>()
+                        .expect("to deserialize");
                     debug!("Received event: {ev:?}");
                     send!(tx, ev);
                 }

--- a/src/clients/upower/device.rs
+++ b/src/clients/upower/device.rs
@@ -1,0 +1,122 @@
+/// Originally taken from `upower-dbus` crate
+/// https://github.com/pop-os/upower-dbus/blob/main/LICENSE
+// Copyright 2021 System76 <info@system76.com>
+// SPDX-License-Identifier: MPL-2.0
+use zbus::proxy;
+use zbus::zvariant::OwnedValue;
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, OwnedValue)]
+#[repr(u32)]
+pub enum BatteryState {
+    Unknown = 0,
+    Charging = 1,
+    Discharging = 2,
+    Empty = 3,
+    FullyCharged = 4,
+    PendingCharge = 5,
+    PendingDischarge = 6,
+}
+
+#[derive(Debug, Copy, Clone, OwnedValue)]
+#[repr(u32)]
+pub enum BatteryType {
+    Unknown = 0,
+    LinePower = 1,
+    Battery = 2,
+    Ups = 3,
+    Monitor = 4,
+    Mouse = 5,
+    Keyboard = 6,
+    Pda = 7,
+    Phone = 8,
+}
+
+#[derive(Debug, Copy, Clone, OwnedValue)]
+#[repr(u32)]
+pub enum BatteryLevel {
+    Unknown = 0,
+    None = 1,
+    Low = 3,
+    Critical = 4,
+    Normal = 6,
+    High = 7,
+    Full = 8,
+}
+
+#[proxy(
+    interface = "org.freedesktop.UPower.Device",
+    default_service = "org.freedesktop.UPower",
+    assume_defaults = false
+)]
+pub trait Device {
+    #[zbus(property)]
+    fn battery_level(&self) -> zbus::Result<BatteryLevel>;
+
+    #[zbus(property)]
+    fn capacity(&self) -> zbus::Result<f64>;
+
+    #[zbus(property)]
+    fn energy(&self) -> zbus::Result<f64>;
+
+    #[zbus(property)]
+    fn energy_empty(&self) -> zbus::Result<f64>;
+
+    #[zbus(property)]
+    fn energy_full(&self) -> zbus::Result<f64>;
+
+    #[zbus(property)]
+    fn energy_full_design(&self) -> zbus::Result<f64>;
+
+    #[zbus(property)]
+    fn has_history(&self) -> zbus::Result<bool>;
+
+    #[zbus(property)]
+    fn has_statistics(&self) -> zbus::Result<bool>;
+
+    #[zbus(property)]
+    fn icon_name(&self) -> zbus::Result<String>;
+
+    #[zbus(property)]
+    fn is_present(&self) -> zbus::Result<bool>;
+
+    #[zbus(property)]
+    fn is_rechargeable(&self) -> zbus::Result<bool>;
+
+    #[zbus(property)]
+    fn luminosity(&self) -> zbus::Result<f64>;
+
+    #[zbus(property)]
+    fn model(&self) -> zbus::Result<String>;
+
+    #[zbus(property)]
+    fn native_path(&self) -> zbus::Result<String>;
+
+    #[zbus(property)]
+    fn online(&self) -> zbus::Result<bool>;
+
+    #[zbus(property)]
+    fn percentage(&self) -> zbus::Result<f64>;
+
+    #[zbus(property)]
+    fn power_supply(&self) -> zbus::Result<bool>;
+
+    fn refresh(&self) -> zbus::Result<()>;
+
+    #[zbus(property)]
+    fn serial(&self) -> zbus::Result<String>;
+
+    #[zbus(property)]
+    fn state(&self) -> zbus::Result<BatteryState>;
+
+    #[zbus(property)]
+    fn temperature(&self) -> zbus::Result<f64>;
+
+    #[zbus(property, name = "Type")]
+    fn type_(&self) -> zbus::Result<BatteryType>;
+
+    #[zbus(property)]
+    fn vendor(&self) -> zbus::Result<String>;
+
+    #[zbus(property)]
+    fn voltage(&self) -> zbus::Result<f64>;
+}

--- a/src/clients/upower/mod.rs
+++ b/src/clients/upower/mod.rs
@@ -1,8 +1,14 @@
+mod device;
+mod upower;
+
 use crate::clients::ClientResult;
 use crate::register_fallible_client;
 use std::sync::Arc;
-use upower_dbus::UPowerProxy;
+use upower::UPowerProxy;
 use zbus::fdo::PropertiesProxy;
+use zbus::proxy::CacheProperties;
+
+pub use device::BatteryState;
 
 pub async fn create_display_proxy() -> ClientResult<PropertiesProxy<'static>> {
     let dbus = Box::pin(zbus::Connection::system()).await?;
@@ -11,14 +17,14 @@ pub async fn create_display_proxy() -> ClientResult<PropertiesProxy<'static>> {
 
     let display_device = device_proxy.get_display_device().await?;
 
-    let path = display_device.path().to_owned();
+    let path = display_device.inner().path();
 
     let proxy = PropertiesProxy::builder(&dbus)
         .destination("org.freedesktop.UPower")
         .expect("failed to set proxy destination address")
         .path(path)
         .expect("failed to set proxy path")
-        .cache_properties(zbus::CacheProperties::No)
+        .cache_properties(CacheProperties::No)
         .build()
         .await?;
 

--- a/src/clients/upower/upower.rs
+++ b/src/clients/upower/upower.rs
@@ -1,0 +1,43 @@
+use super::device::DeviceProxy;
+/// Originally taken from `upower-dbus` crate
+/// https://github.com/pop-os/upower-dbus/blob/main/LICENSE
+// Copyright 2021 System76 <info@system76.com>
+// SPDX-License-Identifier: MPL-2.0
+use zbus::proxy;
+
+#[proxy(interface = "org.freedesktop.UPower", assume_defaults = true)]
+pub trait UPower {
+    /// EnumerateDevices method
+    fn enumerate_devices(&self) -> zbus::Result<Vec<zbus::zvariant::OwnedObjectPath>>;
+
+    /// GetCriticalAction method
+    fn get_critical_action(&self) -> zbus::Result<String>;
+
+    /// GetDisplayDevice method
+    #[zbus(object = "Device")]
+    fn get_display_device(&self);
+
+    /// DeviceAdded signal
+    #[zbus(signal)]
+    fn device_added(&self, device: zbus::zvariant::ObjectPath<'_>) -> zbus::Result<()>;
+
+    /// DeviceRemoved signal
+    #[zbus(signal)]
+    fn device_removed(&self, device: zbus::zvariant::ObjectPath<'_>) -> zbus::Result<()>;
+
+    /// DaemonVersion property
+    #[zbus(property)]
+    fn daemon_version(&self) -> zbus::Result<String>;
+
+    /// LidIsClosed property
+    #[zbus(property)]
+    fn lid_is_closed(&self) -> zbus::Result<bool>;
+
+    /// LidIsPresent property
+    #[zbus(property)]
+    fn lid_is_present(&self) -> zbus::Result<bool>;
+
+    /// OnBattery property
+    #[zbus(property)]
+    fn on_battery(&self) -> zbus::Result<bool>;
+}

--- a/src/modules/upower.rs
+++ b/src/modules/upower.rs
@@ -4,10 +4,10 @@ use gtk::{prelude::*, Button};
 use gtk::{Label, Orientation};
 use serde::Deserialize;
 use tokio::sync::{broadcast, mpsc};
-use upower_dbus::BatteryState;
 use zbus;
 use zbus::fdo::PropertiesProxy;
 
+use crate::clients::upower::BatteryState;
 use crate::config::CommonConfig;
 use crate::gtk_helpers::{IronbarGtkExt, IronbarLabelExt};
 use crate::image::ImageProvider;
@@ -59,7 +59,7 @@ pub struct UpowerProperties {
     time_to_empty: i64,
 }
 
-impl Module<gtk::Button> for UpowerModule {
+impl Module<Button> for UpowerModule {
     type SendMessage = UpowerProperties;
     type ReceiveMessage = ();
 
@@ -84,23 +84,23 @@ impl Module<gtk::Button> for UpowerModule {
 
             let properties = display_proxy.get_all(device_interface_name.clone()).await?;
 
-            let percentage = *properties["Percentage"]
+            let percentage = properties["Percentage"]
                 .downcast_ref::<f64>()
                 .expect("expected percentage: f64 in HashMap of all properties");
             let icon_name = properties["IconName"]
-                .downcast_ref::<str>()
+                .downcast_ref::<&str>()
                 .expect("expected IconName: str in HashMap of all properties")
                 .to_string();
             let state = u32_to_battery_state(
-                *properties["State"]
+                properties["State"]
                     .downcast_ref::<u32>()
                     .expect("expected State: u32 in HashMap of all properties"),
             )
             .unwrap_or(BatteryState::Unknown);
-            let time_to_full = *properties["TimeToFull"]
+            let time_to_full = properties["TimeToFull"]
                 .downcast_ref::<i64>()
                 .expect("expected TimeToFull: i64 in HashMap of all properties");
-            let time_to_empty = *properties["TimeToEmpty"]
+            let time_to_empty = properties["TimeToEmpty"]
                 .downcast_ref::<i64>()
                 .expect("expected TimeToEmpty: i64 in HashMap of all properties");
             let mut properties = UpowerProperties {
@@ -128,7 +128,7 @@ impl Module<gtk::Button> for UpowerModule {
                         }
                         "IconName" => {
                             properties.icon_name = changed_value
-                                .downcast_ref::<str>()
+                                .downcast_ref::<&str>()
                                 .expect("expected IconName to be str")
                                 .to_string();
                         }


### PR DESCRIPTION
Also drops the deprecated `upower-dbus` crate