### PR TITLE
keyboard: fix panic when layout update channel lags behind

### DIFF
--- a/src/clients/compositor/hyprland.rs
+++ b/src/clients/compositor/hyprland.rs
@@ -25,7 +25,7 @@ pub struct Client {
 impl Client {
     pub(crate) fn new() -> Self {
         let (workspace_tx, workspace_rx) = channel(16);
-        let (keyboard_layout_tx, keyboard_layout_rx) = channel(4);
+        let (keyboard_layout_tx, keyboard_layout_rx) = channel(16);
 
         let instance = Self {
             workspace_tx,

--- a/src/clients/compositor/sway.rs
+++ b/src/clients/compositor/sway.rs
@@ -166,7 +166,7 @@ impl KeyboardLayoutClient for Client {
     }
 
     fn subscribe(&self) -> Receiver<KeyboardLayoutUpdate> {
-        let (tx, rx) = channel(4);
+        let (tx, rx) = channel(16);
 
         let client = self.connection().clone();
 


### PR DESCRIPTION
Not sure of the implications of increasing capacity but I don't think it's really a problem.
Switched event loop to avoid ending on `RecvError::Lagged` response.