### PR TITLE
Launcher pagination and label truncation options

### DIFF
--- a/docs/modules/Custom.md
+++ b/docs/modules/Custom.md
@@ -54,11 +54,16 @@ A text label. Pango markup is supported.
 
 > Type `label`
 
-| Name          | Type                                                       | Default        | Description                                                          |
-|---------------|------------------------------------------------------------|----------------|----------------------------------------------------------------------|
-| `label`       | [Dynamic String](dynamic-values#dynamic-string)            | `null`         | Widget text label. Pango markup and embedded scripts are supported.  |
-| `orientation` | `'horizontal'` or `'vertical'` (shorthand: `'h'` or `'v'`) | `'horizontal'` | Orientation of the label text.                                       |
-| `justify`     | `'left'`, `'right'`, `'center'`, or `'fill'`               | `'left'`       | Justification (alignment) of the label text.                         |
+| Name                  | Type                                                       | Default        | Description                                                                                                                                           |
+|-----------------------|------------------------------------------------------------|----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `label`               | [Dynamic String](dynamic-values#dynamic-string)            | `null`         | Widget text label. Pango markup and embedded scripts are supported.                                                                                   |
+| `orientation`         | `'horizontal'` or `'vertical'` (shorthand: `'h'` or `'v'`) | `'horizontal'` | Orientation of the label text.                                                                                                                        |
+| `justify`             | `'left'`, `'right'`, `'center'`, or `'fill'`               | `'left'`       | Justification (alignment) of the label text.                                                                                                          |
+| `truncate`            | `'start'` or `'middle'` or `'end'` or `off` or `Map`       | `off`          | The location of the ellipses and where to truncate text from. Leave null to avoid truncating. Use the long-hand `Map` version if specifying a length. |
+| `truncate.mode`       | `'start'` or `'middle'` or `'end'` or `off`                | `off`          | The location of the ellipses and where to truncate text from. Leave null to avoid truncating.                                                         |
+| `truncate.length`     | `integer`                                                  | `null`         | The fixed width (in chars) of the widget. Leave blank to let GTK automatically handle.                                                                |
+| `truncate.max_length` | `integer`                                                  | `null`         | The maximum number of characters before truncating. Leave blank to let GTK automatically handle.                                                      |
+
 
 #### Button
 

--- a/docs/modules/Label.md
+++ b/docs/modules/Label.md
@@ -7,9 +7,14 @@ For more advanced use-cases, use [custom](custom).
 
 > Type: `label`
 
-| Name    | Type                                            | Default | Description            |
-|---------|-------------------------------------------------|---------|------------------------|
-| `label` | [Dynamic String](dynamic-values#dynamic-string) | `null`  | Text to show on label. |
+| Name                  | Type                                                 | Default | Description                                                                                                                                           |
+|-----------------------|------------------------------------------------------|---------|-------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `label`               | [Dynamic String](dynamic-values#dynamic-string)      | `null`  | Text to show on label.                                                                                                                                |
+| `truncate`            | `'start'` or `'middle'` or `'end'` or `off` or `Map` | `off`   | The location of the ellipses and where to truncate text from. Leave null to avoid truncating. Use the long-hand `Map` version if specifying a length. |
+| `truncate.mode`       | `'start'` or `'middle'` or `'end'` or `off`          | `off`   | The location of the ellipses and where to truncate text from. Leave null to avoid truncating.                                                         |
+| `truncate.length`     | `integer`                                            | `null`  | The fixed width (in chars) of the widget. Leave blank to let GTK automatically handle.                                                                |
+| `truncate.max_length` | `integer`                                            | `null`  | The maximum number of characters before truncating. Leave blank to let GTK automatically handle.                                                      |
+
 
 <details>
 <summary>JSON</summary>

--- a/docs/modules/Launcher.md
+++ b/docs/modules/Launcher.md
@@ -13,22 +13,23 @@ Optionally displays a launchable set of favourites.
 
 > Type: `launcher`
 
-|                             | Type                                        | Default  | Description                                                                                                              |
-|-----------------------------|---------------------------------------------|----------|--------------------------------------------------------------------------------------------------------------------------|
-| `favorites`                 | `string[]`                                  | `[]`     | List of app IDs (or classes) to always show at the start of the launcher.                                                |
-| `show_names`                | `boolean`                                   | `false`  | Whether to show app names on the button label. Names will still show on tooltips when set to false.                      |
-| `show_icons`                | `boolean`                                   | `true`   | Whether to show app icons on the button.                                                                                 |
-| `icon_size`                 | `integer`                                   | `32`     | Size to render icon at (image icons only).                                                                               |
-| `reversed`                  | `boolean`                                   | `false`  | Whether to reverse the order of favorites/items                                                                          |
-| `minimize_focused`   | `boolean`  | `true`  | Whether to minimize a focused window when its icon is clicked. Only minimizes single windows.       |
-| `truncate.mode`             | `'start'` or `'middle'` or `'end'` or `off` | `end`    | The location of the ellipses and where to truncate text from. Applies to application names when `show_names` is enabled. |
-| `truncate.length`           | `integer`                                   | `null`   | The fixed width (in chars) of the widget. Leave blank to let GTK automatically handle.                                   |
-| `truncate.max_length`       | `integer`                                   | `null`   | The maximum number of characters before truncating. Leave blank to let GTK automatically handle.                         |
-| `truncate_popup.mode`       | `'start'` or `'middle'` or `'end'` or `off` | `middle` | The location of the ellipses and where to truncate text from. Applies to window names within a group popup.              |
-| `truncate_popup.length`     | `integer`                                   | `null`   | The fixed width (in chars) of the widget. Leave blank to let GTK automatically handle.                                   |
-| `truncate_popup.max_length` | `integer`                                   | `25`     | The maximum number of characters before truncating. Leave blank to let GTK automatically handle.                         |
-
-
+|                             | Type                                        | Default  | Description                                                                                                                                               |
+|-----------------------------|---------------------------------------------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `favorites`                 | `string[]`                                  | `[]`     | List of app IDs (or classes) to always show at the start of the launcher.                                                                                 |
+| `show_names`                | `boolean`                                   | `false`  | Whether to show app names on the button label. Names will still show on tooltips when set to false.                                                       |
+| `show_icons`                | `boolean`                                   | `true`   | Whether to show app icons on the button.                                                                                                                  |
+| `icon_size`                 | `integer`                                   | `32`     | Size to render icon at (image icons only).                                                                                                                |
+| `reversed`                  | `boolean`                                   | `false`  | Whether to reverse the order of favorites/items                                                                                                           |
+| `minimize_focused`          | `boolean`                                   | `true`   | Whether to minimize a focused window when its icon is clicked. Only minimizes single windows.                                                             |
+| `truncate.mode`             | `'start'` or `'middle'` or `'end'` or `off` | `end`    | Location of the ellipses and where to truncate text from. Applies to application names when `show_names` is enabled.                                      |
+| `truncate.length`           | `integer`                                   | `null`   | Fixed width (in chars) of the widget. Leave blank to let GTK automatically handle.                                                                        |
+| `truncate.max_length`       | `integer`                                   | `null`   | Maximum number of characters before truncating. Leave blank to let GTK automatically handle.                                                              |
+| `truncate_popup.mode`       | `'start'` or `'middle'` or `'end'` or `off` | `middle` | Location of the ellipses and where to truncate text from. Applies to window names within a group popup.                                                   |
+| `truncate_popup.length`     | `integer`                                   | `null`   | Fixed width (in chars) of the widget. Leave blank to let GTK automatically handle.                                                                        |
+| `truncate_popup.max_length` | `integer`                                   | `25`     | Maximum number of characters before truncating. Leave blank to let GTK automatically handle.                                                              |
+| `page_size`                 | `integer`                                   | `1000`   | Number of items to show on a page. When the number of items is reached, controls appear which can be used to move forward/back through the list of items. |
+| `icons.page_back`           | `string` or [image](images)                 | `󰅁`     | Icon to show for page back button.                                                                                                                        |                                                                                                                                                         
+| `icons.page_forward`        | `string` or [image](images)                 | `󰅂`     | Icon to show for page forward button.                                                                                                                     |                                                                                                                                                         
 <details>
 <summary>JSON</summary>
 
@@ -104,14 +105,17 @@ start:
 
 ## Styling
 
-| Selector                      | Description              |
-|-------------------------------|--------------------------|
-| `.launcher`                   | Launcher widget box      |
-| `.launcher .item`             | App button               |
-| `.launcher .item.open`        | App button (open app)    |
-| `.launcher .item.focused`     | App button (focused app) |
-| `.launcher .item.urgent`      | App button (urgent app)  |
-| `.popup-launcher`             | Popup container          |
-| `.popup-launcher .popup-item` | Window button in popup   |
+| Selector                             | Description               |
+|--------------------------------------|---------------------------|
+| `.launcher`                          | Launcher widget box       |
+| `.launcher .item`                    | App button                |
+| `.launcher .item.open`               | App button (open app)     |
+| `.launcher .item.focused`            | App button (focused app)  |
+| `.launcher .item.urgent`             | App button (urgent app)   |
+| `.launcher .pagination`              | Pagination controls box   |
+| `.launcher .pagination .btn-back`    | Pagination back button    |
+| `.launcher .pagination .btn-forward` | Pagination forward button |
+| `.popup-launcher`                    | Popup container           |
+| `.popup-launcher .popup-item`        | Window button in popup    |
 
 For more information on styling, please see the [styling guide](styling-guide).

--- a/src/modules/custom/label.rs
+++ b/src/modules/custom/label.rs
@@ -4,7 +4,7 @@ use serde::Deserialize;
 
 use super::{CustomWidget, CustomWidgetContext};
 use crate::build;
-use crate::config::{ModuleJustification, ModuleOrientation};
+use crate::config::{ModuleJustification, ModuleOrientation, TruncateMode};
 use crate::dynamic_value::dynamic_string;
 use crate::gtk_helpers::IronbarLabelExt;
 
@@ -44,6 +44,11 @@ pub struct LabelWidget {
     /// **Default**: `left`
     #[serde(default)]
     justify: ModuleJustification,
+
+    /// See [truncate options](module-level-options#truncate-mode).
+    ///
+    /// **Default**: `null`
+    truncate: Option<TruncateMode>,
 }
 
 impl CustomWidget for LabelWidget {
@@ -55,6 +60,10 @@ impl CustomWidget for LabelWidget {
         label.set_angle(self.orientation.to_angle());
         label.set_justify(self.justify.into());
         label.set_use_markup(true);
+
+        if let Some(truncate) = self.truncate {
+            label.truncate(truncate);
+        }
 
         {
             let label = label.clone();

--- a/src/modules/label.rs
+++ b/src/modules/label.rs
@@ -1,4 +1,4 @@
-use crate::config::CommonConfig;
+use crate::config::{CommonConfig, TruncateMode};
 use crate::dynamic_value::dynamic_string;
 use crate::gtk_helpers::IronbarLabelExt;
 use crate::modules::{Module, ModuleInfo, ModuleParts, ModuleUpdateEvent, WidgetContext};
@@ -17,6 +17,12 @@ pub struct LabelModule {
     /// **Required**
     label: String,
 
+    // -- Common --
+    /// See [truncate options](module-level-options#truncate-mode).
+    ///
+    /// **Default**: `null`
+    truncate: Option<TruncateMode>,
+
     /// See [common options](module-level-options#common-options).
     #[serde(flatten)]
     pub common: Option<CommonConfig>,
@@ -26,6 +32,7 @@ impl LabelModule {
     pub(crate) fn new(label: String) -> Self {
         Self {
             label,
+            truncate: None,
             common: Some(CommonConfig::default()),
         }
     }
@@ -57,6 +64,10 @@ impl Module<Label> for LabelModule {
         _info: &ModuleInfo,
     ) -> Result<ModuleParts<Label>> {
         let label = Label::builder().use_markup(true).build();
+
+        if let Some(truncate) = self.truncate {
+            label.truncate(truncate);
+        }
 
         {
             let label = label.clone();

--- a/src/modules/launcher/pagination.rs
+++ b/src/modules/launcher/pagination.rs
@@ -1,0 +1,140 @@
+use crate::gtk_helpers::IronbarGtkExt;
+use crate::image::new_icon_button;
+use gtk::prelude::*;
+use gtk::{Button, IconTheme, Orientation};
+use std::cell::RefCell;
+use std::ops::Deref;
+use std::rc::Rc;
+
+pub struct Pagination {
+    offset: Rc<RefCell<usize>>,
+
+    controls_container: gtk::Box,
+    btn_fwd: Button,
+}
+
+pub struct IconContext<'a> {
+    pub icon_back: &'a str,
+    pub icon_fwd: &'a str,
+    pub icon_size: i32,
+    pub icon_theme: &'a IconTheme,
+}
+
+impl Pagination {
+    pub fn new(
+        container: &gtk::Box,
+        page_size: usize,
+        orientation: Orientation,
+        icon_context: IconContext,
+    ) -> Self {
+        let scroll_box = gtk::Box::new(orientation, 0);
+
+        let scroll_back = new_icon_button(
+            icon_context.icon_back,
+            icon_context.icon_theme,
+            icon_context.icon_size,
+        );
+
+        let scroll_fwd = new_icon_button(
+            icon_context.icon_fwd,
+            icon_context.icon_theme,
+            icon_context.icon_size,
+        );
+
+        scroll_back.set_sensitive(false);
+        scroll_fwd.set_sensitive(false);
+
+        scroll_box.add_class("pagination");
+        scroll_back.add_class("btn-back");
+        scroll_fwd.add_class("btn-forward");
+
+        scroll_box.add(&scroll_back);
+        scroll_box.add(&scroll_fwd);
+        container.add(&scroll_box);
+
+        let offset = Rc::new(RefCell::new(1));
+
+        {
+            let offset = offset.clone();
+            let container = container.clone();
+            let scroll_back = scroll_back.clone();
+
+            scroll_fwd.connect_clicked(move |btn| {
+                let mut offset = offset.borrow_mut();
+                let child_count = container.children().len();
+
+                *offset = std::cmp::min(child_count - 1, *offset + page_size);
+
+                Self::update_page(&container, *offset, page_size);
+
+                if *offset + page_size >= child_count {
+                    btn.set_sensitive(false);
+                }
+
+                scroll_back.set_sensitive(true);
+            });
+        }
+
+        {
+            let offset = offset.clone();
+            let container = container.clone();
+            let scroll_fwd = scroll_fwd.clone();
+
+            scroll_back.connect_clicked(move |btn| {
+                let mut offset = offset.borrow_mut();
+                // avoid using std::cmp::max due to possible overflow
+                if page_size < *offset {
+                    *offset -= page_size;
+                } else {
+                    *offset = 1
+                };
+
+                Self::update_page(&container, *offset, page_size);
+
+                if *offset == 1 || *offset - page_size < 1 {
+                    btn.set_sensitive(false);
+                }
+
+                scroll_fwd.set_sensitive(true);
+            });
+        }
+
+        Self {
+            offset,
+
+            controls_container: scroll_box,
+            btn_fwd: scroll_fwd,
+        }
+    }
+
+    fn update_page(container: &gtk::Box, offset: usize, page_size: usize) {
+        for (i, btn) in container.children().iter().enumerate() {
+            // skip offset buttons
+            if i == 0 {
+                continue;
+            }
+
+            if i >= offset && i < offset + page_size {
+                btn.show();
+            } else {
+                btn.hide();
+            }
+        }
+    }
+
+    pub fn set_sensitive_fwd(&self, sensitive: bool) {
+        self.btn_fwd.set_sensitive(sensitive);
+    }
+
+    pub fn offset(&self) -> usize {
+        *self.offset.borrow()
+    }
+}
+
+impl Deref for Pagination {
+    type Target = gtk::Box;
+
+    fn deref(&self) -> &Self::Target {
+        &self.controls_container
+    }
+}


### PR DESCRIPTION
Adds `page_size` option to launcher module. Adds truncation option to label module/widget.

Resolves #633