### PR TITLE
feat(sysinfo): expose values as ironvars

### DIFF
--- a/docs/Ironvars.md
+++ b/docs/Ironvars.md
@@ -7,3 +7,18 @@ Any UTF-8 string is a valid value.
 Reference values using `#my_variable`. These update as soon as the value changes.
 
 You can set defaults using the `ironvar_defaults` key in your top-level config.
+
+Some modules (such as `sys_info`) expose their values over the Ironvar interface,
+allowing you to build custom interfaces and integrate into scripts.
+These present their values inside read-only namespaces.
+
+Some examples below:
+
+```shell
+ironbar var list
+ironbar var list sysinfo
+ironbar var list sysinfo.disk_percent
+ironbar var get sysinfo.disk_percent./home
+ironbar var get sysinfo.disk_percent.mean
+ironbar var get sysinfo.memory_percent 
+```

--- a/src/clients/mod.rs
+++ b/src/clients/mod.rs
@@ -1,4 +1,4 @@
-use crate::await_sync;
+use crate::{await_sync, Ironbar};
 use color_eyre::Result;
 use std::collections::HashMap;
 use std::path::Path;
@@ -192,7 +192,11 @@ impl Clients {
     #[cfg(feature = "sys_info")]
     pub fn sys_info(&mut self) -> Arc<sysinfo::Client> {
         self.sys_info
-            .get_or_insert_with(|| Arc::new(sysinfo::Client::new()))
+            .get_or_insert_with(|| {
+                let client = Arc::new(sysinfo::Client::new());
+                Ironbar::variable_manager().register_namespace("sysinfo", client.clone());
+                client
+            })
             .clone()
     }
 

--- a/src/dynamic_value/dynamic_bool.rs
+++ b/src/dynamic_value/dynamic_bool.rs
@@ -58,7 +58,7 @@ impl DynamicBool {
                     let variable_manager = Ironbar::variable_manager();
 
                     let variable_name = variable[1..].into(); // remove hash
-                    let mut rx = crate::write_lock!(variable_manager).subscribe(variable_name);
+                    let mut rx = variable_manager.subscribe(variable_name);
 
                     while let Ok(value) = rx.recv().await {
                         let has_value = value.is_some_and(|s| is_truthy(&s));

--- a/src/dynamic_value/dynamic_string.rs
+++ b/src/dynamic_value/dynamic_string.rs
@@ -71,7 +71,7 @@ where
 
                 spawn(async move {
                     let variable_manager = Ironbar::variable_manager();
-                    let mut rx = crate::write_lock!(variable_manager).subscribe(name);
+                    let mut rx = variable_manager.subscribe(name);
 
                     while let Ok(value) = rx.recv().await {
                         if let Some(value) = value {

--- a/src/ipc/commands.rs
+++ b/src/ipc/commands.rs
@@ -52,7 +52,7 @@ pub enum IronvarCommand {
     },
 
     /// Gets the current value of all `ironvar`s.
-    List,
+    List { namespace: Option<Box<str>> },
 }
 
 #[derive(Args, Debug, Serialize, Deserialize)]

--- a/src/ipc/server/ironvar.rs
+++ b/src/ipc/server/ironvar.rs
@@ -1,36 +1,73 @@
 use crate::ipc::commands::IronvarCommand;
 use crate::ipc::Response;
-use crate::{read_lock, write_lock, Ironbar};
+use crate::ironvar::{Namespace, WritableNamespace};
+use crate::Ironbar;
+use std::sync::Arc;
 
 pub fn handle_command(command: IronvarCommand) -> Response {
     match command {
         IronvarCommand::Set { key, value } => {
             let variable_manager = Ironbar::variable_manager();
-            let mut variable_manager = write_lock!(variable_manager);
-            match variable_manager.set(key, value) {
+            match variable_manager.set(&key, value) {
                 Ok(()) => Response::Ok,
                 Err(err) => Response::error(&format!("{err}")),
             }
         }
-        IronvarCommand::Get { key } => {
+        IronvarCommand::Get { mut key } => {
             let variable_manager = Ironbar::variable_manager();
-            let value = read_lock!(variable_manager).get(&key);
+            let mut ns: Arc<dyn Namespace + Sync + Send> = variable_manager;
+
+            if key.contains('.') {
+                for part in key.split('.') {
+                    ns = match ns.get_namespace(part) {
+                        Some(ns) => ns.clone(),
+                        None => {
+                            key = part.into();
+                            break;
+                        }
+                    };
+                }
+            }
+
+            let value = ns.get(&key);
             match value {
                 Some(value) => Response::OkValue { value },
                 None => Response::error("Variable not found"),
             }
         }
-        IronvarCommand::List => {
+        IronvarCommand::List { namespace } => {
             let variable_manager = Ironbar::variable_manager();
+            let mut ns: Arc<dyn Namespace + Sync + Send> = variable_manager;
 
-            let mut values = read_lock!(variable_manager)
+            if let Some(namespace) = namespace {
+                for part in namespace.split('.') {
+                    ns = match ns.get_namespace(part) {
+                        Some(ns) => ns.clone(),
+                        None => return Response::error("Namespace not found"),
+                    };
+                }
+            }
+
+            let mut namespaces = ns
+                .namespaces()
+                .iter()
+                .map(|ns| format!("<{ns}>"))
+                .collect::<Vec<_>>();
+
+            namespaces.sort();
+
+            let mut value = namespaces.join("\n");
+
+            let mut values = ns
                 .get_all()
                 .iter()
-                .map(|(k, v)| format!("{k}: {}", v.get().unwrap_or_default()))
+                .map(|(k, v)| format!("{k}: {v}"))
                 .collect::<Vec<_>>();
 
             values.sort();
-            let value = values.join("\n");
+
+            value.push('\n');
+            value.push_str(&values.join("\n"));
 
             Response::OkValue { value }
         }

--- a/src/modules/sysinfo/mod.rs
+++ b/src/modules/sysinfo/mod.rs
@@ -2,9 +2,10 @@ mod parser;
 mod renderer;
 mod token;
 
+use crate::clients::sysinfo::TokenType;
 use crate::config::{CommonConfig, ModuleOrientation};
 use crate::gtk_helpers::{IronbarGtkExt, IronbarLabelExt};
-use crate::modules::sysinfo::token::{Part, TokenType};
+use crate::modules::sysinfo::token::Part;
 use crate::modules::{Module, ModuleInfo, ModuleParts, ModuleUpdateEvent, WidgetContext};
 use crate::{clients, glib_recv, module_impl, send_async, spawn, try_send};
 use color_eyre::Result;

--- a/src/modules/sysinfo/parser.rs
+++ b/src/modules/sysinfo/parser.rs
@@ -1,64 +1,8 @@
-use crate::clients::sysinfo::{Function, Prefix};
-use crate::modules::sysinfo::token::{Alignment, Formatting, Part, Token, TokenType};
+use crate::clients::sysinfo::{Function, Prefix, TokenType};
+use crate::modules::sysinfo::token::{Alignment, Formatting, Part, Token};
 use color_eyre::{Report, Result};
 use std::iter::Peekable;
 use std::str::{Chars, FromStr};
-
-impl FromStr for TokenType {
-    type Err = Report;
-
-    fn from_str(s: &str) -> Result<Self> {
-        match s {
-            "cpu_frequency" => Ok(Self::CpuFrequency),
-            "cpu_percent" => Ok(Self::CpuPercent),
-
-            "memory_free" => Ok(Self::MemoryFree),
-            "memory_available" => Ok(Self::MemoryAvailable),
-            "memory_total" => Ok(Self::MemoryTotal),
-            "memory_used" => Ok(Self::MemoryUsed),
-            "memory_percent" => Ok(Self::MemoryPercent),
-
-            "swap_free" => Ok(Self::SwapFree),
-            "swap_total" => Ok(Self::SwapTotal),
-            "swap_used" => Ok(Self::SwapUsed),
-            "swap_percent" => Ok(Self::SwapPercent),
-
-            "temp_c" => Ok(Self::TempC),
-            "temp_f" => Ok(Self::TempF),
-
-            "disk_free" => Ok(Self::DiskFree),
-            "disk_total" => Ok(Self::DiskTotal),
-            "disk_used" => Ok(Self::DiskUsed),
-            "disk_percent" => Ok(Self::DiskPercent),
-            "disk_read" => Ok(Self::DiskRead),
-            "disk_write" => Ok(Self::DiskWrite),
-
-            "net_down" => Ok(Self::NetDown),
-            "net_up" => Ok(Self::NetUp),
-
-            "load_average_1" => Ok(Self::LoadAverage1),
-            "load_average_5" => Ok(Self::LoadAverage5),
-            "load_average_15" => Ok(Self::LoadAverage15),
-            "uptime" => Ok(Self::Uptime),
-            _ => Err(Report::msg(format!("invalid token type: '{s}'"))),
-        }
-    }
-}
-
-impl FromStr for Function {
-    type Err = ();
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_lowercase().as_str() {
-            "sum" => Ok(Self::Sum),
-            "min" => Ok(Self::Min),
-            "max" => Ok(Self::Max),
-            "mean" => Ok(Self::Mean),
-            "" => Err(()),
-            _ => Ok(Self::Name(s.to_string())),
-        }
-    }
-}
 
 impl Function {
     pub(crate) fn default_for(token_type: TokenType) -> Self {

--- a/src/modules/sysinfo/renderer.rs
+++ b/src/modules/sysinfo/renderer.rs
@@ -1,7 +1,7 @@
-use super::token::{Alignment, Part, Token, TokenType};
+use super::token::{Alignment, Part, Token};
 use super::Interval;
 use crate::clients;
-use crate::clients::sysinfo::{Value, ValueSet};
+use crate::clients::sysinfo::{TokenType, Value, ValueSet};
 
 pub enum TokenValue {
     Number(f64),

--- a/src/modules/sysinfo/token.rs
+++ b/src/modules/sysinfo/token.rs
@@ -1,39 +1,4 @@
-use crate::clients::sysinfo::{Function, Prefix};
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum TokenType {
-    CpuFrequency,
-    CpuPercent,
-
-    MemoryFree,
-    MemoryAvailable,
-    MemoryTotal,
-    MemoryUsed,
-    MemoryPercent,
-
-    SwapFree,
-    SwapTotal,
-    SwapUsed,
-    SwapPercent,
-
-    TempC,
-    TempF,
-
-    DiskFree,
-    DiskTotal,
-    DiskUsed,
-    DiskPercent,
-    DiskRead,
-    DiskWrite,
-
-    NetDown,
-    NetUp,
-
-    LoadAverage1,
-    LoadAverage5,
-    LoadAverage15,
-    Uptime,
-}
+use crate::clients::sysinfo::{Function, Prefix, TokenType};
 
 #[derive(Debug, Clone)]
 pub struct Token {


### PR DESCRIPTION
This is the alternative idea in #142. Since the overhaul plus this now make it very easy to find which variables are available, I don't think the main suggestion in that issue is needed.

When a `sys_info` module is configured on the bar, a `sysinfo` namespace will appear in the Ironvar list. 

The following are all valid:
```
ironbar var list
ironbar var list sysinfo
ironbar var list sysinfo.disk_percent
ironbar var get sysinfo.disk_percent./home
ironbar var get sysinfo.disk_percent.mean
ironbar var get sysinfo.memory_percent 
```

Resolves #142.