### PR TITLE
Fixed volume module inability to rotate based on bar location

### DIFF
--- a/src/modules/volume.rs
+++ b/src/modules/volume.rs
@@ -1,5 +1,5 @@
 use crate::clients::volume::{self, Event};
-use crate::config::CommonConfig;
+use crate::config::{CommonConfig, ModuleOrientation};
 use crate::gtk_helpers::{IronbarGtkExt, IronbarLabelExt};
 use crate::modules::{
     Module, ModuleInfo, ModuleParts, ModulePopup, ModuleUpdateEvent, PopupButton, WidgetContext,
@@ -35,6 +35,9 @@ pub struct VolumeModule {
     /// See [icons](#icons).
     #[serde(default)]
     icons: Icons,
+
+    #[serde(default)]
+    orientation: ModuleOrientation,
 
     /// See [common options](module-level-options#common-options).
     #[serde(flatten)]
@@ -204,7 +207,7 @@ impl Module<Button> for VolumeModule {
     {
         let button_label = Label::builder()
             .use_markup(true)
-            .angle(info.bar_position.get_angle())
+            .angle(self.orientation.to_angle())
             .build();
 
         let button = Button::new();


### PR DESCRIPTION
Made a discussion #887 which show this problem.

This change based on [clock module](https://github.com/JakeStanger/ironbar/blob/master/src/modules/clock.rs#L132)

Tested horizontal and vertical, all good.
There is still a problem with the behavior of the text and the icon. Currently the icon is not trying to center itself. I can try to fix this in the this PR, but this is my first time using rust so don't at me xD.