### PR TITLE
feat: fully implement orientation/justify options

### DIFF
--- a/docs/Configuration guide.md
+++ b/docs/Configuration guide.md
@@ -351,7 +351,14 @@ For information on the `Script` type, and embedding scripts in strings, see [her
 | Name      | Type     | Default | Description                                                                       |
 |-----------|----------|---------|-----------------------------------------------------------------------------------|
 | `tooltip` | `string` | `null`  | Shows this text on hover. Supports embedding scripts between `{{double braces}}`. |
-| `name`    | `string` | `null`  | Sets the unique widget name, allowing you to style it using `#name`.              |
-| `class`   | `string` | `null`  | Sets one or more CSS classes, allowing you to style it using `.class`.            |
+| `name`    | `string` | `null`  | The unique widget name, allowing you to style it using `#name`.              |
+| `class`   | `string` | `null`  | One or more CSS classes, allowing you to style it using `.class`.            |
 
 For more information on styling, please see the [styling guide](styling-guide).
+
+#### Formatting
+
+| Name          | Type                                                   | Default                    | Description                                                                                                                                     |
+|---------------|--------------------------------------------------------|----------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------|
+| `orientation` | `horizontal` or `vertical` (shorthand: `'h'` or `'v'`) | `horizontal` or `vertical` | The direction in which the widget and its text are laid out. Some modules additionally provide a `direction` option to provide further control. |
+| `justify`     | `left`, `right`, `center`, `fill`                      | `left`                     | The justification (alignment) of the widget text shown on the bar.                                                                              |

--- a/docs/modules/Custom.md
+++ b/docs/modules/Custom.md
@@ -71,12 +71,13 @@ A clickable button, which can run a command when clicked.
 
 > Type `button`
 
-| Name       | Type                                            | Default | Description                                                                                      |
-|------------|-------------------------------------------------|---------|--------------------------------------------------------------------------------------------------|
-| `label`    | [Dynamic String](dynamic-values#dynamic-string) | `null`  | Widget text label. Pango markup and embedded scripts are supported. Ignored if `widgets` is set. |
-| `widgets`  | `(Module or Widget)[]`                          | `[]`    | List of modules/widgets to add to this button.                                                   |
-| `on_click` | `string [command]`                              | `null`  | Command to execute. More on this [below](#commands).                                             |
-| `orientation` | `'horizontal'` or `'vertical'` (shorthand: `'h'` or `'v'`) | `'horizontal'` | Orientation of the button.                                                                                                      |
+| Name          | Type                                                       | Default        | Description                                                                                      |
+|---------------|------------------------------------------------------------|----------------|--------------------------------------------------------------------------------------------------|
+| `label`       | [Dynamic String](dynamic-values#dynamic-string)            | `null`         | Widget text label. Pango markup and embedded scripts are supported. Ignored if `widgets` is set. |
+| `widgets`     | `(Module or Widget)[]`                                     | `[]`           | List of modules/widgets to add to this button.                                                   |
+| `on_click`    | `string [command]`                                         | `null`         | Command to execute. More on this [below](#commands).                                             |
+| `orientation` | `'horizontal'` or `'vertical'` (shorthand: `'h'` or `'v'`) | `'horizontal'` | Orientation of the label text.                                                                   |
+| `justify`     | `'left'`, `'right'`, `'center'`, or `'fill'`               | `'left'`       | Justification (alignment) of the label text.                                                     |
 
 #### Image
 

--- a/docs/modules/Network-Manager.md
+++ b/docs/modules/Network-Manager.md
@@ -17,6 +17,9 @@ Supports wired ethernet, wifi, cellular data and VPN connections among others.
 |-------------|-----------|---------|-------------------------|
 | `icon_size` | `integer` | `24`    | Size to render icon at. |
 
+> [!NOTE]
+> This module does not support module-level [layout options](module-level-options#layout).
+
 <details>
   <summary>JSON</summary>
 

--- a/docs/modules/Notifications.md
+++ b/docs/modules/Notifications.md
@@ -21,6 +21,8 @@ Clicking the widget opens the SwayNC panel.
 | `icons.open_some`   | `string`  | `󱥁`    | Icon to show when the panel is open, with notifications.                                               |
 | `icons.open_dnd`    | `string`  | `󱅮`    | Icon to show when the panel is open, with DnD enabled. Takes higher priority than count-based icons.   |
 
+> [!NOTE]
+> This module does not support module-level [layout options](module-level-options#layout).
 
 <details>
 <summary>JSON</summary>

--- a/src/config/impl.rs
+++ b/src/config/impl.rs
@@ -77,7 +77,7 @@ impl BarPosition {
 
     /// Gets the angle that label text should be displayed at
     /// based on this position.
-    pub const fn get_angle(self) -> f64 {
+    pub const fn angle(self) -> f64 {
         match self {
             Self::Top | Self::Bottom => 0.0,
             Self::Left => 90.0,

--- a/src/config/layout.rs
+++ b/src/config/layout.rs
@@ -1,0 +1,37 @@
+use crate::config::{ModuleJustification, ModuleOrientation};
+use crate::modules::ModuleInfo;
+use serde::Deserialize;
+
+#[derive(Clone, Debug, Deserialize, Default)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct LayoutConfig {
+    /// The orientation to display the widget contents.
+    /// Setting to vertical will rotate text 90 degrees.
+    ///
+    /// **Valid options**: `horizontal`, `vertical`
+    /// <br>
+    /// **Default**: `horizontal`
+    orientation: Option<ModuleOrientation>,
+
+    /// The justification (alignment) of the widget text shown on the bar.
+    ///
+    /// **Valid options**: `left`, `right`, `center`, `fill`
+    /// <br>
+    /// **Default**: `left`
+    #[serde(default)]
+    pub justify: ModuleJustification,
+}
+
+impl LayoutConfig {
+    pub fn orientation(&self, info: &ModuleInfo) -> gtk::Orientation {
+        self.orientation
+            .map(ModuleOrientation::into)
+            .unwrap_or(info.bar_position.orientation())
+    }
+
+    pub fn angle(&self, info: &ModuleInfo) -> f64 {
+        self.orientation
+            .map(ModuleOrientation::to_angle)
+            .unwrap_or(info.bar_position.angle())
+    }
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,5 +1,6 @@
 mod common;
 mod r#impl;
+mod layout;
 mod truncate;
 
 #[cfg(feature = "cairo")]
@@ -46,6 +47,7 @@ use std::collections::HashMap;
 use schemars::JsonSchema;
 
 pub use self::common::{CommonConfig, ModuleJustification, ModuleOrientation, TransitionType};
+pub use self::layout::LayoutConfig;
 pub use self::truncate::{EllipsizeMode, TruncateMode};
 
 #[derive(Debug, Deserialize, Clone)]

--- a/src/image/gtk.rs
+++ b/src/image/gtk.rs
@@ -5,30 +5,54 @@ use gtk::{Button, IconTheme, Image, Label, Orientation};
 use std::ops::Deref;
 
 #[cfg(any(feature = "music", feature = "workspaces", feature = "clipboard"))]
-pub fn new_icon_button(input: &str, icon_theme: &IconTheme, size: i32) -> Button {
-    let button = Button::new();
+#[derive(Debug, Clone)]
+pub struct IconButton {
+    button: Button,
+    label: Label,
+}
 
-    if ImageProvider::is_definitely_image_input(input) {
+#[cfg(any(feature = "music", feature = "workspaces", feature = "clipboard"))]
+impl IconButton {
+    pub fn new(input: &str, icon_theme: &IconTheme, size: i32) -> Self {
+        let button = Button::new();
         let image = Image::new();
-        image.add_class("image");
-        image.add_class("icon");
+        let label = Label::new(Some(input));
 
-        match ImageProvider::parse(input, icon_theme, false, size)
-            .map(|provider| provider.load_into_image(&image))
-        {
-            Some(_) => {
-                button.set_image(Some(&image));
-                button.set_always_show_image(true);
+        if ImageProvider::is_definitely_image_input(input) {
+            image.add_class("image");
+            image.add_class("icon");
+
+            match ImageProvider::parse(input, icon_theme, false, size)
+                .map(|provider| provider.load_into_image(&image))
+            {
+                Some(_) => {
+                    button.set_image(Some(&image));
+                    button.set_always_show_image(true);
+                }
+                None => {
+                    button.set_child(Some(&label));
+                    label.show();
+                }
             }
-            None => {
-                button.set_label(input);
-            }
+        } else {
+            button.set_child(Some(&label));
+            label.show();
         }
-    } else {
-        button.set_label(input);
+
+        Self { button, label }
     }
 
-    button
+    pub fn label(&self) -> &Label {
+        &self.label
+    }
+}
+
+impl Deref for IconButton {
+    type Target = Button;
+
+    fn deref(&self) -> &Self::Target {
+        &self.button
+    }
 }
 
 #[cfg(any(feature = "music", feature = "keyboard"))]
@@ -97,6 +121,10 @@ impl IconLabel {
             label.hide();
             image.hide();
         }
+    }
+
+    pub fn label(&self) -> &Label {
+        &self.label
     }
 }
 

--- a/src/modules/custom/button.rs
+++ b/src/modules/custom/button.rs
@@ -1,9 +1,9 @@
 use gtk::prelude::*;
-use gtk::{Button, Label, Orientation};
+use gtk::{Button, Label};
 use serde::Deserialize;
 
 use super::{CustomWidget, CustomWidgetContext, ExecEvent, WidgetConfig};
-use crate::config::ModuleOrientation;
+use crate::config::LayoutConfig;
 use crate::dynamic_value::dynamic_string;
 use crate::gtk_helpers::IronbarLabelExt;
 use crate::modules::PopupButton;
@@ -37,13 +37,9 @@ pub struct ButtonWidget {
     /// **Default**: `null`
     on_click: Option<String>,
 
-    /// Orientation of the button.
-    ///
-    /// **Valid options**: `horizontal`, `vertical`, `h`, `v`
-    /// <br />
-    /// **Default**: `horizontal`
-    #[serde(default)]
-    orientation: ModuleOrientation,
+    /// See [layout options](module-level-options#layout)
+    #[serde(default, flatten)]
+    layout: LayoutConfig,
 
     /// Modules and widgets to add to this box.
     ///
@@ -59,7 +55,7 @@ impl CustomWidget for ButtonWidget {
         context.popup_buttons.borrow_mut().push(button.clone());
 
         if let Some(widgets) = self.widgets {
-            let container = gtk::Box::new(Orientation::Horizontal, 0);
+            let container = gtk::Box::new(self.layout.orientation(context.info), 0);
 
             for widget in widgets {
                 widget.widget.add_to(&container, &context, widget.common);
@@ -70,7 +66,9 @@ impl CustomWidget for ButtonWidget {
             let label = Label::new(None);
             label.set_use_markup(true);
 
-            label.set_angle(self.orientation.to_angle());
+            if !context.is_popup {
+                label.set_angle(self.layout.angle(context.info));
+            }
 
             button.add(&label);
 

--- a/src/modules/custom/mod.rs
+++ b/src/modules/custom/mod.rs
@@ -91,6 +91,7 @@ struct CustomWidgetContext<'a> {
     info: &'a ModuleInfo<'a>,
     tx: &'a mpsc::Sender<ExecEvent>,
     bar_orientation: Orientation,
+    is_popup: bool,
     icon_theme: &'a IconTheme,
     popup_buttons: Rc<RefCell<Vec<Button>>>,
     module_factory: AnyModuleFactory,
@@ -235,6 +236,7 @@ impl Module<gtk::Box> for CustomModule {
             info,
             tx: &context.controller_tx,
             bar_orientation: orientation,
+            is_popup: false,
             icon_theme: info.icon_theme,
             popup_buttons: popup_buttons.clone(),
             module_factory: BarModuleFactory::new(context.ironbar.clone(), context.popup.clone())
@@ -287,7 +289,8 @@ impl Module<gtk::Box> for CustomModule {
             let custom_context = CustomWidgetContext {
                 info,
                 tx: &tx,
-                bar_orientation: info.bar_position.orientation(),
+                bar_orientation: Orientation::Horizontal,
+                is_popup: true,
                 icon_theme: info.icon_theme,
                 popup_buttons: Rc::new(RefCell::new(vec![])),
                 module_factory: PopupModuleFactory::new(

--- a/src/modules/label.rs
+++ b/src/modules/label.rs
@@ -1,4 +1,4 @@
-use crate::config::{CommonConfig, TruncateMode};
+use crate::config::{CommonConfig, LayoutConfig, TruncateMode};
 use crate::dynamic_value::dynamic_string;
 use crate::gtk_helpers::IronbarLabelExt;
 use crate::modules::{Module, ModuleInfo, ModuleParts, ModuleUpdateEvent, WidgetContext};
@@ -23,6 +23,10 @@ pub struct LabelModule {
     /// **Default**: `null`
     truncate: Option<TruncateMode>,
 
+    /// See [layout options](module-level-options#layout)
+    #[serde(default, flatten)]
+    layout: LayoutConfig,
+
     /// See [common options](module-level-options#common-options).
     #[serde(flatten)]
     pub common: Option<CommonConfig>,
@@ -33,6 +37,7 @@ impl LabelModule {
         Self {
             label,
             truncate: None,
+            layout: LayoutConfig::default(),
             common: Some(CommonConfig::default()),
         }
     }
@@ -61,9 +66,13 @@ impl Module<Label> for LabelModule {
     fn into_widget(
         self,
         context: WidgetContext<Self::SendMessage, Self::ReceiveMessage>,
-        _info: &ModuleInfo,
+        info: &ModuleInfo,
     ) -> Result<ModuleParts<Label>> {
-        let label = Label::builder().use_markup(true).build();
+        let label = Label::builder()
+            .use_markup(true)
+            .angle(self.layout.angle(info))
+            .justify(self.layout.justify.into())
+            .build();
 
         if let Some(truncate) = self.truncate {
             label.truncate(truncate);

--- a/src/modules/launcher/item.rs
+++ b/src/modules/launcher/item.rs
@@ -9,7 +9,7 @@ use crate::{read_lock, try_send};
 use glib::Propagation;
 use gtk::gdk::{BUTTON_MIDDLE, BUTTON_PRIMARY};
 use gtk::prelude::*;
-use gtk::{Button, IconTheme, Image, Label, Orientation};
+use gtk::{Align, Button, IconTheme, Image, Justification, Label, Orientation};
 use indexmap::IndexMap;
 use std::ops::Deref;
 use std::rc::Rc;
@@ -156,6 +156,9 @@ pub struct AppearanceOptions {
     pub show_icons: bool,
     pub icon_size: i32,
     pub truncate: TruncateMode,
+    pub orientation: Orientation,
+    pub angle: f64,
+    pub justify: Justification,
 }
 
 impl ItemButton {
@@ -167,11 +170,13 @@ impl ItemButton {
         tx: &Sender<ModuleUpdateEvent<LauncherUpdate>>,
         controller_tx: &Sender<ItemEvent>,
     ) -> Self {
-        let button = ImageTextButton::new();
+        let button = ImageTextButton::new(appearance.orientation);
 
         if appearance.show_names {
             button.label.set_label(&item.name);
             button.label.truncate(appearance.truncate);
+            button.label.set_angle(appearance.angle);
+            button.label.set_justify(appearance.justify);
         }
 
         if appearance.show_icons {
@@ -329,17 +334,19 @@ pub struct ImageTextButton {
 }
 
 impl ImageTextButton {
-    pub(crate) fn new() -> Self {
+    pub(crate) fn new(orientation: Orientation) -> Self {
         let button = Button::new();
-        let container = gtk::Box::new(Orientation::Horizontal, 0);
+        let container = gtk::Box::new(orientation, 0);
 
         let label = Label::new(None);
         let image = Image::new();
 
-        button.add(&container);
-
         container.add(&image);
         container.add(&label);
+
+        button.add(&container);
+        container.set_halign(Align::Center);
+        container.set_valign(Align::Center);
 
         ImageTextButton {
             button,

--- a/src/modules/launcher/pagination.rs
+++ b/src/modules/launcher/pagination.rs
@@ -1,5 +1,5 @@
 use crate::gtk_helpers::IronbarGtkExt;
-use crate::image::new_icon_button;
+use crate::image::IconButton;
 use gtk::prelude::*;
 use gtk::{Button, IconTheme, Orientation};
 use std::cell::RefCell;
@@ -29,13 +29,13 @@ impl Pagination {
     ) -> Self {
         let scroll_box = gtk::Box::new(orientation, 0);
 
-        let scroll_back = new_icon_button(
+        let scroll_back = IconButton::new(
             icon_context.icon_back,
             icon_context.icon_theme,
             icon_context.icon_size,
         );
 
-        let scroll_fwd = new_icon_button(
+        let scroll_fwd = IconButton::new(
             icon_context.icon_fwd,
             icon_context.icon_theme,
             icon_context.icon_size,
@@ -48,8 +48,8 @@ impl Pagination {
         scroll_back.add_class("btn-back");
         scroll_fwd.add_class("btn-forward");
 
-        scroll_box.add(&scroll_back);
-        scroll_box.add(&scroll_fwd);
+        scroll_box.add(&*scroll_back);
+        scroll_box.add(&*scroll_fwd);
         container.add(&scroll_box);
 
         let offset = Rc::new(RefCell::new(1));
@@ -103,7 +103,7 @@ impl Pagination {
             offset,
 
             controls_container: scroll_box,
-            btn_fwd: scroll_fwd,
+            btn_fwd: scroll_fwd.deref().clone(),
         }
     }
 

--- a/src/modules/music/config.rs
+++ b/src/modules/music/config.rs
@@ -1,4 +1,4 @@
-use crate::config::{CommonConfig, TruncateMode};
+use crate::config::{CommonConfig, LayoutConfig, TruncateMode};
 use dirs::{audio_dir, home_dir};
 use serde::Deserialize;
 use std::path::PathBuf;
@@ -146,6 +146,10 @@ pub struct MusicModule {
     ///
     /// **Default**: `null`
     pub(crate) truncate: Option<TruncateMode>,
+
+    /// See [layout options](module-level-options#layout)
+    #[serde(default, flatten)]
+    pub(crate) layout: LayoutConfig,
 
     /// See [common options](module-level-options#common-options).
     #[serde(flatten)]

--- a/src/modules/music/mod.rs
+++ b/src/modules/music/mod.rs
@@ -17,7 +17,7 @@ use crate::clients::music::{
     self, MusicClient, PlayerState, PlayerUpdate, ProgressTick, Status, Track,
 };
 use crate::gtk_helpers::{IronbarGtkExt, IronbarLabelExt};
-use crate::image::{IconLabel, ImageProvider, new_icon_button};
+use crate::image::{IconButton, IconLabel, ImageProvider};
 use crate::modules::PopupButton;
 use crate::modules::{
     Module, ModuleInfo, ModuleParts, ModulePopup, ModuleUpdateEvent, WidgetContext,
@@ -182,7 +182,7 @@ impl Module<Button> for MusicModule {
         info: &ModuleInfo,
     ) -> Result<ModuleParts<Button>> {
         let button = Button::new();
-        let button_contents = gtk::Box::new(Orientation::Horizontal, 5);
+        let button_contents = gtk::Box::new(self.layout.orientation(info), 5);
         button_contents.add_class("contents");
 
         button.add(&button_contents);
@@ -190,9 +190,16 @@ impl Module<Button> for MusicModule {
         let icon_play = IconLabel::new(&self.icons.play, info.icon_theme, self.icon_size);
         let icon_pause = IconLabel::new(&self.icons.pause, info.icon_theme, self.icon_size);
 
+        icon_play.label().set_angle(self.layout.angle(info));
+        icon_play.label().set_justify(self.layout.justify.into());
+
+        icon_pause.label().set_angle(self.layout.angle(info));
+        icon_pause.label().set_justify(self.layout.justify.into());
+
         let label = Label::builder()
             .use_markup(true)
-            .angle(info.bar_position.get_angle())
+            .angle(self.layout.angle(info))
+            .justify(self.layout.justify.into())
             .build();
 
         if let Some(truncate) = self.truncate {
@@ -297,22 +304,22 @@ impl Module<Button> for MusicModule {
         let controls_box = gtk::Box::new(Orientation::Horizontal, 0);
         controls_box.add_class("controls");
 
-        let btn_prev = new_icon_button(&icons.prev, icon_theme, self.icon_size);
+        let btn_prev = IconButton::new(&icons.prev, icon_theme, self.icon_size);
         btn_prev.add_class("btn-prev");
 
-        let btn_play = new_icon_button(&icons.play, icon_theme, self.icon_size);
+        let btn_play = IconButton::new(&icons.play, icon_theme, self.icon_size);
         btn_play.add_class("btn-play");
 
-        let btn_pause = new_icon_button(&icons.pause, icon_theme, self.icon_size);
+        let btn_pause = IconButton::new(&icons.pause, icon_theme, self.icon_size);
         btn_pause.add_class("btn-pause");
 
-        let btn_next = new_icon_button(&icons.next, icon_theme, self.icon_size);
+        let btn_next = IconButton::new(&icons.next, icon_theme, self.icon_size);
         btn_next.add_class("btn-next");
 
-        controls_box.add(&btn_prev);
-        controls_box.add(&btn_play);
-        controls_box.add(&btn_pause);
-        controls_box.add(&btn_next);
+        controls_box.add(&*btn_prev);
+        controls_box.add(&*btn_play);
+        controls_box.add(&*btn_pause);
+        controls_box.add(&*btn_next);
 
         info_box.add(&controls_box);
 

--- a/src/modules/sway/mode.rs
+++ b/src/modules/sway/mode.rs
@@ -1,4 +1,4 @@
-use crate::config::{CommonConfig, TruncateMode};
+use crate::config::{CommonConfig, LayoutConfig, TruncateMode};
 use crate::gtk_helpers::IronbarLabelExt;
 use crate::modules::{Module, ModuleInfo, ModuleParts, ModuleUpdateEvent, WidgetContext};
 use crate::{await_sync, glib_recv, module_impl, try_send};
@@ -18,6 +18,10 @@ pub struct SwayModeModule {
     ///
     /// **Default**: `null`
     pub truncate: Option<TruncateMode>,
+
+    /// See [layout options](module-level-options#layout)
+    #[serde(default, flatten)]
+    layout: LayoutConfig,
 
     /// See [common options](module-level-options#common-options).
     #[serde(flatten)]
@@ -57,10 +61,13 @@ impl Module<Label> for SwayModeModule {
     fn into_widget(
         self,
         context: WidgetContext<Self::SendMessage, Self::ReceiveMessage>,
-        _info: &ModuleInfo,
+        info: &ModuleInfo,
     ) -> Result<ModuleParts<Label>> {
-        let label = Label::new(None);
-        label.set_use_markup(true);
+        let label = Label::builder()
+            .use_markup(true)
+            .angle(self.layout.angle(info))
+            .justify(self.layout.justify.into())
+            .build();
 
         {
             let label = label.clone();

--- a/src/modules/tray/mod.rs
+++ b/src/modules/tray/mod.rs
@@ -39,6 +39,7 @@ pub struct TrayModule {
     /// **Default**: `horizontal` for horizontal bars, `vertical` for vertical bars
     #[serde(default)]
     direction: Option<ModuleOrientation>,
+
     /// See [common options](module-level-options#common-options).
     #[serde(flatten)]
     pub common: Option<CommonConfig>,

--- a/src/modules/upower.rs
+++ b/src/modules/upower.rs
@@ -8,7 +8,7 @@ use zbus;
 use zbus::fdo::PropertiesProxy;
 
 use crate::clients::upower::BatteryState;
-use crate::config::CommonConfig;
+use crate::config::{CommonConfig, LayoutConfig};
 use crate::gtk_helpers::{IronbarGtkExt, IronbarLabelExt};
 use crate::image::ImageProvider;
 use crate::modules::PopupButton;
@@ -36,6 +36,11 @@ pub struct UpowerModule {
     /// **Default**: `24`
     #[serde(default = "default_icon_size")]
     icon_size: i32,
+
+    // -- Common --
+    /// See [layout options](module-level-options#layout)
+    #[serde(default, flatten)]
+    layout: LayoutConfig,
 
     /// See [common options](module-level-options#common-options).
     #[serde(flatten)]
@@ -172,10 +177,13 @@ impl Module<Button> for UpowerModule {
         let label = Label::builder()
             .label(&self.format)
             .use_markup(true)
+            .angle(self.layout.angle(info))
+            .justify(self.layout.justify.into())
             .build();
+
         label.add_class("label");
 
-        let container = gtk::Box::new(info.bar_position.orientation(), 5);
+        let container = gtk::Box::new(self.layout.orientation(info), 5);
         container.add_class("contents");
 
         let button = Button::new();

--- a/src/modules/volume.rs
+++ b/src/modules/volume.rs
@@ -1,5 +1,5 @@
 use crate::clients::volume::{self, Event};
-use crate::config::CommonConfig;
+use crate::config::{CommonConfig, LayoutConfig};
 use crate::gtk_helpers::{IronbarGtkExt, IronbarLabelExt};
 use crate::modules::{
     Module, ModuleInfo, ModuleParts, ModulePopup, ModuleUpdateEvent, PopupButton, WidgetContext,
@@ -35,6 +35,11 @@ pub struct VolumeModule {
     /// See [icons](#icons).
     #[serde(default)]
     icons: Icons,
+
+    // -- Common --
+    /// See [layout options](module-level-options#layout)
+    #[serde(default, flatten)]
+    layout: LayoutConfig,
 
     /// See [common options](module-level-options#common-options).
     #[serde(flatten)]
@@ -204,7 +209,8 @@ impl Module<Button> for VolumeModule {
     {
         let button_label = Label::builder()
             .use_markup(true)
-            .angle(info.bar_position.get_angle())
+            .angle(self.layout.angle(info))
+            .justify(self.layout.justify.into())
             .build();
 
         let button = Button::new();

--- a/src/modules/workspaces/button.rs
+++ b/src/modules/workspaces/button.rs
@@ -1,6 +1,6 @@
 use super::open_state::OpenState;
 use crate::gtk_helpers::IronbarGtkExt;
-use crate::image::new_icon_button;
+use crate::image::IconButton;
 use crate::modules::workspaces::WorkspaceItemContext;
 use crate::try_send;
 use gtk::Button as GtkButton;
@@ -8,7 +8,7 @@ use gtk::prelude::*;
 
 #[derive(Debug, Clone)]
 pub struct Button {
-    button: GtkButton,
+    button: IconButton,
     workspace_id: i64,
 }
 
@@ -16,7 +16,7 @@ impl Button {
     pub fn new(id: i64, name: &str, open_state: OpenState, context: &WorkspaceItemContext) -> Self {
         let label = context.name_map.get(name).map_or(name, String::as_str);
 
-        let button = new_icon_button(label, &context.icon_theme, context.icon_size);
+        let button = IconButton::new(label, &context.icon_theme, context.icon_size);
         button.set_widget_name(name);
         button.add_class("item");
 

--- a/src/modules/workspaces/mod.rs
+++ b/src/modules/workspaces/mod.rs
@@ -4,7 +4,7 @@ mod open_state;
 
 use self::button::Button;
 use crate::clients::compositor::{Workspace, WorkspaceClient, WorkspaceUpdate};
-use crate::config::CommonConfig;
+use crate::config::{CommonConfig, LayoutConfig};
 use crate::modules::workspaces::button_map::{ButtonMap, Identifier};
 use crate::modules::workspaces::open_state::OpenState;
 use crate::modules::{Module, ModuleInfo, ModuleParts, ModuleUpdateEvent, WidgetContext};
@@ -127,6 +127,11 @@ pub struct WorkspacesModule {
     #[serde(default = "default_icon_size")]
     icon_size: i32,
 
+    // -- Common --
+    /// See [layout options](module-level-options#layout)
+    #[serde(default, flatten)]
+    layout: LayoutConfig,
+
     /// See [common options](module-level-options#common-options).
     #[serde(flatten)]
     pub common: Option<CommonConfig>,
@@ -228,7 +233,7 @@ impl Module<gtk::Box> for WorkspacesModule {
         context: WidgetContext<Self::SendMessage, Self::ReceiveMessage>,
         info: &ModuleInfo,
     ) -> Result<ModuleParts<gtk::Box>> {
-        let container = gtk::Box::new(info.bar_position.orientation(), 0);
+        let container = gtk::Box::new(self.layout.orientation(info), 0);
 
         let mut button_map = ButtonMap::new();
 


### PR DESCRIPTION
Adds `orientation` and `justify` options to all modules and custom widgets where it makes sense to do so.

Any modules without support document this. Widgets fully document the options inline where present for now.

Resolves #296