### PR TITLE
build: decouple `workspace` and `keyboard` modules

### DIFF
--- a/src/clients/mod.rs
+++ b/src/clients/mod.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 #[cfg(feature = "clipboard")]
 pub mod clipboard;
-#[cfg(feature = "workspaces")]
+#[cfg(any(feature = "keyboard", feature = "workspaces"))]
 pub mod compositor;
 #[cfg(feature = "keyboard")]
 pub mod libinput;
@@ -46,7 +46,7 @@ pub struct Clients {
     clipboard: Option<Arc<clipboard::Client>>,
     #[cfg(feature = "keyboard")]
     libinput: HashMap<Box<str>, Arc<libinput::Client>>,
-    #[cfg(any(feature = "keyboard+sway", feature = "keyboard+hyprland"))]
+    #[cfg(feature = "keyboard")]
     keyboard_layout: Option<Arc<dyn compositor::KeyboardLayoutClient>>,
     #[cfg(feature = "cairo")]
     lua: Option<Rc<lua::LuaEngine>>,
@@ -101,7 +101,7 @@ impl Clients {
         Ok(client)
     }
 
-    #[cfg(any(feature = "keyboard+sway", feature = "keyboard+hyprland"))]
+    #[cfg(feature = "keyboard")]
     pub fn keyboard_layout(&mut self) -> ClientResult<dyn compositor::KeyboardLayoutClient> {
         let client = if let Some(keyboard_layout) = &self.keyboard_layout {
             keyboard_layout.clone()

--- a/src/image/gtk.rs
+++ b/src/image/gtk.rs
@@ -4,14 +4,24 @@ use gtk::prelude::*;
 use gtk::{Button, IconTheme, Image, Label, Orientation};
 use std::ops::Deref;
 
-#[cfg(any(feature = "music", feature = "workspaces", feature = "clipboard"))]
 #[derive(Debug, Clone)]
+#[cfg(any(
+    feature = "clipboard",
+    feature = "keyboard",
+    feature = "music",
+    feature = "workspaces"
+))]
 pub struct IconButton {
     button: Button,
     label: Label,
 }
 
-#[cfg(any(feature = "music", feature = "workspaces", feature = "clipboard"))]
+#[cfg(any(
+    feature = "clipboard",
+    feature = "keyboard",
+    feature = "music",
+    feature = "workspaces"
+))]
 impl IconButton {
     pub fn new(input: &str, icon_theme: &IconTheme, size: i32) -> Self {
         let button = Button::new();
@@ -55,7 +65,7 @@ impl Deref for IconButton {
     }
 }
 
-#[cfg(any(feature = "music", feature = "keyboard"))]
+#[cfg(any(feature = "keyboard", feature = "music", feature = "workspaces"))]
 pub struct IconLabel {
     container: gtk::Box,
     label: Label,
@@ -65,7 +75,7 @@ pub struct IconLabel {
     size: i32,
 }
 
-#[cfg(any(feature = "music", feature = "keyboard"))]
+#[cfg(any(feature = "keyboard", feature = "music", feature = "workspaces"))]
 impl IconLabel {
     pub fn new(input: &str, icon_theme: &IconTheme, size: i32) -> Self {
         let container = gtk::Box::new(Orientation::Horizontal, 0);

--- a/src/image/mod.rs
+++ b/src/image/mod.rs
@@ -1,7 +1,12 @@
-#[cfg(any(feature = "music", feature = "workspaces", feature = "clipboard"))]
+#[cfg(any(
+    feature = "clipboard",
+    feature = "keyboard",
+    feature = "music",
+    feature = "workspaces"
+))]
 mod gtk;
 mod provider;
 
-#[cfg(any(feature = "music", feature = "workspaces"))]
+#[cfg(any(feature = "keyboard", feature = "music", feature = "workspaces"))]
 pub use self::gtk::*;
 pub use provider::ImageProvider;


### PR DESCRIPTION
Fixes #862