### PR TITLE
refactor: sort niri workspaces before WorkspaceUpdate::Init

### DIFF
--- a/src/clients/compositor/niri/mod.rs
+++ b/src/clients/compositor/niri/mod.rs
@@ -40,7 +40,9 @@ impl Client {
                         let mut updates: Vec<WorkspaceUpdate> = vec![];
 
                         if first_event {
-                            updates.push(WorkspaceUpdate::Init(new_workspaces.clone()));
+                            let mut new_workspaces = new_workspaces.clone();
+                            new_workspaces.sort_by_key(|w| w.id);
+                            updates.push(WorkspaceUpdate::Init(new_workspaces));
                             first_event = false;
                         } else {
                             // first pass - add/update

--- a/src/clients/compositor/niri/mod.rs
+++ b/src/clients/compositor/niri/mod.rs
@@ -40,6 +40,8 @@ impl Client {
                         let mut updates: Vec<WorkspaceUpdate> = vec![];
 
                         if first_event {
+                            // Niri's WorkspacesChanged event does not initially sort workspaces by ID when first output,
+                            // which makes sort = added meaningless. Therefore, new_workspaces are sorted by ID here to ensure a consistent addition order.
                             let mut new_workspaces = new_workspaces.clone();
                             new_workspaces.sort_by_key(|w| w.id);
                             updates.push(WorkspaceUpdate::Init(new_workspaces));


### PR DESCRIPTION
Niri has a "[Named Workspaces](https://github.com/YaLTeR/niri/wiki/Configuration:-Named-Workspaces)" feature, 
where Workspace's id are assigned based on the order declared in the configuration file. 

However, when Ironbar initializes, the WorkspacesChanged event output by Niri is not sorted by ID. As a result, even when I declare `sort = "added"` in Ironbar's configuration file, the final sorting remains inconsistent. 

To achieve the expected behavior, we simply need to sort new_workspaces by ID before initializing workspaces in Ironbar. This change will not affect the original functionality.

This is my ironbar workspaces configuration
```
[[start]]
type = "workspaces"
sort = "added"
[start.name_map]
NETW = " NETW  "
TERM = " TERM  "
CODE = " CODE  "
CHAT = " CHAT  "
GAME = " GAME  "
6 = " TEMP  "
```
Before change
![grim_20250324_210020](https://github.com/user-attachments/assets/63788beb-26af-4783-9c88-4a812796fdd6)
After change
![grim_20250324_210036](https://github.com/user-attachments/assets/c71cc251-f919-484f-8c7f-449f8c233005)
