### PR TITLE
build: add feature flags for `custom`, `label`, `script` modules

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,14 +15,17 @@ default = [
     "clipboard",
     "clock",
     "config+all",
+    "custom",
     "focused",
     "http",
     "ipc",
     "keyboard+all",
     "launcher",
+    "label",
     "music+all",
     "network_manager",
     "notifications",
+    "script",
     "sys_info",
     "tray",
     "upower",
@@ -54,12 +57,16 @@ clipboard = ["dep:nix"]
 
 clock = ["chrono"]
 
+custom = []
+
 focused = []
 
 keyboard = ["dep:input", "dep:evdev-rs", "dep:libc", "dep:nix"]
 "keyboard+all" = ["keyboard", "keyboard+sway", "keyboard+hyprland"]
 "keyboard+sway" = ["keyboard", "sway"]
 "keyboard+hyprland" = ["keyboard", "hyprland"]
+
+label = []
 
 launcher = []
 
@@ -71,6 +78,8 @@ music = ["dep:regex"]
 network_manager = ["futures-lite", "futures-signals", "zbus"]
 
 notifications = ["zbus"]
+
+script = []
 
 sys_info = ["dep:sysinfo"]
 

--- a/docs/Compiling.md
+++ b/docs/Compiling.md
@@ -85,7 +85,7 @@ cargo build --release --no-default-features \
 > ⚠ Make sure you enable at least one `config` feature otherwise you will not be able to start the bar!
 
 | Feature             | Description                                                                       |
-| ------------------- | --------------------------------------------------------------------------------- |
+|---------------------|-----------------------------------------------------------------------------------|
 | **Core**            |                                                                                   |
 | http                | Enables HTTP features. Currently this includes the ability to load remote images. |
 | ipc                 | Enables the IPC server.                                                           |
@@ -100,11 +100,13 @@ cargo build --release --no-default-features \
 | cairo               | Enables the `cairo` module                                                        |
 | clipboard           | Enables the `clipboard` module.                                                   |
 | clock               | Enables the `clock` module.                                                       |
+| custom              | Enables the `custom` module.                                                      |
 | focused             | Enables the `focused` module.                                                     |
 | keyboard            | Enables the `keyboard` module without keyboard layout support.                    |
 | keyboard+all        | Enables the `keyboard` module with keyboard layout support for all compositors.   |
 | keyboard+sway       | Enables the `keyboard` module with keyboard layout support for Sway.              |
 | keyboard+hyprland   | Enables the `keyboard` module with keyboard layout support for Hyprland.          |
+| label               | Enables the `label` module.                                                       |
 | launcher            | Enables the `launcher` module.                                                    |
 | music+all           | Enables the `music` module with support for all player types.                     |
 | music+mpris         | Enables the `music` module with MPRIS support.                                    |
@@ -112,6 +114,7 @@ cargo build --release --no-default-features \
 | network_manager     | Enables the `network_manager` module.                                             |
 | notifications       | Enables the `notiications` module.                                                |
 | sys_info            | Enables the `sys_info` module.                                                    |
+| script              | Enables the `script` module.                                                      |
 | tray                | Enables the `tray` module.                                                        |
 | upower              | Enables the `upower` module.                                                      |
 | volume              | Enables the `volume` module.                                                      |

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -9,11 +9,13 @@ use crate::modules::cairo::CairoModule;
 use crate::modules::clipboard::ClipboardModule;
 #[cfg(feature = "clock")]
 use crate::modules::clock::ClockModule;
+#[cfg(feature = "custom")]
 use crate::modules::custom::CustomModule;
 #[cfg(feature = "focused")]
 use crate::modules::focused::FocusedModule;
 #[cfg(feature = "keyboard")]
 use crate::modules::keyboard::KeyboardModule;
+#[cfg(feature = "label")]
 use crate::modules::label::LabelModule;
 #[cfg(feature = "launcher")]
 use crate::modules::launcher::LauncherModule;
@@ -23,6 +25,7 @@ use crate::modules::music::MusicModule;
 use crate::modules::networkmanager::NetworkManagerModule;
 #[cfg(feature = "notifications")]
 use crate::modules::notifications::NotificationsModule;
+#[cfg(feature = "script")]
 use crate::modules::script::ScriptModule;
 #[cfg(feature = "sway")]
 use crate::modules::sway::mode::SwayModeModule;
@@ -60,11 +63,13 @@ pub enum ModuleConfig {
     Clipboard(Box<ClipboardModule>),
     #[cfg(feature = "clock")]
     Clock(Box<ClockModule>),
+    #[cfg(feature = "custom")]
     Custom(Box<CustomModule>),
     #[cfg(feature = "focused")]
     Focused(Box<FocusedModule>),
     #[cfg(feature = "keyboard")]
     Keyboard(Box<KeyboardModule>),
+    #[cfg(feature = "label")]
     Label(Box<LabelModule>),
     #[cfg(feature = "launcher")]
     Launcher(Box<LauncherModule>),
@@ -74,6 +79,7 @@ pub enum ModuleConfig {
     NetworkManager(Box<NetworkManagerModule>),
     #[cfg(feature = "notifications")]
     Notifications(Box<NotificationsModule>),
+    #[cfg(feature = "script")]
     Script(Box<ScriptModule>),
     #[cfg(feature = "sys_info")]
     SysInfo(Box<SysInfoModule>),
@@ -109,11 +115,13 @@ impl ModuleConfig {
             Self::Clipboard(module) => create!(module),
             #[cfg(feature = "clock")]
             Self::Clock(module) => create!(module),
+            #[cfg(feature = "custom")]
             Self::Custom(module) => create!(module),
             #[cfg(feature = "focused")]
             Self::Focused(module) => create!(module),
             #[cfg(feature = "keyboard")]
             Self::Keyboard(module) => create!(module),
+            #[cfg(feature = "label")]
             Self::Label(module) => create!(module),
             #[cfg(feature = "launcher")]
             Self::Launcher(module) => create!(module),
@@ -123,6 +131,7 @@ impl ModuleConfig {
             Self::NetworkManager(module) => create!(module),
             #[cfg(feature = "notifications")]
             Self::Notifications(module) => create!(module),
+            #[cfg(feature = "script")]
             Self::Script(module) => create!(module),
             #[cfg(feature = "sys_info")]
             Self::SysInfo(module) => create!(module),
@@ -340,9 +349,12 @@ impl Default for BarConfig {
             start_hidden: None,
             autohide: None,
             icon_theme: None,
+            #[cfg(feature = "label")]
             start: Some(vec![ModuleConfig::Label(
                 LabelModule::new("ℹ️ Using default config".to_string()).into(),
             )]),
+            #[cfg(not(feature = "label"))]
+            start: None,
             center,
             end,
             anchor_to_edges: default_true(),

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -29,11 +29,15 @@ pub mod clipboard;
 /// with second-level precision and a calendar.
 #[cfg(feature = "clock")]
 pub mod clock;
+
+#[cfg(feature = "custom")]
 pub mod custom;
 #[cfg(feature = "focused")]
 pub mod focused;
 #[cfg(feature = "keyboard")]
 pub mod keyboard;
+
+#[cfg(feature = "label")]
 pub mod label;
 #[cfg(feature = "launcher")]
 pub mod launcher;
@@ -43,6 +47,8 @@ pub mod music;
 pub mod networkmanager;
 #[cfg(feature = "notifications")]
 pub mod notifications;
+
+#[cfg(feature = "script")]
 pub mod script;
 #[cfg(feature = "sway")]
 pub mod sway;


### PR DESCRIPTION
All modules can now be toggled at compile time by feature flags