### PR TITLE
fix(notifications): gtk4 port

### DIFF
--- a/src/modules/notifications.rs
+++ b/src/modules/notifications.rs
@@ -184,7 +184,7 @@ impl Module<Overlay> for NotificationsModule {
     {
         let overlay = Overlay::new();
         let button = Button::with_label(&self.icons.closed_none);
-        overlay.add(&button);
+        overlay.add_overlay(&button);
 
         let label = Label::builder()
             .label("0")
@@ -194,8 +194,8 @@ impl Module<Overlay> for NotificationsModule {
 
         if self.show_count {
             label.add_class("count");
+            label.set_can_target(false);
             overlay.add_overlay(&label);
-            overlay.set_overlay_pass_through(&label, true);
         }
 
         let ctx = context.controller_tx.clone();


### PR DESCRIPTION
Replaced the overlay_pass_through call following the migration notes doc: https://docs.gtk.org/gtk4/migrating-3to4.html#adapt-to-changes-in-gtkoverlay-api

Now it successfully compiles and on the first glance seems to be behaving the same as the gtk3 version, so hopefully a little bit of help towards #112 :crossed_fingers: 