### PR TITLE
Fix compilation for many feature combinations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,11 +30,11 @@ default = [
     "tray",
     "upower",
     "volume",
-    "workspaces+all"
+    "workspaces+all",
 ]
 
 cli = ["dep:clap", "ipc"]
-ipc = ["dep:serde_json"]
+ipc = ["dep:serde_json", "dep:clap"]
 
 http = ["dep:reqwest"]
 
@@ -61,7 +61,7 @@ custom = []
 
 focused = []
 
-keyboard = ["dep:colpetto", "dep:evdev-rs", "dep:rustix"]
+keyboard = ["dep:colpetto", "dep:evdev-rs", "dep:rustix", "futures-lite"]
 "keyboard+all" = ["keyboard", "keyboard+sway", "keyboard+hyprland"]
 "keyboard+sway" = ["keyboard", "sway"]
 "keyboard+hyprland" = ["keyboard", "hyprland"]
@@ -81,7 +81,7 @@ notifications = ["zbus"]
 
 script = []
 
-sys_info = ["dep:sysinfo"]
+sys_info = ["dep:sysinfo", "ipc"]
 
 tray = ["system-tray"]
 
@@ -93,9 +93,11 @@ workspaces = ["futures-lite"]
 "workspaces+all" = ["workspaces", "workspaces+sway", "workspaces+hyprland", "workspaces+niri"]
 "workspaces+sway" = ["workspaces", "sway"]
 "workspaces+hyprland" = ["workspaces", "hyprland"]
-"workspaces+niri" = ["workspaces"]
+"workspaces+niri" = ["workspaces", "niri"]
 
 sway = ["swayipc-async", "futures-lite"]
+
+niri = ["dep:serde_json"]
 
 schema = ["dep:schemars"]
 

--- a/src/clients/compositor/sway.rs
+++ b/src/clients/compositor/sway.rs
@@ -1,11 +1,11 @@
-use super::{KeyboardLayoutClient, KeyboardLayoutUpdate, Visibility, Workspace, WorkspaceUpdate};
+use super::{Visibility, Workspace, WorkspaceUpdate};
 use crate::clients::sway::Client;
 use crate::{await_sync, error, send, spawn};
 use color_eyre::Report;
 use swayipc_async::{InputChange, InputEvent, Node, WorkspaceChange, WorkspaceEvent};
 use tokio::sync::broadcast::{Receiver, channel};
 
-#[cfg(feature = "workspaces")]
+#[cfg(feature = "workspaces+sway")]
 impl super::WorkspaceClient for Client {
     fn focus(&self, id: i64) {
         let client = self.connection().clone();
@@ -153,6 +153,10 @@ impl From<WorkspaceEvent> for WorkspaceUpdate {
     }
 }
 
+#[cfg(feature = "keyboard+sway")]
+use super::{KeyboardLayoutClient, KeyboardLayoutUpdate};
+
+#[cfg(feature = "keyboard+sway")]
 impl KeyboardLayoutClient for Client {
     fn set_next_active(&self) {
         let client = self.connection().clone();
@@ -210,6 +214,7 @@ impl KeyboardLayoutClient for Client {
     }
 }
 
+#[cfg(feature = "keyboard+sway")]
 impl TryFrom<InputEvent> for KeyboardLayoutUpdate {
     type Error = ();
 

--- a/src/clients/mod.rs
+++ b/src/clients/mod.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 #[cfg(feature = "clipboard")]
 pub mod clipboard;
-#[cfg(any(feature = "keyboard", feature = "workspaces"))]
+#[cfg(any(feature = "keyboard", feature = "workspaces", feature = "hyprland"))]
 pub mod compositor;
 #[cfg(feature = "keyboard")]
 pub mod libinput;

--- a/src/clients/music/mod.rs
+++ b/src/clients/music/mod.rs
@@ -70,13 +70,17 @@ pub trait MusicClient: Debug + Send + Sync {
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub enum ClientType {
+    #[cfg(feature = "music+mpd")]
     Mpd { host: String, music_dir: PathBuf },
+    #[cfg(feature = "music+mpris")]
     Mpris,
 }
 
 pub fn create_client(client_type: ClientType) -> Arc<dyn MusicClient> {
     match client_type {
+        #[cfg(feature = "music+mpd")]
         ClientType::Mpd { host, music_dir } => Arc::new(mpd::Client::new(host, music_dir)),
+        #[cfg(feature = "music+mpris")]
         ClientType::Mpris => Arc::new(mpris::Client::new()),
     }
 }

--- a/src/image/gtk.rs
+++ b/src/image/gtk.rs
@@ -9,7 +9,10 @@ use std::ops::Deref;
     feature = "clipboard",
     feature = "keyboard",
     feature = "music",
-    feature = "workspaces"
+    feature = "workspaces",
+    feature = "cairo",
+    feature = "clipboard",
+    feature = "launcher",
 ))]
 pub struct IconButton {
     button: Button,
@@ -20,7 +23,10 @@ pub struct IconButton {
     feature = "clipboard",
     feature = "keyboard",
     feature = "music",
-    feature = "workspaces"
+    feature = "workspaces",
+    feature = "cairo",
+    feature = "clipboard",
+    feature = "launcher",
 ))]
 impl IconButton {
     pub fn new(input: &str, icon_theme: &IconTheme, size: i32) -> Self {
@@ -57,6 +63,15 @@ impl IconButton {
     }
 }
 
+#[cfg(any(
+    feature = "clipboard",
+    feature = "keyboard",
+    feature = "music",
+    feature = "workspaces",
+    feature = "cairo",
+    feature = "clipboard",
+    feature = "launcher",
+))]
 impl Deref for IconButton {
     type Target = Button;
 
@@ -138,6 +153,7 @@ impl IconLabel {
     }
 }
 
+#[cfg(any(feature = "keyboard", feature = "music", feature = "workspaces"))]
 impl Deref for IconLabel {
     type Target = gtk::Box;
 

--- a/src/image/mod.rs
+++ b/src/image/mod.rs
@@ -2,11 +2,18 @@
     feature = "clipboard",
     feature = "keyboard",
     feature = "music",
-    feature = "workspaces"
+    feature = "workspaces",
+    feature = "launcher",
 ))]
 mod gtk;
 mod provider;
 
-#[cfg(any(feature = "keyboard", feature = "music", feature = "workspaces"))]
+#[cfg(any(
+    feature = "clipboard",
+    feature = "keyboard",
+    feature = "music",
+    feature = "workspaces",
+    feature = "launcher",
+))]
 pub use self::gtk::*;
 pub use provider::ImageProvider;

--- a/src/modules/music/config.rs
+++ b/src/modules/music/config.rs
@@ -74,13 +74,23 @@ impl Default for Icons {
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub enum PlayerType {
+    #[cfg(feature = "music+mpd")]
     Mpd,
+    #[cfg(feature = "music+mpris")]
     Mpris,
 }
 
 impl Default for PlayerType {
     fn default() -> Self {
-        Self::Mpris
+        cfg_if::cfg_if! {
+            if #[cfg(feature = "music+mpd")] {
+                Self::Mpd
+            } else if #[cfg(feature = "music+mpris")] {
+                Self::Mpris
+            } else {
+                compile_error!("No player type feature enabled")
+            }
+        }
     }
 }
 

--- a/src/modules/music/mod.rs
+++ b/src/modules/music/mod.rs
@@ -76,7 +76,9 @@ fn get_client(
     music_dir: PathBuf,
 ) -> Arc<dyn MusicClient> {
     let client_type = match player_type {
+        #[cfg(feature = "music+mpd")]
         PlayerType::Mpd => music::ClientType::Mpd { host, music_dir },
+        #[cfg(feature = "music+mpris")]
         PlayerType::Mpris => music::ClientType::Mpris,
     };
 


### PR DESCRIPTION
This is a extended fix for the issue I pointed out in https://github.com/JakeStanger/ironbar/pull/855#issuecomment-2632505664 and tracked by the issue #862 which was not fully fixed by #910. This also fixes many issues with other features.

I use the following shell script to test the changes:

```sh
#!/bin/sh

check() {
    echo "Checking $1"
    cargo check --no-default-features --features "$@" 1>/dev/null 2>/dev/null
}

cargo check \
&& check config+json \
&& check config+yaml \
&& check config+toml \
&& check config+ron \
&& check config+all \
&& check config+yaml,keyboard+all \
&& check config+yaml,workspaces+all \
&& check config+yaml,workspaces+all,keyboard+all \
&& check config+yaml,workspaces+sway,keyboard+hyprland \
&& check config+yaml,workspaces+hyprland,keyboard+sway \
&& check config+yaml,workspaces+hyprland,keyboard+sway \
&& check config+yaml,workspaces,hyprland,keyboard,sway \
&& check config+yaml,workspaces \
&& check config+yaml,keyboard \
&& check config+yaml,sway \
&& check config+yaml,niri \
&& check config+yaml,hyprland \
&& check config+yaml,music+mpris \
&& check config+yaml,music+mpd \
&& check config+yaml,cli \
&& check config+yaml,cairo \
&& check config+yaml,clipboard \
&& check config+yaml,clock \
&& check config+yaml,config+all \
&& check config+yaml,custom \
&& check config+yaml,focused \
&& check config+yaml,http \
&& check config+yaml,ipc \
&& check config+yaml,keyboard+all \
&& check config+yaml,launcher \
&& check config+yaml,label \
&& check config+yaml,music+all \
&& check config+yaml,network_manager \
&& check config+yaml,notifications \
&& check config+yaml,script \
&& check config+yaml,sys_info \
&& check config+yaml,tray \
&& check config+yaml,upower \
&& check config+yaml,volume \
&& check config+yaml,workspaces+all \
&& check config+yaml,schema \
&& echo "Check passed" \
|| echo "Check failed"

# Fails to compile, cannot get a default for PlayerType
# && check config+yaml,music \

# universal-config fails to compile
# && check ''
# && check config+corn \
```

Some notes:
- I added `config+yaml` as a feature to all checks, because without it `universal-config` fails to compile (but that is fixed by https://github.com/JakeStanger/universal-config-rs/pull/8).
- I was careful with features like `keyboard+sway` and `workspace+hyprland` to only enable the implementation of the module for the given compositor when those specific features are enable, and not when only `keyboard` and `sway` are both enabled, for example.
- I replace cfg checks like `#[cfg(any(feature = "keyboard+hyprland", feature = "workspaces+hyprland"))]` with a feature for each compositor (like `#[cfg(feature = "hyprland")` in that case). This will scale better when more compositor aware modules are added (like my `bindmode+sway` and `bindmode+hyprland` in the near future).