### PR TITLE
fix(wayland): panicking on compositors without protocol support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,13 +5,13 @@ on:
   push:
     branches: [ "master" ]
     paths:
-      - 'src'
+      - 'src/**/*'
       - 'Cargo.*'
       - 'build.rs'
   pull_request:
     branches: [ "master" ]
     paths:
-      - 'src'
+      - 'src/**/*'
       - 'Cargo.*'
       - 'build.rs'
       - '.github/workflows/build.yml'

--- a/.github/workflows/schema.yml
+++ b/.github/workflows/schema.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches: [ "master" ]
     paths:
-      - 'src'
+      - 'src/**/*'
       - 'Cargo.*'
       - 'build.rs'
       - '.github/workflows/schema.yml'

--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ "master" ]
     paths:
-      - 'docs'
+      - 'docs/**/*'
 
 jobs:
   build:

--- a/src/clients/wayland/wl_seat.rs
+++ b/src/clients/wayland/wl_seat.rs
@@ -1,6 +1,6 @@
 use super::Environment;
 use smithay_client_toolkit::seat::{Capability, SeatHandler, SeatState};
-use tracing::debug;
+use tracing::{debug, error};
 use wayland_client::protocol::wl_seat::WlSeat;
 use wayland_client::{Connection, QueueHandle};
 
@@ -37,7 +37,11 @@ impl SeatHandler for Environment {
         {
             debug!("Adding new data control device");
             // create the data device here for this seat
-            let data_control_device_manager = &self.data_control_device_manager_state;
+            let Some(data_control_device_manager) = &self.data_control_device_manager_state else {
+                error!("data_control_device_manager not available, cannot copy");
+                return;
+            };
+
             let data_control_device = data_control_device_manager.get_data_device(qh, &seat);
             self.data_control_devices
                 .push(super::DataControlDeviceEntry {

--- a/src/clients/wayland/wlr_data_control/mod.rs
+++ b/src/clients/wayland/wlr_data_control/mod.rs
@@ -147,6 +147,11 @@ impl Environment {
     pub fn copy_to_clipboard(&mut self, item: ClipboardItem) {
         debug!("Copying item to clipboard: {item:?}");
 
+        let Some(data_control_device_manager) = &self.data_control_device_manager_state else {
+            error!("data_control_device_manager not available, cannot copy");
+            return;
+        };
+
         let seat = self.default_seat();
         let Some(device) = self
             .data_control_devices
@@ -156,8 +161,7 @@ impl Environment {
             return;
         };
 
-        let source = self
-            .data_control_device_manager_state
+        let source = data_control_device_manager
             .create_copy_paste_source(&self.queue_handle, [&item.mime_type, INTERNAL_MIME_TYPE]);
 
         source.set_selection(&device.device);


### PR DESCRIPTION
This allows Ironbar to run on a wider range of compositors, where support for the `wlr_foreign_toplevel` protocol used by focused/launcher, and the `wlr_data_control_device` protocol used by clipboard is missing.