### PR TITLE
fix(music): Fix hours not being displayed in track duration

### DIFF
--- a/src/modules/music/mod.rs
+++ b/src/modules/music/mod.rs
@@ -40,13 +40,18 @@ pub enum PlayerCommand {
 }
 
 /// Formats a duration given in seconds
-/// in hh:mm format
+/// in hh:mm:ss format
 fn format_time(duration: Duration) -> String {
     let time = duration.as_secs();
+    let hours = time / (60 * 60);
     let minutes = (time / 60) % 60;
     let seconds = time % 60;
 
-    format!("{minutes:0>2}:{seconds:0>2}")
+    if hours > 0 {
+        format!("{hours}:{minutes:0>2}:{seconds:0>2}")
+    } else {
+        format!("{minutes:0>2}:{seconds:0>2}")
+    }
 }
 
 /// Extracts the formatting tokens from a formatting string


### PR DESCRIPTION
Closes #967

![20250512_10h48m20s_grim](https://github.com/user-attachments/assets/0a1df0c7-529f-431f-8e46-f4955b7a06a2)

As for the UI I think the convention is to:
- Not pad it with zeros
- Only display hours if track duration is longer than 60 minutes

For instance, that's how SoundCloud displays duration.