### PR TITLE
fix(clock): reset selected calendar date on each popup open

### DIFF
--- a/src/modules/clock.rs
+++ b/src/modules/clock.rs
@@ -1,6 +1,6 @@
 use std::env;
 
-use chrono::{DateTime, Local, Locale};
+use chrono::{DateTime, Datelike, Local, Locale};
 use color_eyre::Result;
 use gtk::prelude::*;
 use gtk::{Align, Button, Calendar, Label, Orientation};
@@ -176,6 +176,13 @@ impl Module<Button> for ClockModule {
         context.subscribe().recv_glib(move |date| {
             let date_string = format!("{}", date.format_localized(&format, locale));
             clock.set_label(&date_string);
+        });
+
+        // Reset selected date on each popup open
+        context.popup.window.connect_show(move |_| {
+            let date = Local::now();
+            calendar.select_day(date.day());
+            calendar.select_month(date.month() - 1, date.year() as u32);
         });
 
         container.show_all();


### PR DESCRIPTION
Closes #931
Additional context #931

So I chose to go with using selections. I think markings have a few cons:
- Would need to somehow style it because by default it's just bold text, much less noticeable than selections. I checked [adw-gtk3](https://github.com/lassekongo83/adw-gtk3) and couldn't find a selector for the marked day.
- Would need to also hook into `connect_{next,prev}_{month,year}` to unmark currently marked day, because marks persist across month/year changes (only a *day* is marked, and not a *date*).
- Would still need to do something with selections, because them being there without user having actually selected anything might be confusing. E.g. boot PC on Monday, open calendar on Wednesday, Monday is selected for some reason.

All in all it's a lot less code and problems with selections and there's currently hardly a non-contrived use case for them so I think changing their semantics is fine.

I'm not sure if it's needed to also reset the date at midnight. It's hard to imagine a scenario where it's either a significant win or a significant loss for UX.