### PR TITLE
feat(keyboard): allow layout map to use markup

### DIFF
--- a/src/image/gtk.rs
+++ b/src/image/gtk.rs
@@ -69,6 +69,10 @@ impl IconButton {
     pub fn label(&self) -> &Label {
         &self.label
     }
+
+    pub fn set_label(&self, input: &str) {
+        self.label.set_label_escaped(input);
+    }
 }
 
 #[cfg(any(


### PR DESCRIPTION
Still working on my text only ironbar and was not able to escape the keyboard layout.

This commit allows to escape the keyboard layout:

![layout_escaped](https://github.com/user-attachments/assets/b228b612-f7e7-4558-98fe-3b2206cf9767)

Using this config:

```toml
[end.icons.layout_map]
German = "<span color='#0091e5'>LAYOUT</span>\n<span color='#0091e5'>[</span>de<span color='#0091e5'>]</span>"
```