### PR TITLE
fix(nix): default HM module `config` option to `null`

### DIFF
--- a/nix/module.nix
+++ b/nix/module.nix
@@ -36,7 +36,7 @@ in {
 
     config = mkOption {
       type = jsonFormat.type;
-      default = {};
+      default = null;
       description = "The config to pass to ironbar.";
     };
 
@@ -53,7 +53,7 @@ in {
     ];
 
     xdg.configFile = {
-      "ironbar/config.json" = mkIf (cfg.config != "") {
+      "ironbar/config.json" = mkIf (cfg.config != null) {
         onChange = "${getExe cfg.package} reload";
         source = jsonFormat.generate "ironbar-config" cfg.config;
       };


### PR DESCRIPTION
This makes it more semantically approachable IMO.

I would expect this behavior:
- Default value is `null`
- Config is created if the value is not `null`
- Option unset (i.e. the default) => no config created
- This matches a lot of other HM modules

Currently it's this behavior (makes little sense to me):
- Default value is `{}`
- Config is created if the values is not `""`
- Need to explicitly set the option to `""` in order to not create a config

This would be a breaking change for:
- People who were setting the option to `""` to achieve not creating a config
- (Contrived) People who needed some sort of a nonsense config like `{}`