### PR TITLE
feat(volume): Add `truncate` option for `volume` popup

### DIFF
--- a/docs/modules/Volume.md
+++ b/docs/modules/Volume.md
@@ -1,6 +1,7 @@
 Displays the current volume level.
 Clicking on the widget opens a volume mixer, which allows you to change the device output level,
 the default playback device, and control application volume levels individually.
+Use `truncate` option to control the display of application titles in the volume mixer.
 
 This requires PulseAudio to function (`pipewire-pulse` is supported).
 
@@ -10,14 +11,18 @@ This requires PulseAudio to function (`pipewire-pulse` is supported).
 
 > Type: `volume`
 
-| Name                  | Type     | Default                | Description                                                                                                    |
-|-----------------------|----------|------------------------|----------------------------------------------------------------------------------------------------------------|
-| `format`              | `string` | `{icon} {percentage}%` | Format string to use for the widget button label.                                                              |
-| `max_volume`          | `float`  | `100`                  | Maximum value to allow volume sliders to reach. Pulse supports values > 100 but this may result in distortion. |
-| `icons.volume_high`   | `string` | `󰕾`                   | Icon to show for high volume levels.                                                                           |
-| `icons.volume_medium` | `string` | `󰖀`                   | Icon to show for medium volume levels.                                                                         |
-| `icons.volume_low`    | `string` | `󰕿`                   | Icon to show for low volume levels.                                                                            |
-| `icons.muted`         | `string` | `󰝟`                   | Icon to show for muted outputs.                                                                                |
+| Name                  | Type                                                 | Default                | Description                                                                                                    |
+|-----------------------|------------------------------------------------------|------------------------|----------------------------------------------------------------------------------------------------------------|
+| `format`              | `string`                                             | `{icon} {percentage}%` | Format string to use for the widget button label.                                                              |
+| `max_volume`          | `float`                                              | `100`                  | Maximum value to allow volume sliders to reach. Pulse supports values > 100 but this may result in distortion. |
+| `icons.volume_high`   | `string`                                             | `󰕾`                    | Icon to show for high volume levels.                                                                           |
+| `icons.volume_medium` | `string`                                             | `󰖀`                    | Icon to show for medium volume levels.                                                                         |
+| `icons.volume_low`    | `string`                                             | `󰕿`                    | Icon to show for low volume levels.                                                                            |
+| `icons.muted`         | `string`                                             | `󰝟`                    | Icon to show for muted outputs.                                                                                |
+| `truncate`            | `'start'` or `'middle'` or `'end'` or `off` or `Map` | `off`                  | The location of the ellipses and where to truncate text from. Leave null to avoid truncating. Use the long-hand `Map` version if specifying a length. |
+| `truncate.mode`       | `'start'` or `'middle'` or `'end'` or `off`          | `off`                  | The location of the ellipses and where to truncate text from. Leave null to avoid truncating.                                                         |
+| `truncate.length`     | `integer`                                            | `null`                 | The fixed width (in chars) of the widget. Leave blank to let GTK automatically handle.                                                                |
+| `truncate.max_length` | `integer`                                            | `null`                 | The maximum number of characters before truncating. Leave blank to let GTK automatically handle.                                                      |
 
 <details>
 <summary>JSON</summary>
@@ -29,6 +34,7 @@ This requires PulseAudio to function (`pipewire-pulse` is supported).
       "type": "volume",
       "format": "{icon} {percentage}%",
       "max_volume": 100,
+      "truncate": "middle",
       "icons": {
         "volume_high": "󰕾",
         "volume_medium": "󰖀",
@@ -51,6 +57,7 @@ This requires PulseAudio to function (`pipewire-pulse` is supported).
 type = "volume"
 format = "{icon} {percentage}%"
 max_volume = 100
+truncate = "middle"
 
 [end.icons]
 volume_high = "󰕾"
@@ -69,6 +76,7 @@ end:
   - type: "volume"
     format: "{icon} {percentage}%"
     max_volume: 100
+    truncate: "middle"
     icons:
       volume_high: "󰕾"
       volume_medium: "󰖀"
@@ -88,6 +96,7 @@ end:
       type = "volume"
       format = "{icon} {percentage}%"
       max_volume = 100
+      truncate = "end"
       icons.volume_high = "󰕾"
       icons.volume_medium = "󰖀"
       icons.volume_low = "󰕿"

--- a/src/modules/volume.rs
+++ b/src/modules/volume.rs
@@ -1,6 +1,6 @@
 use crate::channels::{AsyncSenderExt, BroadcastReceiverExt};
 use crate::clients::volume::{self, Event};
-use crate::config::{CommonConfig, LayoutConfig};
+use crate::config::{CommonConfig, LayoutConfig, TruncateMode};
 use crate::gtk_helpers::{IronbarGtkExt, IronbarLabelExt};
 use crate::modules::{
     Module, ModuleInfo, ModuleParts, ModulePopup, ModuleUpdateEvent, PopupButton, WidgetContext,
@@ -39,6 +39,11 @@ pub struct VolumeModule {
     icons: Icons,
 
     // -- Common --
+    /// See [truncate options](module-level-options#truncate-mode).
+    ///
+    /// **Default**: `null`
+    pub(crate) truncate: Option<TruncateMode>,
+
     /// See [layout options](module-level-options#layout)
     #[serde(default, flatten)]
     layout: LayoutConfig,
@@ -402,6 +407,10 @@ impl Module<Button> for VolumeModule {
 
                         let label = Label::new(Some(&info.name));
                         label.add_class("title");
+
+                        if let Some(truncate) = self.truncate {
+                            label.truncate(truncate);
+                        };
 
                         let slider = Scale::builder().sensitive(info.can_set_volume).build();
                         slider.set_range(0.0, self.max_volume);


### PR DESCRIPTION
Part of #1011

As noted in the issue, I'm still down for marquee/rotation effect, but truncation would be an easy start.