### PR TITLE
UPower: Round battery percent to whole number

### DIFF
--- a/src/modules/upower.rs
+++ b/src/modules/upower.rs
@@ -216,7 +216,7 @@ impl Module<Button> for UpowerModule {
             .unwrap_or_default();
 
             let format = format
-                .replace("{percentage}", &properties.percentage.to_string())
+                .replace("{percentage}", &properties.percentage.round().to_string())
                 .replace("{time_remaining}", &time_remaining)
                 .replace("{state}", battery_state_to_string(state));
 


### PR DESCRIPTION
Was getting stuff like this on my ThinkPad T480:

![image](https://github.com/user-attachments/assets/68083e49-4386-42ad-9944-d4ca99229da4)

I think it was because it has two batteries. Anyway, this PR makes sure the number is rounded