### PR TITLE
fix: regression caused by #1089

### DIFF
--- a/src/modules/menu/ui.rs
+++ b/src/modules/menu/ui.rs
@@ -104,9 +104,7 @@ where
                         let file_name = file_name.clone();
                         let command = command.clone();
 
-                        glib::spawn_future_local(async move {
-                            open_program(&file_name, &command).await
-                        });
+                        spawn(async move { open_program(&file_name, &command).await });
 
                         sub_menu.hide();
                         tx.send_spawn(ModuleUpdateEvent::ClosePopup);


### PR DESCRIPTION
This resolves an issue caused by a previous fix which broke launching applications with the `launcher` and `menu` modules.

Resolves #1020 (again)