### PR TITLE
fix: pass the correct GDK Monitor

### DIFF
--- a/src/clients/wayland/mod.rs
+++ b/src/clients/wayland/mod.rs
@@ -24,7 +24,7 @@ use tokio::sync::{broadcast, mpsc};
 use tracing::{debug, error, trace};
 use wayland_client::globals::registry_queue_init;
 use wayland_client::{Connection, QueueHandle};
-pub use wl_output::{OutputEvent, OutputEventType};
+pub use wl_output::{OutputEvent, OutputEventType, list::get as output_list_get};
 
 cfg_if! {
     if #[cfg(any(feature = "focused", feature = "launcher"))] {

--- a/src/clients/wayland/wl_output.rs
+++ b/src/clients/wayland/wl_output.rs
@@ -6,6 +6,8 @@ use tracing::{debug, error};
 use wayland_client::protocol::wl_output::WlOutput;
 use wayland_client::{Connection, QueueHandle};
 
+pub mod list;
+
 #[derive(Debug, Clone)]
 pub struct OutputEvent {
     pub output: OutputInfo,

--- a/src/clients/wayland/wl_output/list.rs
+++ b/src/clients/wayland/wl_output/list.rs
@@ -1,0 +1,84 @@
+//! Obtain the vector of Outputs
+
+use std::error::Error;
+
+use smithay_client_toolkit::{
+    delegate_output, delegate_registry,
+    output::{OutputHandler, OutputInfo, OutputState},
+    registry::{ProvidesRegistryState, RegistryState},
+    registry_handlers,
+};
+use wayland_client::{globals::registry_queue_init, protocol::wl_output::{self}, Connection, QueueHandle};
+
+pub fn get() -> Result<Vec<OutputInfo>, Box<dyn Error>> {
+    let conn = Connection::connect_to_env()?;
+
+    let (globals, mut event_queue) = registry_queue_init(&conn).unwrap();
+    let qh = event_queue.handle();
+
+    let registry_state = RegistryState::new(&globals);
+
+    let output_delegate = OutputState::new(&globals, &qh);
+
+    let mut list_outputs = ListOutputs { registry_state, output_state: output_delegate };
+
+    event_queue.roundtrip(&mut list_outputs)?;
+
+    let mut outputs = vec![];
+    for output in list_outputs.output_state.outputs() {
+        outputs.push(list_outputs
+                .output_state
+                .info(&output)
+                .ok_or_else(|| "output has no info".to_owned())?);
+    }
+
+    return Ok(outputs);
+}
+
+struct ListOutputs {
+    registry_state: RegistryState,
+    output_state: OutputState,
+}
+
+impl OutputHandler for ListOutputs {
+    fn output_state(&mut self) -> &mut OutputState {
+        &mut self.output_state
+    }
+
+    fn new_output(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _output: wl_output::WlOutput,
+    ) {
+    }
+
+    fn update_output(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _output: wl_output::WlOutput,
+    ) {
+    }
+
+    fn output_destroyed(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _output: wl_output::WlOutput,
+    ) {
+    }
+}
+
+delegate_output!(ListOutputs);
+delegate_registry!(ListOutputs);
+
+impl ProvidesRegistryState for ListOutputs {
+    fn registry(&mut self) -> &mut RegistryState {
+        &mut self.registry_state
+    }
+
+    registry_handlers! {
+        OutputState,
+    }
+}

--- a/src/ipc/server/mod.rs
+++ b/src/ipc/server/mod.rs
@@ -147,8 +147,8 @@ impl Ipc {
 
                 ironbar.reload_config();
 
-                for output in outputs {
-                    match crate::load_output_bars(ironbar, application, &output) {
+                for (idx, output ) in outputs.iter().enumerate() {
+                    match crate::load_output_bars(ironbar, application, output, idx as i32) {
                         Ok(mut bars) => ironbar.bars.borrow_mut().append(&mut bars),
                         Err(err) => error!("{err:?}"),
                     }


### PR DESCRIPTION
On dual monitor scaling configuration, seems that obtaining the Monitor position using GDK yields the wrong results - both bars end up on the same monitor.

We can use `monitor(idx: i32)` to obtain the correct one. However the Rust bindings for GdkMonitor are not complete enough to let us call the function that provides the connector name, therefore we need to query smithay to get the vector and from the vector guess the index.

Fixes #1042.