### PR TITLE
feat: smooth scrolling speed option

### DIFF
--- a/docs/Configuration guide.md
+++ b/docs/Configuration guide.md
@@ -327,15 +327,16 @@ For information on the `Script` type, and embedding scripts in strings, see [her
 
 #### Events
 
-| Name              | Type               | Default | Description                                                |
-|-------------------|--------------------|---------|------------------------------------------------------------|
-| `on_click_left`   | `Script [oneshot]` | `null`  | Runs the script when the module is left clicked.           |
-| `on_click_middle` | `Script [oneshot]` | `null`  | Runs the script when the module is middle clicked.         |
-| `on_click_right`  | `Script [oneshot]` | `null`  | Runs the script when the module is right clicked.          |
-| `on_scroll_up`    | `Script [oneshot]` | `null`  | Runs the script when the module is scroll up on.           |
-| `on_scroll_down`  | `Script [oneshot]` | `null`  | Runs the script when the module is scrolled down on.       |
-| `on_mouse_enter`  | `Script [oneshot]` | `null`  | Runs the script when the module is hovered over.           |
-| `on_mouse_exit`   | `Script [oneshot]` | `null`  | Runs the script when the module is no longer hovered over. |
+| Name                  | Type               | Default | Description                                                                                      |
+|-----------------------|--------------------|---------|--------------------------------------------------------------------------------------------------|
+| `on_click_left`       | `Script [oneshot]` | `null`  | Runs the script when the module is left clicked.                                                 |
+| `on_click_middle`     | `Script [oneshot]` | `null`  | Runs the script when the module is middle clicked.                                               |
+| `on_click_right`      | `Script [oneshot]` | `null`  | Runs the script when the module is right clicked.                                                |
+| `on_scroll_up`        | `Script [oneshot]` | `null`  | Runs the script when the module is scroll up on.                                                 |
+| `on_scroll_down`      | `Script [oneshot]` | `null`  | Runs the script when the module is scrolled down on.                                             |
+| `on_mouse_enter`      | `Script [oneshot]` | `null`  | Runs the script when the module is hovered over.                                                 |
+| `on_mouse_exit`       | `Script [oneshot]` | `null`  | Runs the script when the module is no longer hovered over.                                       |
+| `smooth_scroll_speed` | `float`            | `1.0`   | Speed multiplier `0.0` - `10.0` which controls scroll up/down events triggered using a trackpad. |
 
 #### Visibility
 

--- a/test-configs/custom-scroll.corn
+++ b/test-configs/custom-scroll.corn
@@ -1,0 +1,13 @@
+{
+    center = [
+        {
+            type = "custom"
+            bar = [{
+                type = "label"
+                label="val: #value"
+                on_scroll_up = "target/debug/ironbar var set value \$((`target/debug/ironbar var get value` + 1))"
+                on_scroll_down = "target/debug/ironbar var set value \$((`target/debug/ironbar var get value` - 1))"
+            }]
+        }
+    ]
+}


### PR DESCRIPTION
Adds a new common option `smooth_scroll_speed` which controls the speed at which scroll events are emitted when scrolling on a trackpad, and using `on_scroll_up` and `on_scroll_down`.

Resolves #775 