### PR TITLE
feat(menu, notifications, upower): use ironbar image system

### DIFF
--- a/src/image/gtk.rs
+++ b/src/image/gtk.rs
@@ -218,3 +218,48 @@ impl Deref for IconLabel {
         &self.container
     }
 }
+
+#[derive(Clone, Debug)]
+#[cfg(feature = "music")]
+pub struct IconPrefixedLabel {
+    label: Label,
+    container: gtk::Box,
+}
+
+#[cfg(feature = "music")]
+impl IconPrefixedLabel {
+    pub fn new(icon_input: &str, label: Option<&str>, image_provider: &image::Provider) -> Self {
+        let container = gtk::Box::new(Orientation::Horizontal, 5);
+
+        let icon = IconLabel::new(icon_input, 24, image_provider);
+
+        let mut builder = Label::builder().use_markup(true);
+
+        if let Some(label) = label {
+            builder = builder.label(label);
+        }
+
+        let label = builder.build();
+
+        icon.add_class("icon-box");
+        label.add_class("label");
+
+        container.add(&*icon);
+        container.add(&label);
+
+        Self { label, container }
+    }
+
+    pub fn label(&self) -> &Label {
+        &self.label
+    }
+}
+
+#[cfg(feature = "music")]
+impl Deref for IconPrefixedLabel {
+    type Target = gtk::Box;
+
+    fn deref(&self) -> &Self::Target {
+        &self.container
+    }
+}

--- a/src/image/gtk.rs
+++ b/src/image/gtk.rs
@@ -12,6 +12,7 @@ use std::ops::Deref;
     feature = "keyboard",
     feature = "launcher",
     feature = "music",
+    feature = "notifications",
     feature = "workspaces",
 ))]
 pub struct IconButton {
@@ -26,6 +27,7 @@ pub struct IconButton {
     feature = "keyboard",
     feature = "launcher",
     feature = "music",
+    feature = "notifications",
     feature = "workspaces",
 ))]
 impl IconButton {
@@ -73,6 +75,7 @@ impl IconButton {
     feature = "clipboard",
     feature = "keyboard",
     feature = "music",
+    feature = "notifications",
     feature = "workspaces",
     feature = "cairo",
     feature = "clipboard",
@@ -89,8 +92,10 @@ impl Deref for IconButton {
 #[cfg(any(
     feature = "bluetooth",
     feature = "keyboard",
+    feature = "menu",
     feature = "music",
-    feature = "workspaces"
+    feature = "workspaces",
+    feature = "upower"
 ))]
 pub struct IconLabel {
     provider: image::Provider,
@@ -104,8 +109,10 @@ pub struct IconLabel {
 #[cfg(any(
     feature = "bluetooth",
     feature = "keyboard",
+    feature = "menu",
     feature = "music",
-    feature = "workspaces"
+    feature = "workspaces",
+    feature = "upower"
 ))]
 impl IconLabel {
     pub fn new(input: &str, size: i32, image_provider: &image::Provider) -> Self {
@@ -199,8 +206,10 @@ impl IconLabel {
 #[cfg(any(
     feature = "bluetooth",
     feature = "keyboard",
+    feature = "menu",
     feature = "music",
-    feature = "workspaces"
+    feature = "workspaces",
+    feature = "upower"
 ))]
 impl Deref for IconLabel {
     type Target = gtk::Box;

--- a/src/image/mod.rs
+++ b/src/image/mod.rs
@@ -3,8 +3,11 @@
     feature = "clipboard",
     feature = "keyboard",
     feature = "launcher",
+    feature = "menu",
     feature = "music",
+    feature = "notifications",
     feature = "workspaces",
+    feature = "upower"
 ))]
 mod gtk;
 mod provider;
@@ -14,8 +17,11 @@ mod provider;
     feature = "clipboard",
     feature = "keyboard",
     feature = "launcher",
+    feature = "menu",
     feature = "music",
+    feature = "notifications",
     feature = "workspaces",
+    feature = "upower"
 ))]
 pub use self::gtk::*;
 pub use provider::{Provider, create_and_load_surface};

--- a/src/modules/menu/ui.rs
+++ b/src/modules/menu/ui.rs
@@ -3,6 +3,7 @@ use crate::channels::AsyncSenderExt;
 use crate::config::TruncateMode;
 use crate::desktop_file::open_program;
 use crate::gtk_helpers::{IronbarGtkExt, IronbarLabelExt};
+use crate::image::IconLabel;
 use crate::modules::ModuleUpdateEvent;
 use crate::script::Script;
 use crate::{image, spawn};
@@ -32,16 +33,9 @@ where
     label.truncate(truncate_mode);
 
     if let Some(icon_name) = entry.icon() {
-        let gtk_image = gtk::Image::new();
-        gtk_image.set_halign(Align::Start);
-        button_container.add(&gtk_image);
-
-        let image_provider = image_provider.clone();
-        glib::spawn_future_local(async move {
-            image_provider
-                .load_into_image_silent(&icon_name, 16, true, &gtk_image)
-                .await;
-        });
+        let image = IconLabel::new(&icon_name, 16, image_provider);
+        image.set_halign(Align::Start);
+        button_container.add(&*image);
     }
 
     button_container.add(&label);

--- a/src/modules/music/mod.rs
+++ b/src/modules/music/mod.rs
@@ -20,12 +20,12 @@ use crate::clients::music::{
     self, MusicClient, PlayerState, PlayerUpdate, ProgressTick, Status, Track,
 };
 use crate::gtk_helpers::{IronbarGtkExt, IronbarLabelExt};
-use crate::image::{IconButton, IconLabel};
+use crate::image::{IconButton, IconLabel, IconPrefixedLabel};
 use crate::modules::PopupButton;
 use crate::modules::{
     Module, ModuleInfo, ModuleParts, ModulePopup, ModuleUpdateEvent, WidgetContext,
 };
-use crate::{image, module_impl, spawn};
+use crate::{module_impl, spawn};
 
 mod config;
 
@@ -283,26 +283,26 @@ impl Module<Button> for MusicModule {
 
         let title_label = IconPrefixedLabel::new(&icons.track, None, &image_provider);
         if let Some(truncate) = self.truncate_popup_title {
-            title_label.label.truncate(truncate);
+            title_label.label().truncate(truncate);
         }
 
         let album_label = IconPrefixedLabel::new(&icons.album, None, &image_provider);
         if let Some(truncate) = self.truncate_popup_album {
-            album_label.label.truncate(truncate);
+            album_label.label().truncate(truncate);
         }
 
         let artist_label = IconPrefixedLabel::new(&icons.artist, None, &image_provider);
         if let Some(truncate) = self.truncate_popup_artist {
-            artist_label.label.truncate(truncate);
+            artist_label.label().truncate(truncate);
         }
 
-        title_label.container.add_class("title");
-        album_label.container.add_class("album");
-        artist_label.container.add_class("artist");
+        title_label.add_class("title");
+        album_label.add_class("album");
+        artist_label.add_class("artist");
 
-        info_box.add(&title_label.container);
-        info_box.add(&album_label.container);
-        info_box.add(&artist_label.container);
+        info_box.add(&*title_label);
+        info_box.add(&*album_label);
+        info_box.add(&*artist_label);
 
         let controls_box = gtk::Box::new(Orientation::Horizontal, 0);
         controls_box.add_class("controls");
@@ -526,11 +526,11 @@ impl Module<Button> for MusicModule {
 fn update_popup_metadata_label(text: Option<String>, label: &IconPrefixedLabel) {
     match text {
         Some(value) => {
-            label.label.set_label_escaped(&value);
-            label.container.show_all();
+            label.label().set_label_escaped(&value);
+            label.show_all();
         }
         None => {
-            label.container.hide();
+            label.hide();
         }
     }
 }
@@ -560,34 +560,4 @@ fn get_token_value(song: &Track, token: &str) -> String {
         _ => Some(token.to_string()),
     }
     .unwrap_or_default()
-}
-
-#[derive(Clone, Debug)]
-struct IconPrefixedLabel {
-    label: Label,
-    container: gtk::Box,
-}
-
-impl IconPrefixedLabel {
-    fn new(icon_input: &str, label: Option<&str>, image_provider: &image::Provider) -> Self {
-        let container = gtk::Box::new(Orientation::Horizontal, 5);
-
-        let icon = IconLabel::new(icon_input, 24, image_provider);
-
-        let mut builder = Label::builder().use_markup(true);
-
-        if let Some(label) = label {
-            builder = builder.label(label);
-        }
-
-        let label = builder.build();
-
-        icon.add_class("icon-box");
-        label.add_class("label");
-
-        container.add(&*icon);
-        container.add(&label);
-
-        Self { label, container }
-    }
 }

--- a/src/modules/notifications.rs
+++ b/src/modules/notifications.rs
@@ -2,10 +2,11 @@ use crate::channels::{AsyncSenderExt, BroadcastReceiverExt};
 use crate::clients::swaync;
 use crate::config::CommonConfig;
 use crate::gtk_helpers::IronbarGtkExt;
+use crate::image::IconButton;
 use crate::modules::{Module, ModuleInfo, ModuleParts, WidgetContext};
 use crate::{module_impl, spawn};
 use gtk::prelude::*;
-use gtk::{Align, Button, Label, Overlay};
+use gtk::{Align, Label, Overlay};
 use serde::Deserialize;
 use tokio::sync::mpsc::Receiver;
 use tracing::error;
@@ -184,8 +185,12 @@ impl Module<Overlay> for NotificationsModule {
         <Self as Module<Overlay>>::SendMessage: Clone,
     {
         let overlay = Overlay::new();
-        let button = Button::with_label(&self.icons.closed_none);
-        overlay.add(&button);
+        let button = IconButton::new(
+            &self.icons.closed_none,
+            16,
+            context.ironbar.image_provider(),
+        );
+        overlay.add(&*button);
 
         let label = Label::builder()
             .label("0")


### PR DESCRIPTION
These modules should now offer more control over the icons, allowing images and textual icons, and ensuring they work with the overrides system.

Resolves #511 