### PR TITLE
feat(ipc): commands for controlling css class names

### DIFF
--- a/docs/Controlling Ironbar.md
+++ b/docs/Controlling Ironbar.md
@@ -86,19 +86,6 @@ Responds with `ok`.
 }
 ```
 
-### `load_css`
-
-Loads an additional CSS stylesheet, with hot-reloading enabled.
-
-Responds with `ok` if the stylesheet exists, otherwise `error`.
-
-```json
-{
-  "command": "load_css",
-  "path": "/path/to/style.css"
-}
-```
-
 ### `var`
 
 Subcommand for controlling Ironvars.
@@ -300,6 +287,67 @@ Sets whether the bar reserves an exclusive zone.
   "command": "bar",
   "subcommand": "set_exclusive",
   "exclusive": true
+}
+```
+
+### `style`
+
+#### `load_css`
+
+Loads an additional CSS stylesheet, with hot-reloading enabled.
+
+Responds with `ok` if the stylesheet exists, otherwise `error`.
+
+```json
+{
+  "command": "load_css",
+  "path": "/path/to/style.css"
+}
+```
+
+#### `add_class`
+
+Adds a CSS class to the top-level widget for all modules matching `module_name`.
+If the module also has a popup, the class is added to the top container.
+
+Response with `ok` if at least one module is found, otherwise `error`.
+
+```json
+{
+  "command": "add_class",
+  "module_name": "clock",
+  "name": "night"
+}
+```
+
+#### `remove_class`
+
+Removes a CSS class from the top-level widget for all modules matching `module_name`.
+If the module also has a popup, the class is added to the top container.
+
+Response with `ok` if at least one module is found, otherwise `error`.
+
+```json
+{
+  "command": "remove_class",
+  "module_name": "clock",
+  "name": "night"
+}
+```
+
+#### `toggle_class`
+
+Toggles a CSS class on the top-level widget for all modules matching `module_name`, 
+removing it if already present and adding it otherwise.
+If the module also has a popup, the class is added to the top container.
+
+Response with `ok` if at least one module is found, otherwise `error`.
+
+```json
+{
+  "command": "toggle_class",
+  "module_name": "clock",
+  "name": "night"
 }
 ```
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -44,7 +44,7 @@ use crate::modules::volume::VolumeModule;
 #[cfg(feature = "workspaces")]
 use crate::modules::workspaces::WorkspacesModule;
 
-use crate::modules::{AnyModuleFactory, ModuleFactory, ModuleInfo};
+use crate::modules::{AnyModuleFactory, ModuleFactory, ModuleInfo, ModuleRef};
 use cfg_if::cfg_if;
 use color_eyre::Result;
 #[cfg(feature = "schema")]
@@ -108,7 +108,7 @@ impl ModuleConfig {
         module_factory: &AnyModuleFactory,
         container: &gtk::Box,
         info: &ModuleInfo,
-    ) -> Result<()> {
+    ) -> Result<ModuleRef> {
         macro_rules! create {
             ($module:expr) => {
                 module_factory.create(*$module, container, info)

--- a/src/ipc/commands.rs
+++ b/src/ipc/commands.rs
@@ -16,19 +16,16 @@ pub enum Command {
     /// Reload the config.
     Reload,
 
-    /// Load an additional CSS stylesheet.
-    /// The sheet is automatically hot-reloaded.
-    LoadCss {
-        /// The path to the sheet.
-        path: PathBuf,
-    },
-
     /// Get and set reactive Ironvar values.
     #[command(subcommand)]
     Var(IronvarCommand),
 
     /// Interact with a specific bar.
     Bar(BarCommand),
+
+    /// Load stylesheets and dynamically add/remove classes
+    #[command(subcommand)]
+    Style(StyleCommand),
 }
 
 #[derive(Subcommand, Debug, Serialize, Deserialize)]
@@ -128,5 +125,43 @@ pub enum BarCommandType {
             action = ArgAction::Set,
         )]
         exclusive: bool,
+    },
+}
+
+#[derive(Subcommand, Debug, Serialize, Deserialize)]
+#[serde(tag = "subcommand", rename_all = "snake_case")]
+pub enum StyleCommand {
+    /// Load an additional CSS stylesheet.
+    /// The sheet is automatically hot-reloaded.
+    LoadCss {
+        /// The path to the sheet.
+        path: PathBuf,
+    },
+
+    /// Add a CSS class `name` to all modules
+    /// matching `module_name`.
+    AddClass {
+        /// The name of the module to target.
+        module_name: String,
+        /// The class name to add.
+        name: String,
+    },
+
+    /// Remove a CSS class `name` from all modules
+    /// matching `module_name`.
+    RemoveClass {
+        /// The name of the module to target.
+        module_name: String,
+        /// The class name to remove.
+        name: String,
+    },
+
+    /// Toggle a CSS class `name` on all modules
+    /// matching `module_name`.
+    ToggleClass {
+        /// The name of the module to target.
+        module_name: String,
+        /// The class name to toggle.
+        name: String,
     },
 }

--- a/src/ipc/server/bar.rs
+++ b/src/ipc/server/bar.rs
@@ -49,9 +49,9 @@ pub fn handle_command(command: &BarCommand, ironbar: &Rc<Ironbar>) -> Response {
             }
         })
         .reduce(|acc, rsp| match (acc, rsp) {
-            // If all responses are Ok, return one Ok. We assume we'll never mix Ok and OkValue.
+            // If all responses are `Ok`, return one `Ok`. We assume we'll never mix `Ok` and `OkValue`.
             (Response::Ok, _) => Response::Ok,
-            // Two or more OkValues create a multi:
+            // Two or more `OkValue`s create a multi:
             (Response::OkValue { value: v1 }, Response::OkValue { value: v2 }) => Response::Multi {
                 values: vec![v1, v2],
             },

--- a/src/ipc/server/mod.rs
+++ b/src/ipc/server/mod.rs
@@ -1,5 +1,6 @@
 mod bar;
 mod ironvar;
+mod style;
 
 use std::fs;
 use std::path::Path;
@@ -16,7 +17,6 @@ use tracing::{debug, error, info, trace, warn};
 use super::Ipc;
 use crate::channels::{AsyncSenderExt, MpscReceiverExt};
 use crate::ipc::{Command, Response};
-use crate::style::load_css;
 use crate::{Ironbar, spawn};
 
 impl Ipc {
@@ -156,16 +156,9 @@ impl Ipc {
 
                 Response::Ok
             }
-            Command::LoadCss { path } => {
-                if path.exists() {
-                    load_css(path, application.clone());
-                    Response::Ok
-                } else {
-                    Response::error("File not found")
-                }
-            }
             Command::Var(cmd) => ironvar::handle_command(cmd),
             Command::Bar(cmd) => bar::handle_command(&cmd, ironbar),
+            Command::Style(cmd) => style::handle_command(cmd, ironbar, application),
         }
     }
 


### PR DESCRIPTION
Three new commands have been added, under a new `style` subcommand:

- `add_class`
- `remove_class`
- `toggle_class`

These extend the scripting capabilities, allowing styles to be externally controlled. This potentially pairs well with the extended ironvar system, for example by watching `ironbar var list sysinfo.cpu_percent` a class could be added when reaching a defined threshold.

BREAKING CHANGE: The `load-css` command has been moved to the `style` subcommand (ie `ironbar style load-css`).

Resolves #516