### PR TITLE
refactor(music): remove regex dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1966,7 +1966,6 @@ dependencies = [
  "mpd-utils",
  "mpris",
  "notify",
- "regex",
  "reqwest",
  "rustix 1.0.8",
  "schemars",
@@ -2864,18 +2863,6 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.39",
  "syn 2.0.99",
-]
-
-[[package]]
-name = "regex"
-version = "1.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,7 @@ launcher = []
 
 menu = []
 
-music = ["dep:regex"]
+music = []
 "music+all" = ["music", "music+mpris", "music+mpd"]
 "music+mpris" = ["music", "mpris"]
 "music+mpd" = ["music", "mpd-utils"]
@@ -176,9 +176,6 @@ evdev-rs = { version = "0.6.2", optional = true }
 # music
 mpd-utils = { version = "0.2.1", optional = true }
 mpris = { version = "2.0.1", optional = true }
-regex = { version = "1.11.2", default-features = false, features = [
-    "std",
-], optional = true }
 
 # network_manager
 futures-signals = { version = "0.3.34", optional = true }


### PR DESCRIPTION
Rather than some complicated regex based token replace system...we can just perform a bunch of `.replace` calls on the string for the token literals...

Groundbreaking.

Fixes #1139