### PR TITLE
fix: `on_click` events not working on button widgets

### DIFF
--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -596,7 +596,7 @@ pub fn wrap_widget<W: IsA<Widget>>(
     container.add_events(EventMask::SCROLL_MASK | EventMask::SMOOTH_SCROLL_MASK);
     container.add(&revealer);
 
-    common.install_events(&container, &revealer);
+    common.install_events(widget, &container, &revealer);
 
     container
 }


### PR DESCRIPTION
For button-type modules, although it was possible to disable the popup, it was not possible to attach an `on_click` listener. This is now fixed

Fixes #906
Fixes #1112