### PR TITLE
doc(fix): bluetooth type not interpreted as string in corn config example

### DIFF
--- a/docs/modules/Bluetooth.md
+++ b/docs/modules/Bluetooth.md
@@ -168,7 +168,7 @@ end:
 {
   end = [
     {
-      type = bluetooth
+      type = "bluetooth"
       icon_size = 32
       format.not_found = ""
       format.disabled = " Off"


### PR DESCRIPTION
Not adding `"` around the type was causing a config error :
```
2025-09-09T09:51:08.523989Z ERROR ironbar: 345: Failed to load config:   --> 55:12
   |
55 |     type = bluetooth
   |            ^---
   |
   = expected object, array, boolean, null, string, integer, float, or input
```
Hope this will help someone !