### PR TITLE
fix(flake): correct apps.default to point to ironbar

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -72,12 +72,14 @@
     });
 
     # Apps
-    apps = forAllSystems (pkgs: {
+    apps = forAllSystems (pkgs: let
       ironbar = {
         type = "app";
         program = pkgs.lib.getExe self.packages.${pkgs.hostPlatform.system}.ironbar;
       };
-      default = self.apps.ironbar;
+    in {
+      inherit ironbar;
+      default = ironbar;
     });
 
     homeManagerModules.default = import ./nix/module.nix self;


### PR DESCRIPTION
Fixes a broken reference in the apps output of the flake.
Previously, `default = self.apps.ironbar;` caused evaluation errors when running `nix run .` because self.apps.ironbar didn’t exist yet inside its own definition.