### PR TITLE
feat(inhibit): Add inhibit module

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,6 +94,7 @@ jobs:
         feature:
           - http
           - ipc
+          - inhibit
           - cli
           - config+all
           - config+json

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ default = [
     "custom",
     "focused",
     "http",
+    "inhibit",
     "ipc",
     "keyboard+all",
     "launcher",
@@ -76,6 +77,8 @@ clock = ["chrono"]
 custom = []
 
 focused = []
+
+inhibit = ["chrono"]
 
 keyboard = ["dep:colpetto", "dep:evdev-rs", "dep:rustix", "futures-lite"]
 "keyboard+all" = ["keyboard", "keyboard+sway", "keyboard+hyprland"]
@@ -165,9 +168,6 @@ reqwest = { version = "0.12.24", default-features = false, features = ["default-
 lua-src = { version = "548.1.2", optional = true }
 mlua = { version = "0.11.4", optional = true, features = ["luajit", "send"] }
 
-# clock
-chrono = { version = "0.4.42", optional = true, default-features = false, features = ["clock", "unstable-locales"] }
-
 # keyboard
 colpetto = { version = "0.7.0", features = ["tokio", "tracing"], optional = true }
 evdev-rs = { version = "0.6.3", optional = true }
@@ -192,6 +192,7 @@ libpulse-binding = { version = "2.30.1", optional = true }
 futures-lite = { version = "2.6.1", optional = true } # battery, network_manager, workspaces, keyboard
 zbus = { version = "5.12.0", default-features = false, features = ["tokio"], optional = true } # battery, network_manager, notifications
 swayipc-async = { version = "3.0.0", optional = true } # workspaces, keyboard
+chrono = { version = "0.4.42", optional = true, default-features = false, features = ["clock", "unstable-locales"] } # clock, inhibit
 hyprland = { version = "0.4.0-beta.3", optional = true } # workspaces, keyboard
 rustix = { version = "1.1.2", default-features = false, features = ["std", "fs", "pipe", "event"], optional = true } # clipboard, input
 serde_json = { version = "1.0.145", optional = true } # ipc, niri

--- a/docs/Compiling.md
+++ b/docs/Compiling.md
@@ -140,6 +140,7 @@ cargo build --release --no-default-features \
 | clock               | Enables the `clock` module.                                                                                          |
 | custom              | Enables the `custom` module.                                                                                         |
 | focused             | Enables the `focused` module.                                                                                        |
+| inhibit             | Enables the `inhibit` module.                                                                                        |
 | keyboard            | Enables the `keyboard` module without keyboard layout support.                                                       |
 | keyboard+all        | Enables the `keyboard` module with keyboard layout support for all compositors.                                      |
 | keyboard+sway       | Enables the `keyboard` module with keyboard layout support for Sway.                                                 |

--- a/docs/_Sidebar.md
+++ b/docs/_Sidebar.md
@@ -33,6 +33,7 @@
 - [Clock](clock)
 - [Custom](custom)
 - [Focused](focused)
+- [Inhibit](inhibit)
 - [Keyboard](keyboard)
 - [Label](label)
 - [Launcher](launcher)

--- a/docs/modules/Inhibit.md
+++ b/docs/modules/Inhibit.md
@@ -1,0 +1,116 @@
+Prevents the compositor from auto-suspending the system or auto-locking the screen. Click to toggle inhibit on/off or cycle through preset durations.
+
+> [!NOTE]
+> Inhibit is tracked globally (system-wide).
+> Multiple inhibit modules share the same inhibit state.
+
+## Configuration
+
+> Type: `inhibit`
+
+| Name               | Type                    | Default         | Description                                                     |
+| ------------------ | ----------------------- | --------------- | --------------------------------------------------------------- |
+| `durations`        | `string[]`              | See below       | List of durations to cycle through. See duration format.        |
+| `default_duration` | `string`                | `00:30:00`      | Starting duration. Defaults to first in `durations`.            |
+| `on_click_left`    | `'toggle'` or `'cycle'` | `'toggle'`      | Action on left click.                                           |
+| `on_click_right`   | `'toggle'` or `'cycle'` | `'cycle'`       | Action on right click.                                          |
+| `on_click_middle`  | `'toggle'` or `'cycle'` | `null`          | Action on middle click.                                         |
+| `format_on`        | `string`                | `☕ {duration}` | Format string when inhibit is active. Pango markup supported.   |
+| `format_off`       | `string`                | `💤 {duration}` | Format string when inhibit is inactive. Pango markup supported. |
+
+> **Default durations:** `["00:30:00", "01:00:00", "01:30:00", "02:00:00", "inf"]`
+>
+> **Duration format:** Time format `HH:MM:SS` (e.g., `01:30:00` for 1 hour 30 minutes). Use `0`, `00:00:00`, or `inf` for infinite duration.
+
+### Click Actions
+
+- **`toggle`**: Toggles inhibit on/off using the selected duration
+- **`cycle`**: Cycles to the next duration in the list (and applies it if already active)
+
+<details>
+<summary>JSON</summary>
+
+```json
+{
+  "end": [
+    {
+      "type": "inhibit",
+      "durations": ["00:30:00", "01:00:00", "01:30:00", "02:00:00", "inf"],
+      "default_duration": "00:30:00",
+      "on_click_left": "toggle",
+      "on_click_right": "cycle",
+      "format_on": "☕ {duration}",
+      "format_off": "💤 {duration}"
+    }
+  ]
+}
+```
+
+</details>
+
+<details>
+<summary>TOML</summary>
+
+```toml
+[[end]]
+type = "inhibit"
+durations = ["00:30:00", "01:00:00", "01:30:00", "02:00:00", "inf"]
+default_duration = "00:30:00"
+on_click_left = "toggle"
+on_click_right = "cycle"
+format_on = "☕ {duration}"
+format_off = "💤 {duration}"
+```
+
+</details>
+
+<details>
+<summary>YAML</summary>
+
+```yaml
+end:
+  - type: "inhibit"
+    durations: ["00:30:00", "01:00:00", "01:30:00", "02:00:00", "inf"]
+    default_duration: "00:30:00"
+    on_click_left: "toggle"
+    on_click_right: "cycle"
+    format_on: "☕ {duration}"
+    format_off: "💤 {duration}"
+```
+
+</details>
+
+<details>
+<summary>Corn</summary>
+
+```corn
+{
+  end = [
+    {
+      type = "inhibit"
+      durations = ["00:30:00" "01:00:00" "01:30:00" "02:00:00" "inf"]
+      default_duration = "00:30:00"
+      on_click_left = "toggle"
+      on_click_right = "cycle"
+      format_on = "☕ {duration}"
+      format_off = "💤 {duration}"
+    }
+  ]
+}
+```
+
+</details>
+
+### Formatting Tokens
+
+| Token        | Description       |
+| ------------ | ----------------- |
+| `{duration}` | Current duration. |
+
+## Styling
+
+| Selector   | Description           |
+| ---------- | --------------------- |
+| `.inhibit` | Inhibit widget button |
+
+For more information on styling, please see the [styling guide](styling-guide).

--- a/src/clients/inhibit.rs
+++ b/src/clients/inhibit.rs
@@ -1,0 +1,68 @@
+use crate::{lock, register_client};
+use gtk::ApplicationInhibitFlags;
+use gtk::prelude::*;
+use std::sync::{Arc, Mutex, Weak};
+use tracing::{error, trace};
+
+fn get_app() -> gtk::Application {
+    gtk::gio::Application::default()
+        .and_downcast()
+        .expect("GTK application not initialized")
+}
+
+/// Cookie holder that uninhibits on drop
+pub struct InhibitCookie(pub u32);
+
+impl Drop for InhibitCookie {
+    fn drop(&mut self) {
+        get_app().uninhibit(self.0);
+    }
+}
+
+/// Client for managing GTK application inhibit state.
+///
+/// Uses Weak reference to delegate ownership to modules - when all modules
+/// drop their `InhibitCookie`, the system uninhibit is called automatically.
+#[derive(Debug)]
+pub struct Client {
+    cookie: Mutex<Option<Weak<InhibitCookie>>>,
+}
+
+impl Client {
+    pub(crate) fn new() -> Self {
+        trace!("Initializing inhibit client");
+        Self {
+            cookie: Mutex::new(None),
+        }
+    }
+
+    /// Acquires an inhibit cookie.
+    ///
+    /// Uses global inhibition (no window-specific behavior).
+    /// Reuses existing cookie when multiple modules request inhibit.
+    /// Returns None if platform doesn't support inhibit.
+    pub fn acquire(&self) -> Option<Arc<InhibitCookie>> {
+        let mut cookie_opt = lock!(self.cookie);
+
+        // Upgrade weak cookie ref if it exists else create a new one
+        cookie_opt.as_ref().and_then(Weak::upgrade).or_else(|| {
+            let cookie = get_app().inhibit(
+                None::<&gtk::Window>,
+                ApplicationInhibitFlags::IDLE,
+                Some("Ironbar inhibit"),
+            );
+
+            if cookie == 0 {
+                error!("GTK inhibit failed - platform may not support it");
+                return None;
+            }
+
+            trace!("Created inhibit cookie: {}", cookie);
+            let rc = Arc::new(InhibitCookie(cookie));
+            *cookie_opt = Some(Arc::downgrade(&rc));
+            Some(rc)
+        })
+    }
+}
+
+register_client!(Client, inhibit);

--- a/src/clients/mod.rs
+++ b/src/clients/mod.rs
@@ -16,6 +16,8 @@ pub mod clipboard;
     feature = "workspaces",
 ))]
 pub mod compositor;
+#[cfg(feature = "inhibit")]
+pub mod inhibit;
 #[cfg(feature = "keyboard")]
 pub mod libinput;
 #[cfg(feature = "cairo")]
@@ -55,6 +57,8 @@ pub struct Clients {
     bindmode: Option<Arc<dyn compositor::BindModeClient>>,
     #[cfg(feature = "clipboard")]
     clipboard: Option<Arc<clipboard::Client>>,
+    #[cfg(feature = "inhibit")]
+    inhibit: Option<Arc<inhibit::Client>>,
     #[cfg(feature = "keyboard")]
     libinput: HashMap<Box<str>, Arc<libinput::Client>>,
     #[cfg(feature = "keyboard")]
@@ -104,6 +108,13 @@ impl Clients {
 
         self.clipboard
             .get_or_insert_with(|| Arc::new(clipboard::Client::new(wayland)))
+            .clone()
+    }
+
+    #[cfg(feature = "inhibit")]
+    pub fn inhibit(&mut self) -> Arc<inhibit::Client> {
+        self.inhibit
+            .get_or_insert_with(|| Arc::new(inhibit::Client::new()))
             .clone()
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -20,6 +20,8 @@ use crate::modules::clock::ClockModule;
 use crate::modules::custom::CustomModule;
 #[cfg(feature = "focused")]
 use crate::modules::focused::FocusedModule;
+#[cfg(feature = "inhibit")]
+use crate::modules::inhibit::InhibitModule;
 #[cfg(feature = "keyboard")]
 use crate::modules::keyboard::KeyboardModule;
 #[cfg(feature = "label")]
@@ -83,6 +85,8 @@ pub enum ModuleConfig {
     Custom(Box<CustomModule>),
     #[cfg(feature = "focused")]
     Focused(Box<FocusedModule>),
+    #[cfg(feature = "inhibit")]
+    Inhibit(Box<InhibitModule>),
     #[cfg(feature = "keyboard")]
     Keyboard(Box<KeyboardModule>),
     #[cfg(feature = "label")]
@@ -139,6 +143,8 @@ impl ModuleConfig {
             Self::Custom(module) => create!(module),
             #[cfg(feature = "focused")]
             Self::Focused(module) => create!(module),
+            #[cfg(feature = "inhibit")]
+            Self::Inhibit(module) => create!(module),
             #[cfg(feature = "keyboard")]
             Self::Keyboard(module) => create!(module),
             #[cfg(feature = "label")]
@@ -182,6 +188,8 @@ impl ModuleConfig {
             ModuleConfig::Custom(_) => "Custom",
             #[cfg(feature = "focused")]
             ModuleConfig::Focused(_) => "Focused",
+            #[cfg(feature = "inhibit")]
+            ModuleConfig::Inhibit(_) => "Inhibit",
             #[cfg(feature = "keyboard")]
             ModuleConfig::Keyboard(_) => "Keyboard",
             #[cfg(feature = "label")]

--- a/src/modules/inhibit/config.rs
+++ b/src/modules/inhibit/config.rs
@@ -1,0 +1,160 @@
+use crate::config::{CommonConfig, LayoutConfig};
+use chrono::Timelike;
+use serde::de::Error;
+use serde::{Deserialize, Deserializer};
+use std::time::Duration;
+
+/// Command to control inhibit state.
+///
+/// **Valid options**: `toggle`, `cycle`
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
+#[serde(rename_all = "lowercase")]
+pub enum InhibitCommand {
+    /// Toggle inhibit on/off
+    Toggle,
+    /// Cycle to next duration
+    Cycle,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
+#[serde(default)]
+pub struct InhibitModule {
+    /// Duration configuration: list of durations to cycle through and default.
+    /// Use `0` for infinite inhibit. Format: `HH:MM:SS` (e.g., `01:30:00`)
+    ///
+    /// If `default_duration` is not specified, the first item in `durations` is used.
+    ///
+    /// **Default**: `durations = ["00:30:00", "01:00:00", "01:30:00", "02:00:00", "0"]`
+    /// **Default**: `default_duration = "00:30:00"`
+    #[serde(flatten)]
+    pub(super) duration_spec: DurationSpec,
+
+    /// Command to execute on left click.
+    ///
+    /// **Valid options**: `toggle`, `cycle`
+    /// <br>
+    /// **Default**: `toggle`
+    pub(super) on_click_left: Option<InhibitCommand>,
+
+    /// Command to execute on right click.
+    ///
+    /// **Valid options**: `toggle`, `cycle`
+    /// <br>
+    /// **Default**: `cycle`
+    pub(super) on_click_right: Option<InhibitCommand>,
+
+    /// Command to execute on middle click.
+    ///
+    /// **Valid options**: `toggle`, `cycle`
+    /// <br>
+    /// **Default**: `null`
+    pub(super) on_click_middle: Option<InhibitCommand>,
+
+    /// Format string when inhibit is active.
+    /// `{duration}` token shows remaining/selected time.
+    ///
+    /// **Default**: `"☕ {duration}"`
+    pub(super) format_on: String,
+
+    /// Format string when inhibit is inactive.
+    /// `{duration}` token shows selected duration.
+    ///
+    /// **Default**: `"💤 {duration}"`
+    pub(super) format_off: String,
+
+    /// See [layout options](module-level-options#layout).
+    #[serde(flatten)]
+    pub(super) layout: LayoutConfig,
+
+    /// See [common options](module-level-options#common-options).
+    #[serde(flatten)]
+    pub common: Option<CommonConfig>,
+}
+
+impl Default for InhibitModule {
+    fn default() -> Self {
+        Self {
+            duration_spec: DurationSpec::default(),
+            on_click_left: Some(InhibitCommand::Toggle),
+            on_click_right: Some(InhibitCommand::Cycle),
+            on_click_middle: None,
+            format_on: "☕ {duration}".to_string(),
+            format_off: "💤 {duration}".to_string(),
+            layout: LayoutConfig::default(),
+            common: Some(CommonConfig::default()),
+        }
+    }
+}
+
+fn parse_duration(s: &str) -> Result<Duration, String> {
+    if matches!(s, "0" | "00:00:00" | "inf") {
+        return Ok(Duration::MAX);
+    }
+    chrono::NaiveTime::parse_from_str(s, "%H:%M:%S")
+        .map_err(|_| format!("invalid duration: {s}"))
+        .map(|time| Duration::from_secs(time.num_seconds_from_midnight() as u64))
+}
+
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
+pub(super) struct DurationSpec {
+    #[cfg_attr(feature = "extras", schemars(with = "Vec<String>"))]
+    pub(super) durations: Vec<Duration>,
+    #[cfg_attr(feature = "extras", schemars(with = "String"))]
+    pub(super) default_duration: Duration,
+}
+
+impl Default for DurationSpec {
+    fn default() -> Self {
+        let durations: Vec<Duration> = ["00:30:00", "01:00:00", "01:30:00", "02:00:00", "inf"]
+            .iter()
+            .map(|s| parse_duration(s).expect("default duration strings are valid"))
+            .collect();
+
+        Self {
+            default_duration: durations[0],
+            durations,
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for DurationSpec {
+    fn deserialize<D>(d: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize, Default)]
+        #[serde(default)]
+        struct Raw {
+            durations: Option<Vec<String>>,
+            default_duration: Option<String>,
+        }
+
+        let r = Raw::deserialize(d)?;
+
+        let durations = match r.durations {
+            Some(strs) if !strs.is_empty() => strs
+                .iter()
+                .map(|s| parse_duration(s).map_err(Error::custom))
+                .collect::<Result<Vec<_>, _>>()?,
+            Some(_) => return Err(Error::custom("durations list cannot be empty")),
+            None => Self::default().durations,
+        };
+
+        let default_duration = match r.default_duration {
+            Some(ref s) => parse_duration(s).map_err(Error::custom)?,
+            None => durations[0],
+        };
+
+        if !durations.contains(&default_duration) {
+            return Err(Error::custom("default_duration must be in durations list"));
+        }
+
+        Ok(Self {
+            durations,
+            default_duration,
+        })
+    }
+}

--- a/src/modules/inhibit/mod.rs
+++ b/src/modules/inhibit/mod.rs
@@ -1,0 +1,143 @@
+use color_eyre::Result;
+use gtk::prelude::*;
+use gtk::{Button, Label};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::mpsc::Receiver;
+use tracing::{debug, trace};
+
+use crate::channels::{AsyncSenderExt, BroadcastReceiverExt};
+use crate::clients::inhibit;
+use crate::gtk_helpers::{IronbarGtkExt, IronbarLabelExt, MouseButton};
+use crate::modules::{Module, ModuleInfo, ModuleParts, WidgetContext};
+use crate::{module_impl, spawn};
+
+mod config;
+
+use config::InhibitCommand;
+pub use config::InhibitModule;
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct State {
+    active: bool,
+    duration: Duration,
+}
+
+fn format_duration(d: Duration) -> String {
+    if d == Duration::MAX {
+        return "∞".to_string();
+    }
+    let s = d.as_secs();
+    let (h, m, s) = (s / 3600, s % 3600 / 60, s % 60);
+    match (h, m) {
+        (h, m) if h > 0 => format!("{h:02}:{m:02}:{s:02}"),
+        (_, m) => format!("{m:02}:{s:02}"),
+    }
+}
+
+impl Module<Button> for InhibitModule {
+    type SendMessage = State;
+    type ReceiveMessage = InhibitCommand;
+
+    module_impl!("inhibit");
+
+    fn spawn_controller(
+        &self,
+        _info: &ModuleInfo,
+        ctx: &WidgetContext<Self::SendMessage, Self::ReceiveMessage>,
+        mut rx: Receiver<Self::ReceiveMessage>,
+    ) -> Result<()> {
+        let tx = ctx.tx.clone();
+        let durations = self.duration_spec.durations.clone();
+        let default = self.duration_spec.default_duration;
+
+        spawn(async move {
+            debug!("Inhibit controller started");
+            let mut idx = durations.iter().position(|d| *d == default).unwrap_or(0);
+            let mut state = State {
+                active: false,
+                duration: durations[idx],
+            };
+            tx.send_update(state).await;
+
+            loop {
+                tokio::select! {
+                    Some(cmd) = rx.recv() => {
+                        match cmd {
+                            InhibitCommand::Cycle => idx = (idx + 1) % durations.len(),
+                            InhibitCommand::Toggle => state.active = !state.active,
+                        }
+                        state.duration = durations[idx];
+                        trace!("Inhibit state update: active={}, duration={}", state.active, format_duration(state.duration));
+                        tx.send_update(state).await;
+                    }
+                    _ = tokio::time::sleep(Duration::from_secs(1)), if state.active && state.duration != Duration::MAX => {
+                        state.duration = state.duration.saturating_sub(Duration::from_secs(1));
+                        if state.duration == Duration::ZERO {
+                            state.active = false;
+                            state.duration = durations[idx];
+                        }
+                        tx.send_update(state).await;
+                    }
+                }
+            }
+        });
+        Ok(())
+    }
+
+    fn into_widget(
+        self,
+        ctx: WidgetContext<Self::SendMessage, Self::ReceiveMessage>,
+        _info: &ModuleInfo,
+    ) -> Result<ModuleParts<Button>> {
+        let button = Button::new();
+        button.add_css_class("inhibit");
+        let label = Label::builder()
+            .use_markup(true)
+            .justify(self.layout.justify.into())
+            .build();
+        button.set_child(Some(&label));
+        let tx = ctx.controller_tx.clone();
+
+        [
+            (MouseButton::Primary, self.on_click_left),
+            (MouseButton::Secondary, self.on_click_right),
+            (MouseButton::Middle, self.on_click_middle),
+        ]
+        .into_iter()
+        .filter_map(|(btn, cmd)| cmd.map(|c| (btn, c)))
+        .for_each(|(btn, action)| {
+            let tx = tx.clone();
+            button.connect_pressed(btn, move || {
+                tx.send_spawn(action);
+            });
+        });
+
+        let client = ctx.client::<inhibit::Client>();
+        let inhibit_handle = std::cell::RefCell::new(None::<Arc<inhibit::InhibitCookie>>);
+        let was_active = std::cell::Cell::new(false);
+        let (fmt_on, fmt_off) = (self.format_on, self.format_off);
+        let controller_tx = ctx.controller_tx.clone();
+
+        // gtk based inhibit() requires glib context / main thread
+        ctx.subscribe().recv_glib(&label, move |label, state| {
+            if state.active != was_active.replace(state.active) {
+                if state.active {
+                    match client.acquire() {
+                        Some(cookie) => *inhibit_handle.borrow_mut() = Some(cookie),
+                        None => {
+                            controller_tx.send_spawn(InhibitCommand::Toggle);
+                            return;
+                        }
+                    }
+                } else {
+                    *inhibit_handle.borrow_mut() = None;
+                }
+            }
+
+            let fmt = if state.active { &fmt_on } else { &fmt_off };
+            label.set_label_escaped(&fmt.replace("{duration}", &format_duration(state.duration)));
+        });
+        Ok(ModuleParts::new(button, None))
+    }
+}

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -38,6 +38,8 @@ pub mod clock;
 pub mod custom;
 #[cfg(feature = "focused")]
 pub mod focused;
+#[cfg(feature = "inhibit")]
+pub mod inhibit;
 #[cfg(feature = "keyboard")]
 pub mod keyboard;
 #[cfg(feature = "label")]


### PR DESCRIPTION
Resolves #929.
Sample config:
```corn
{
      type = "inhibit"
      backend = "systemd"
      durations = ["30m" "1h" "1h30m" "*2h" "inf"]
      on_click_left = "toggle"
      on_click_right = "cycle"
      format_on = "☕ {duration}"
      format_off = "💤 {duration}"
 }
```
Notes:
*2h => * implies 2h is picked as default.
Can pick systemd or wayland backend.
systemd persists across ironbar restarts (launches a transient service that sleeps for desired time).
wayland surface dies with ironbar process.
Inhibit.md included.