### PR TITLE
refactor(config): prefer `serde(default)` attr at struct-level

### DIFF
--- a/src/clients/bluetooth.rs
+++ b/src/clients/bluetooth.rs
@@ -60,7 +60,7 @@ pub struct Client {
 
 impl Client {
     pub(crate) async fn new() -> Result<Self> {
-        let (tx, _rx) = watch::channel(BluetoothState::NotFound);
+        let (tx, rx) = watch::channel(BluetoothState::NotFound);
         let session = bluer::Session::new().await?;
         {
             let tx = tx.clone();
@@ -102,7 +102,11 @@ impl Client {
             });
         }
 
-        Ok(Self { session, tx, _rx })
+        Ok(Self {
+            session,
+            tx,
+            _rx: rx,
+        })
     }
 
     pub(crate) fn subscribe(&self) -> watch::Receiver<BluetoothState> {

--- a/src/config/default.rs
+++ b/src/config/default.rs
@@ -1,0 +1,17 @@
+/// Command for launching external applications.
+///
+/// `gtk-launch {app_name}`
+pub fn launch_command() -> String {
+    String::from("gtk-launch {app_name}")
+}
+
+/// Image icon sizes.
+#[repr(i32)]
+pub enum IconSize {
+    /// 32
+    Normal = 32,
+    /// 24
+    Small = 24,
+    /// 16
+    Tiny = 16,
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,4 +1,5 @@
 mod common;
+pub mod default;
 mod r#impl;
 mod layout;
 mod truncate;
@@ -232,14 +233,11 @@ impl Default for BarPosition {
 
 #[derive(Debug, Default, Deserialize, Copy, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(default)]
 pub struct MarginConfig {
-    #[serde(default)]
     pub bottom: i32,
-    #[serde(default)]
     pub left: i32,
-    #[serde(default)]
     pub right: i32,
-    #[serde(default)]
     pub top: i32,
 }
 
@@ -251,6 +249,7 @@ pub struct MarginConfig {
 ///
 #[derive(Debug, Deserialize, Clone)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(default)]
 pub struct BarConfig {
     /// A unique identifier for the bar, used for controlling it over IPC.
     /// If not set, uses a generated integer suffix.
@@ -263,14 +262,12 @@ pub struct BarConfig {
     /// **Valid options**: `top`, `bottom`, `left`, `right`
     /// <br>
     /// **Default**: `bottom`
-    #[serde(default)]
     pub position: BarPosition,
 
     /// Whether to anchor the bar to the edges of the screen.
     /// Setting to false centers the bar.
     ///
     /// **Default**: `true`
-    #[serde(default = "default_true")]
     pub anchor_to_edges: bool,
 
     /// The bar's height in pixels.
@@ -280,7 +277,6 @@ pub struct BarConfig {
     /// it will automatically expand to fit.
     ///
     /// **Default**: `42`
-    #[serde(default = "default_bar_height")]
     pub height: i32,
 
     /// The margin to use on each side of the bar, in pixels.
@@ -300,7 +296,6 @@ pub struct BarConfig {
     ///     margin.right = 10
     /// }
     /// ```
-    #[serde(default)]
     pub margin: MarginConfig,
 
     /// The layer-shell layer to place the bar on.
@@ -317,10 +312,7 @@ pub struct BarConfig {
     /// **Valid options**: `background`, `bottom`, `top`, `overlay`
     /// <br>
     /// **Default**: `top`
-    #[serde(
-        default = "default_layer",
-        deserialize_with = "r#impl::deserialize_layer"
-    )]
+    #[serde(deserialize_with = "r#impl::deserialize_layer")]
     #[cfg_attr(feature = "schema", schemars(schema_with = "r#impl::schema_layer"))]
     pub layer: gtk_layer_shell::Layer,
 
@@ -330,14 +322,12 @@ pub struct BarConfig {
     /// as the bar, causing them to shift.
     ///
     /// **Default**: `true` unless `start_hidden` is set.
-    #[serde(default)]
     pub exclusive_zone: Option<bool>,
 
     /// The size of the gap in pixels
     /// between the bar and the popup window.
     ///
     /// **Default**: `5`
-    #[serde(default = "default_popup_gap")]
     pub popup_gap: i32,
 
     /// Whether to enable autohide behaviour on the popup.
@@ -346,20 +336,17 @@ pub struct BarConfig {
     /// On some compositors, this may also aggressively steal mouse/keyboard focus.
     ///
     /// **Default**: `false`
-    #[serde(default)]
     pub popup_autohide: bool,
 
     /// Whether the bar should be hidden when Ironbar starts.
     ///
     /// **Default**: `false`, unless `autohide` is set.
-    #[serde(default)]
     pub start_hidden: Option<bool>,
 
     /// The duration in milliseconds before the bar is hidden after the cursor leaves.
     /// Leave unset to disable auto-hide behaviour.
     ///
     /// **Default**: `null`
-    #[serde(default)]
     pub autohide: Option<u64>,
 
     /// An array of modules to append to the start of the bar.
@@ -404,9 +391,9 @@ impl Default for BarConfig {
             position: BarPosition::default(),
             margin: MarginConfig::default(),
             name: None,
-            layer: default_layer(),
+            layer: gtk_layer_shell::Layer::Top,
             exclusive_zone: None,
-            height: default_bar_height(),
+            height: 42,
             start_hidden: None,
             autohide: None,
             #[cfg(feature = "label")]
@@ -417,8 +404,8 @@ impl Default for BarConfig {
             start: None,
             center,
             end,
-            anchor_to_edges: default_true(),
-            popup_gap: default_popup_gap(),
+            anchor_to_edges: true,
+            popup_gap: 5,
             popup_autohide: false,
         }
     }
@@ -426,6 +413,7 @@ impl Default for BarConfig {
 
 #[derive(Debug, Deserialize, Clone, Default)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(default)]
 pub struct Config {
     /// A map of [ironvar](ironvar) keys and values
     /// to initialize Ironbar with on startup.
@@ -479,30 +467,5 @@ pub struct Config {
     /// overriding the app's default icon.
     ///
     /// **Default**: `{}`
-    #[serde(default)]
     pub icon_overrides: HashMap<String, String>,
-}
-
-const fn default_layer() -> gtk_layer_shell::Layer {
-    gtk_layer_shell::Layer::Top
-}
-
-const fn default_bar_height() -> i32 {
-    42
-}
-
-const fn default_popup_gap() -> i32 {
-    5
-}
-
-pub const fn default_false() -> bool {
-    false
-}
-
-pub const fn default_true() -> bool {
-    true
-}
-
-pub fn default_launch_command() -> String {
-    String::from("gtk-launch {app_name}")
 }

--- a/src/modules/battery.rs
+++ b/src/modules/battery.rs
@@ -1,7 +1,7 @@
 use crate::channels::{AsyncSenderExt, BroadcastReceiverExt};
 use crate::clients::upower;
 use crate::clients::upower::BatteryState;
-use crate::config::{CommonConfig, LayoutConfig};
+use crate::config::{CommonConfig, LayoutConfig, default};
 use crate::gtk_helpers::IronbarLabelExt;
 use crate::image::IconLabel;
 use crate::modules::PopupButton;
@@ -26,23 +26,22 @@ const MINUTE: i64 = 60;
 
 #[derive(Debug, Deserialize, Clone)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(default)]
 pub struct BatteryModule {
     /// The format string to use for the widget button label.
     /// For available tokens, see [below](#formatting-tokens).
     ///
     /// **Default**: `{percentage}%`
-    #[serde(default = "default_format")]
     format: String,
 
     /// The size to render the icon at, in pixels.
     ///
     /// **Default**: `24`
-    #[serde(default = "default_icon_size")]
     icon_size: i32,
 
     // -- Common --
     /// See [layout options](module-level-options#layout)
-    #[serde(default, flatten)]
+    #[serde(flatten)]
     layout: LayoutConfig,
 
     /// A map of threshold names to apply as classes,
@@ -70,7 +69,6 @@ pub struct BatteryModule {
     /// Above 20%, no class applies.
     ///
     /// **Default**: `{}`
-    #[serde(default)]
     thresholds: HashMap<Box<str>, f64>,
 
     /// See [common options](module-level-options#common-options).
@@ -78,12 +76,16 @@ pub struct BatteryModule {
     pub common: Option<CommonConfig>,
 }
 
-fn default_format() -> String {
-    String::from("{percentage}%")
-}
-
-const fn default_icon_size() -> i32 {
-    24
+impl Default for BatteryModule {
+    fn default() -> Self {
+        Self {
+            format: "{percentage}%".to_string(),
+            icon_size: default::IconSize::Small as i32,
+            layout: LayoutConfig::default(),
+            thresholds: HashMap::new(),
+            common: Some(CommonConfig::default()),
+        }
+    }
 }
 
 #[derive(Clone, Debug, Default)]

--- a/src/modules/bluetooth/config.rs
+++ b/src/modules/bluetooth/config.rs
@@ -7,27 +7,23 @@ use crate::{
 
 #[derive(Debug, Deserialize, Clone)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(default)]
 pub struct BluetoothModule {
-    /// Format strings for on-bar button
-    #[serde(default)]
+    /// Format strings for on-bar button.
     pub format: FormatConfig,
 
-    /// Popup related configuration
-    #[serde(default)]
+    /// Popup related configuration.
     pub popup: PopupConfig,
 
     /// Values of `{adapter_status}` formatting token.
-    #[serde(default)]
     pub adapter_status: AdapterStatus,
 
     /// Values of `{device_status}` formatting token.
-    #[serde(default)]
     pub device_status: DeviceStatus,
 
     /// Size to render the icons at, in pixels (image icons only).
     ///
     /// **Default** `32`
-    #[serde(default = "default_icon_size")]
     pub icon_size: i32,
 
     /// See [common options](module-level-options#common-options).
@@ -35,281 +31,205 @@ pub struct BluetoothModule {
     pub common: Option<CommonConfig>,
 }
 
+impl Default for BluetoothModule {
+    fn default() -> Self {
+        Self {
+            format: FormatConfig::default(),
+            popup: PopupConfig::default(),
+            adapter_status: AdapterStatus::default(),
+            device_status: DeviceStatus::default(),
+            icon_size: 32,
+            common: Some(CommonConfig::default()),
+        }
+    }
+}
+
 #[derive(Debug, Deserialize, Clone)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(default)]
 pub struct FormatConfig {
     /// Format string to use for the widget button when bluetooth adapter not found.
     ///
     /// **Default**: `""`
-    #[serde(default = "default_format_not_found")]
     pub not_found: String,
 
     /// Format string to use for the widget button when bluetooth adapter is disabled.
     ///
     /// **Default**: `" Off"`
-    #[serde(default = "default_format_disabled")]
     pub disabled: String,
 
     /// Format string to use for the widget button when bluetooth adapter is enabled but no devices are connected.
     ///
     /// **Default**: `" On"`
-    #[serde(default = "default_format_enabled")]
     pub enabled: String,
 
     /// Format string to use for the widget button when bluetooth adapter is enabled and a device is connected.
     ///
     /// **Default**: `" {device_alias}"`
-    #[serde(default = "default_format_connected")]
     pub connected: String,
 
     /// Format string to use for the widget button when bluetooth adapter is enabled, a device is connected and `{device_battery_percent}` is available.
     ///
     /// **Default**: `" {device_alias} • {device_battery_percent}%"`
-    #[serde(default = "default_format_connected_battery")]
     pub connected_battery: String,
-}
-
-#[derive(Debug, Deserialize, Clone)]
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-pub struct PopupConfig {
-    /// Whether to make the popup scrollable or stretchable to show all of its content.
-    ///
-    /// **Default**: `true`
-    #[serde(default = "crate::config::default_true")]
-    pub scrollable: bool,
-
-    /// Format string to use for the header of popup window.
-    ///
-    /// **Default**: `" Enable Bluetooth"`
-    #[serde(default = "default_popup_header")]
-    pub header: String,
-
-    /// Format string to use for the message that is displayed when the adapter is not found or disabled.
-    ///
-    /// **Default**: `"{adapter_status}"`
-    #[serde(default = "default_popup_disabled")]
-    pub disabled: String,
-
-    /// Device box related configuration
-    #[serde(default)]
-    pub device: PopupDeviceConfig,
-}
-
-#[derive(Debug, Deserialize, Clone)]
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-pub struct AdapterStatus {
-    /// The value of `{adapter_status}` formatting token when adapter is enabling.
-    ///
-    /// **Default**: `"Enabling Bluetooth..."`
-    #[serde(default = "default_adapter_status_enabling")]
-    pub enabling: String,
-
-    /// The value of `{adapter_status}` formatting token when adapter is enabled.
-    ///
-    /// **Default**: `"Bluetooth enabled"`
-    #[serde(default = "default_adapter_status_enabled")]
-    pub enabled: String,
-
-    /// The value of `{adapter_status}` formatting token when adapter is disabling.
-    ///
-    /// **Default**: `"Disabling Bluetooth..."`
-    #[serde(default = "default_adapter_status_disabling")]
-    pub disabling: String,
-
-    /// The value of `{adapter_status}` formatting token when adapter is disabled.
-    ///
-    /// **Default**: `"Bluetooth disabled"`
-    #[serde(default = "default_adapter_status_disabled")]
-    pub disabled: String,
-
-    /// The value of `{adapter_status}` formatting token when adapter not found.
-    ///
-    /// **Default**: `"No Bluetooth adapters found"`
-    #[serde(default = "default_adapter_status_not_found")]
-    pub not_found: String,
-}
-
-#[derive(Debug, Deserialize, Clone)]
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-pub struct DeviceStatus {
-    /// The value of `{device_status}` formatting token when device is connecting.
-    ///
-    /// **Default**: `"Connecting..."`
-    #[serde(default = "default_device_status_connecting")]
-    pub connecting: String,
-
-    /// The value of `{device_status}` formatting token when device is connected.
-    ///
-    /// **Default**: `"Connected"`
-    #[serde(default = "default_device_status_connected")]
-    pub connected: String,
-
-    /// The value of `{device_status}` formatting token when device is disconnecting.
-    ///
-    /// **Default**: `"Disconnecting..."`
-    #[serde(default = "default_device_status_disconnecting")]
-    pub disconnecting: String,
-
-    /// The value of `{device_status}` formatting token when device is disconnected.
-    ///
-    /// **Default**: `"Disconnect"`
-    #[serde(default = "default_device_status_disconnected")]
-    pub disconnected: String,
-}
-
-#[derive(Debug, Deserialize, Clone)]
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-pub struct PopupDeviceConfig {
-    /// Format string to use for the header of device box.
-    ///
-    /// **Default**: `"{device_alias}"`
-    #[serde(default = "default_device_header")]
-    pub header: String,
-
-    /// Format string to use for the header of device box when `{device_battery_percent}` is available.
-    ///
-    /// **Default**: `"{device_alias}"`
-    #[serde(default = "default_device_header")]
-    pub header_battery: String,
-
-    /// Format string to use for the footer of device box.
-    ///
-    /// **Default**: `"{device_status}"`
-    #[serde(default = "default_device_footer")]
-    pub footer: String,
-
-    /// Format string to use for the footer of device box when `{device_battery_percent}` is available.
-    ///
-    /// **Default**: `"{device_status} • Battery {device_battery_percent}%"`
-    #[serde(default = "default_device_footer_battery")]
-    pub footer_battery: String,
-}
-
-const fn default_icon_size() -> i32 {
-    32
-}
-
-fn default_format_not_found() -> String {
-    String::new()
-}
-
-fn default_format_disabled() -> String {
-    " Off".into()
-}
-
-fn default_format_enabled() -> String {
-    " On".into()
-}
-
-fn default_format_connected() -> String {
-    " {device_alias}".into()
-}
-
-fn default_format_connected_battery() -> String {
-    " {device_alias} • {device_battery_percent}%".into()
-}
-
-fn default_popup_header() -> String {
-    " Enable Bluetooth".into()
-}
-
-fn default_popup_disabled() -> String {
-    "{adapter_status}".into()
-}
-
-fn default_device_header() -> String {
-    "{device_alias}".into()
-}
-
-fn default_device_footer() -> String {
-    "{device_status}".into()
-}
-
-fn default_device_footer_battery() -> String {
-    "{device_status} • Battery {device_battery_percent}%".into()
-}
-
-fn default_adapter_status_enabling() -> String {
-    "Enabling Bluetooth...".into()
-}
-fn default_adapter_status_enabled() -> String {
-    "Bluetooth enabled".into()
-}
-fn default_adapter_status_disabling() -> String {
-    "Disabling Bluetooth...".into()
-}
-fn default_adapter_status_disabled() -> String {
-    "Bluetooth disabled".into()
-}
-fn default_adapter_status_not_found() -> String {
-    "No Bluetooth adapters found".into()
-}
-fn default_device_status_connecting() -> String {
-    "Connecting...".into()
-}
-fn default_device_status_connected() -> String {
-    "Connected".into()
-}
-fn default_device_status_disconnecting() -> String {
-    "Disconnecting...".into()
-}
-fn default_device_status_disconnected() -> String {
-    "Disconnected".into()
 }
 
 impl Default for FormatConfig {
     fn default() -> Self {
         Self {
-            not_found: default_format_not_found(),
-            disabled: default_format_disabled(),
-            enabled: default_format_enabled(),
-            connected: default_format_connected(),
-            connected_battery: default_format_connected_battery(),
+            not_found: String::new(),
+            disabled: " Off".to_string(),
+            enabled: " On".to_string(),
+            connected: " {device_alias}".to_string(),
+            connected_battery: " {device_alias} • {device_battery_percent}%".to_string(),
         }
     }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(default)]
+pub struct PopupConfig {
+    /// Whether to make the popup scrollable or stretchable to show all of its content.
+    ///
+    /// **Default**: `true`
+    pub scrollable: bool,
+
+    /// Format string to use for the header of popup window.
+    ///
+    /// **Default**: `" Enable Bluetooth"`
+    pub header: String,
+
+    /// Format string to use for the message that is displayed when the adapter is not found or disabled.
+    ///
+    /// **Default**: `"{adapter_status}"`
+    pub disabled: String,
+
+    /// Device box related configuration
+    pub device: PopupDeviceConfig,
 }
 
 impl Default for PopupConfig {
     fn default() -> Self {
         Self {
             scrollable: true,
-            header: default_popup_header(),
-            disabled: default_popup_disabled(),
+            header: " Enable Bluetooth".to_string(),
+            disabled: "{adapter_status}".to_string(),
             device: PopupDeviceConfig::default(),
         }
     }
 }
 
+#[derive(Debug, Deserialize, Clone)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(default)]
+pub struct AdapterStatus {
+    /// The value of `{adapter_status}` formatting token when adapter is enabling.
+    ///
+    /// **Default**: `"Enabling Bluetooth..."`
+    pub enabling: String,
+
+    /// The value of `{adapter_status}` formatting token when adapter is enabled.
+    ///
+    /// **Default**: `"Bluetooth enabled"`
+    pub enabled: String,
+
+    /// The value of `{adapter_status}` formatting token when adapter is disabling.
+    ///
+    /// **Default**: `"Disabling Bluetooth..."`
+    pub disabling: String,
+
+    /// The value of `{adapter_status}` formatting token when adapter is disabled.
+    ///
+    /// **Default**: `"Bluetooth disabled"`
+    pub disabled: String,
+
+    /// The value of `{adapter_status}` formatting token when adapter not found.
+    ///
+    /// **Default**: `"No Bluetooth adapters found"`
+    pub not_found: String,
+}
+
 impl Default for AdapterStatus {
     fn default() -> Self {
         Self {
-            enabling: default_adapter_status_enabling(),
-            enabled: default_adapter_status_enabled(),
-            disabling: default_adapter_status_disabling(),
-            disabled: default_adapter_status_disabled(),
-            not_found: default_adapter_status_not_found(),
+            enabling: "Enabling Bluetooth...".to_string(),
+            enabled: "Bluetooth enabled".to_string(),
+            disabling: "Disabling Bluetooth...".to_string(),
+            disabled: "Bluetooth disabled".to_string(),
+            not_found: "No Bluetooth adapters found".to_string(),
         }
     }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(default)]
+pub struct DeviceStatus {
+    /// The value of `{device_status}` formatting token when device is connecting.
+    ///
+    /// **Default**: `"Connecting..."`
+    pub connecting: String,
+
+    /// The value of `{device_status}` formatting token when device is connected.
+    ///
+    /// **Default**: `"Connected"`
+    pub connected: String,
+
+    /// The value of `{device_status}` formatting token when device is disconnecting.
+    ///
+    /// **Default**: `"Disconnecting..."`
+    pub disconnecting: String,
+
+    /// The value of `{device_status}` formatting token when device is disconnected.
+    ///
+    /// **Default**: `"Disconnect"`
+    pub disconnected: String,
 }
 
 impl Default for DeviceStatus {
     fn default() -> Self {
         Self {
-            connecting: default_device_status_connecting(),
-            connected: default_device_status_connected(),
-            disconnecting: default_device_status_disconnecting(),
-            disconnected: default_device_status_disconnected(),
+            connecting: "Connecting...".to_string(),
+            connected: "Connected".to_string(),
+            disconnecting: "Disconnecting...".to_string(),
+            disconnected: "Disconnected".to_string(),
         }
     }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(default)]
+pub struct PopupDeviceConfig {
+    /// Format string to use for the header of device box.
+    ///
+    /// **Default**: `"{device_alias}"`
+    pub header: String,
+
+    /// Format string to use for the header of device box when `{device_battery_percent}` is available.
+    ///
+    /// **Default**: `"{device_alias}"`
+    pub header_battery: String,
+
+    /// Format string to use for the footer of device box.
+    ///
+    /// **Default**: `"{device_status}"`
+    pub footer: String,
+
+    /// Format string to use for the footer of device box when `{device_battery_percent}` is available.
+    ///
+    /// **Default**: `"{device_status} • Battery {device_battery_percent}%"`
+    pub footer_battery: String,
 }
 
 impl Default for PopupDeviceConfig {
     fn default() -> Self {
         Self {
-            header: default_device_header(),
-            header_battery: default_device_header(),
-            footer: default_device_footer(),
-            footer_battery: default_device_footer_battery(),
+            header: "{device_alias}".to_string(),
+            header_battery: "{device_alias}".to_string(),
+            footer: "{device_status}".to_string(),
+            footer_battery: "{device_status} • Battery {device_battery_percent}%".to_string(),
         }
     }
 }

--- a/src/modules/cairo.rs
+++ b/src/modules/cairo.rs
@@ -19,6 +19,7 @@ use tracing::{debug, error};
 
 #[derive(Debug, Clone, Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(default)]
 pub struct CairoModule {
     /// The path to the Lua script to load.
     /// This can be absolute, or relative to the working directory.
@@ -31,32 +32,32 @@ pub struct CairoModule {
     /// The number of milliseconds between each draw call.
     ///
     /// **Default**: `200`
-    #[serde(default = "default_frequency")]
     frequency: u64,
 
     /// The canvas width in pixels.
     ///
     /// **Default**: `42`
-    #[serde(default = "default_size")]
     width: u32,
 
     /// The canvas height in pixels.
     ///
     /// **Default**: `42`
-    #[serde(default = "default_size")]
     height: u32,
 
     /// See [common options](module-level-options#common-options).
-    #[serde(flatten)]
     pub common: Option<CommonConfig>,
 }
 
-const fn default_size() -> u32 {
-    42
-}
-
-const fn default_frequency() -> u64 {
-    200
+impl Default for CairoModule {
+    fn default() -> Self {
+        Self {
+            path: PathBuf::default(),
+            frequency: 200,
+            width: 42,
+            height: 42,
+            common: Some(CommonConfig::default()),
+        }
+    }
 }
 
 impl Module<gtk::Box> for CairoModule {

--- a/src/modules/clipboard.rs
+++ b/src/modules/clipboard.rs
@@ -21,26 +21,24 @@ use tracing::{debug, error};
 
 #[derive(Debug, Deserialize, Clone)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(default)]
 pub struct ClipboardModule {
     /// The icon to show on the bar widget button.
     /// Supports [image](images) icons.
     ///
     /// **Default**: `󰨸`
-    #[serde(default = "default_icon")]
     icon: String,
 
     /// The size to render the icon at.
     /// Note this only applies to image-type icons.
     ///
     /// **Default**: `32`
-    #[serde(default = "default_icon_size")]
     icon_size: i32,
 
     /// The maximum number of items to keep in the history,
     /// and to show in the popup.
     ///
     /// **Default**: `10`
-    #[serde(default = "default_max_items")]
     max_items: usize,
 
     // -- Common --
@@ -58,16 +56,17 @@ pub struct ClipboardModule {
     pub common: Option<CommonConfig>,
 }
 
-fn default_icon() -> String {
-    String::from("󰨸")
-}
-
-const fn default_icon_size() -> i32 {
-    32
-}
-
-const fn default_max_items() -> usize {
-    10
+impl Default for ClipboardModule {
+    fn default() -> Self {
+        Self {
+            icon: "󰨸".to_string(),
+            icon_size: 32,
+            max_items: 10,
+            truncate: None,
+            layout: LayoutConfig::default(),
+            common: Some(CommonConfig::default()),
+        }
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/src/modules/clock.rs
+++ b/src/modules/clock.rs
@@ -17,6 +17,7 @@ use crate::{module_impl, spawn};
 
 #[derive(Debug, Deserialize, Clone)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(default)]
 pub struct ClockModule {
     /// The format string to use for the date/time shown on the bar.
     /// Pango markup is supported.
@@ -25,7 +26,6 @@ pub struct ClockModule {
     /// <https://docs.rs/chrono/latest/chrono/format/strftime/index.html>
     ///
     /// **Default**: `%d/%m/%Y %H:%M`
-    #[serde(default = "default_format")]
     format: String,
 
     /// The format string to use for the date/time shown in the popup header.
@@ -35,7 +35,6 @@ pub struct ClockModule {
     /// <https://docs.rs/chrono/latest/chrono/format/strftime/index.html>
     ///
     /// **Default**: `%H:%M:%S`
-    #[serde(default = "default_popup_format")]
     format_popup: String,
 
     /// The locale to use when formatting dates.
@@ -46,11 +45,10 @@ pub struct ClockModule {
     /// **Valid options**: See [here](https://docs.rs/pure-rust-locales/0.8.1/pure_rust_locales/enum.Locale.html#variants)
     /// <br>
     /// **Default**: `$LC_TIME` or `$LANG` or `'POSIX'`
-    #[serde(default = "default_locale")]
     locale: String,
 
     /// See [layout options](module-level-options#layout)
-    #[serde(default, flatten)]
+    #[serde(flatten)]
     layout: LayoutConfig,
 
     /// See [common options](module-level-options#common-options).
@@ -61,21 +59,13 @@ pub struct ClockModule {
 impl Default for ClockModule {
     fn default() -> Self {
         ClockModule {
-            format: default_format(),
-            format_popup: default_popup_format(),
+            format: "%d/%m/%Y %H:%M".to_string(),
+            format_popup: "%H:%M:%S".to_string(),
             locale: default_locale(),
             layout: LayoutConfig::default(),
             common: Some(CommonConfig::default()),
         }
     }
-}
-
-fn default_format() -> String {
-    String::from("%d/%m/%Y %H:%M")
-}
-
-fn default_popup_format() -> String {
-    String::from("%H:%M:%S")
 }
 
 fn default_locale() -> String {

--- a/src/modules/custom/image.rs
+++ b/src/modules/custom/image.rs
@@ -1,13 +1,14 @@
+use super::{CustomWidget, CustomWidgetContext};
 use crate::build;
+use crate::config::default;
 use crate::dynamic_value::dynamic_string;
 use gtk::prelude::*;
 use gtk::{ContentFit, Picture};
 use serde::Deserialize;
 
-use super::{CustomWidget, CustomWidgetContext};
-
 #[derive(Debug, Deserialize, Clone)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(default)]
 pub struct ImageWidget {
     /// Widget name.
     ///
@@ -30,12 +31,18 @@ pub struct ImageWidget {
     /// Aspect ratio is preserved.
     ///
     /// **Default**: `32`
-    #[serde(default = "default_size")]
     size: i32,
 }
 
-const fn default_size() -> i32 {
-    32
+impl Default for ImageWidget {
+    fn default() -> Self {
+        Self {
+            name: None,
+            class: None,
+            src: String::new(),
+            size: default::IconSize::Normal as i32,
+        }
+    }
 }
 
 impl CustomWidget for ImageWidget {

--- a/src/modules/custom/progress.rs
+++ b/src/modules/custom/progress.rs
@@ -14,6 +14,7 @@ use crate::{build, spawn};
 
 #[derive(Debug, Deserialize, Clone)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(default)]
 pub struct ProgressWidget {
     /// Widget name.
     ///
@@ -51,7 +52,6 @@ pub struct ProgressWidget {
     /// The maximum progress bar value.
     ///
     /// **Default**: `100`
-    #[serde(default = "default_max")]
     max: f64,
 
     /// The progress bar length, in pixels.
@@ -61,8 +61,18 @@ pub struct ProgressWidget {
     length: Option<i32>,
 }
 
-const fn default_max() -> f64 {
-    100.0
+impl Default for ProgressWidget {
+    fn default() -> Self {
+        Self {
+            name: None,
+            class: None,
+            orientation: ModuleOrientation::default(),
+            label: None,
+            value: None,
+            max: 100.0,
+            length: None,
+        }
+    }
 }
 
 impl CustomWidget for ProgressWidget {

--- a/src/modules/custom/slider.rs
+++ b/src/modules/custom/slider.rs
@@ -17,6 +17,7 @@ use crate::{build, spawn};
 
 #[derive(Debug, Deserialize, Clone)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(default)]
 pub struct SliderWidget {
     /// Widget name.
     ///
@@ -54,13 +55,11 @@ pub struct SliderWidget {
     /// Minimum slider value.
     ///
     /// **Default**: `0`
-    #[serde(default = "default_min")]
     min: f64,
 
     /// Maximum slider value.
     ///
     /// **Default**: `100`
-    #[serde(default = "default_max")]
     max: f64,
 
     /// If the increment to change when scrolling with the mousewheel.
@@ -79,16 +78,24 @@ pub struct SliderWidget {
     /// Whether to show the value label above the slider.
     ///
     /// **Default**: `true`
-    #[serde(default = "crate::config::default_true")]
     show_label: bool,
 }
 
-const fn default_min() -> f64 {
-    0.0
-}
-
-const fn default_max() -> f64 {
-    100.0
+impl Default for SliderWidget {
+    fn default() -> Self {
+        Self {
+            name: None,
+            class: None,
+            orientation: ModuleOrientation::default(),
+            value: None,
+            on_change: None,
+            min: 0.0,
+            max: 100.0,
+            step: None,
+            length: None,
+            show_label: true,
+        }
+    }
 }
 
 impl CustomWidget for SliderWidget {

--- a/src/modules/focused.rs
+++ b/src/modules/focused.rs
@@ -1,6 +1,6 @@
 use crate::channels::{AsyncSenderExt, BroadcastReceiverExt};
 use crate::clients::wayland::{self, ToplevelEvent};
-use crate::config::{CommonConfig, LayoutConfig, TruncateMode};
+use crate::config::{CommonConfig, LayoutConfig, TruncateMode, default};
 use crate::gtk_helpers::IronbarLabelExt;
 use crate::modules::{Module, ModuleInfo, ModuleParts, WidgetContext};
 use crate::{module_impl, spawn};
@@ -13,22 +13,20 @@ use tracing::debug;
 
 #[derive(Debug, Deserialize, Clone)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(default)]
 pub struct FocusedModule {
     /// Whether to show icon on the bar.
     ///
     /// **Default**: `true`
-    #[serde(default = "crate::config::default_true")]
     show_icon: bool,
     /// Whether to show app name on the bar.
     ///
     /// **Default**: `true`
-    #[serde(default = "crate::config::default_true")]
     show_title: bool,
 
     /// Icon size in pixels.
     ///
     /// **Default**: `32`
-    #[serde(default = "default_icon_size")]
     icon_size: i32,
 
     // -- common --
@@ -38,7 +36,7 @@ pub struct FocusedModule {
     truncate: Option<TruncateMode>,
 
     /// See [layout options](module-level-options#layout)
-    #[serde(default, flatten)]
+    #[serde(flatten)]
     layout: LayoutConfig,
 
     /// See [common options](module-level-options#common-options).
@@ -49,18 +47,14 @@ pub struct FocusedModule {
 impl Default for FocusedModule {
     fn default() -> Self {
         Self {
-            show_icon: crate::config::default_true(),
-            show_title: crate::config::default_true(),
-            icon_size: default_icon_size(),
+            show_icon: true,
+            show_title: true,
+            icon_size: default::IconSize::Normal as i32,
             truncate: None,
             layout: LayoutConfig::default(),
             common: Some(CommonConfig::default()),
         }
     }
-}
-
-const fn default_icon_size() -> i32 {
-    32
 }
 
 impl Module<gtk::Box> for FocusedModule {

--- a/src/modules/keyboard.rs
+++ b/src/modules/keyboard.rs
@@ -16,53 +16,47 @@ use crate::{module_impl, spawn};
 
 #[derive(Debug, Deserialize, Clone)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(default)]
 pub struct KeyboardModule {
     /// Whether to show capslock indicator.
     ///
     /// **Default**: `true`
-    #[serde(default = "crate::config::default_true")]
     show_caps: bool,
 
     /// Whether to show num lock indicator.
     ///
     ///  **Default**: `true`
-    #[serde(default = "crate::config::default_true")]
     show_num: bool,
 
     /// Whether to show scroll lock indicator.
     ///
     ///  **Default**: `true`
-    #[serde(default = "crate::config::default_true")]
     show_scroll: bool,
 
     /// Whether to show the current keyboard layout.
     ///
     ///  **Default**: `true`
-    #[serde(default = "crate::config::default_true")]
     show_layout: bool,
 
     /// Size to render the icons at, in pixels (image icons only).
     ///
     /// **Default** `32`
-    #[serde(default = "default_icon_size")]
     icon_size: i32,
 
     /// Player state icons.
     ///
     /// See [icons](#icons).
-    #[serde(default)]
     icons: Icons,
 
     /// The Wayland seat to attach to.
     /// You almost certainly do not need to change this.
     ///
     /// **Default**: `seat0`
-    #[serde(default = "default_seat")]
     seat: String,
 
     // -- common --
     /// See [layout options](module-level-options#layout)
-    #[serde(default, flatten)]
+    #[serde(flatten)]
     layout: LayoutConfig,
 
     /// See [common options](module-level-options#common-options).
@@ -70,43 +64,54 @@ pub struct KeyboardModule {
     pub common: Option<CommonConfig>,
 }
 
+impl Default for KeyboardModule {
+    fn default() -> Self {
+        Self {
+            show_caps: true,
+            show_num: true,
+            show_scroll: true,
+            show_layout: true,
+            icon_size: 32,
+            icons: Icons::default(),
+            seat: "seat0".to_string(),
+            layout: LayoutConfig::default(),
+            common: Some(CommonConfig::default()),
+        }
+    }
+}
+
 #[derive(Debug, Deserialize, Clone)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(default)]
 struct Icons {
     /// Icon to show when capslock is enabled.
     ///
     /// **Default**: `󰪛`
-    #[serde(default = "default_icon_caps")]
     caps_on: String,
 
     /// Icon to show when capslock is disabled.
     ///
     /// **Default**: `""`
-    #[serde(default)]
     caps_off: String,
 
     /// Icon to show when num lock is enabled.
     ///
     /// **Default**: ``
-    #[serde(default = "default_icon_num")]
     num_on: String,
 
     /// Icon to show when num lock is disabled.
     ///
     /// **Default**: `""`
-    #[serde(default)]
     num_off: String,
 
     /// Icon to show when scroll lock is enabled.
     ///
     /// **Default**: ``
-    #[serde(default = "default_icon_scroll")]
     scroll_on: String,
 
     /// Icon to show when scroll lock is disabled.
     ///
     /// **Default**: `""`
-    #[serde(default)]
     scroll_off: String,
 
     /// Map of icons or labels to show for a particular keyboard layout.
@@ -126,42 +131,21 @@ struct Icons {
     ///   icons.layout_map.Ukrainian = "UA"
     /// }
     /// ```
-    #[serde(default)]
     layout_map: IndexMap<String, String>,
 }
 
 impl Default for Icons {
     fn default() -> Self {
         Self {
-            caps_on: default_icon_caps(),
+            caps_on: "󰪛".to_string(),
             caps_off: String::new(),
-            num_on: default_icon_num(),
+            num_on: "".to_string(),
             num_off: String::new(),
-            scroll_on: default_icon_scroll(),
+            scroll_on: "".to_string(),
             scroll_off: String::new(),
             layout_map: IndexMap::new(),
         }
     }
-}
-
-const fn default_icon_size() -> i32 {
-    32
-}
-
-fn default_seat() -> String {
-    String::from("seat0")
-}
-
-fn default_icon_caps() -> String {
-    String::from("󰪛")
-}
-
-fn default_icon_num() -> String {
-    String::from("")
-}
-
-fn default_icon_scroll() -> String {
-    String::from("")
 }
 
 #[derive(Debug, Clone)]

--- a/src/modules/menu/config.rs
+++ b/src/modules/menu/config.rs
@@ -1,4 +1,4 @@
-use crate::config::default_launch_command;
+use crate::config::default;
 use crate::config::{CommonConfig, TruncateMode};
 use crate::modules::menu::{MenuEntry, XdgSection};
 use indexmap::IndexMap;
@@ -54,11 +54,11 @@ pub struct CustomEntry {
 
 #[derive(Debug, Deserialize, Clone)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(default)]
 pub struct MenuModule {
     /// Items to add to the start of the main menu.
     ///
     /// **Default**: `[]`
-    #[serde(default)]
     pub(super) start: Vec<MenuConfig>,
 
     /// Items to add to the start of the main menu.
@@ -67,13 +67,11 @@ pub struct MenuModule {
     /// that should cover all common applications.
     ///
     /// **Default**: See `examples/menu/default`
-    #[serde(default = "default_menu")]
     pub(super) center: Vec<MenuConfig>,
 
     /// Items to add to the end of the main menu.
     ///
     /// **Default**: `[]`
-    #[serde(default)]
     pub(super) end: Vec<MenuConfig>,
 
     /// Fixed height of the menu.
@@ -84,7 +82,6 @@ pub struct MenuModule {
     /// Leave null to resize dynamically.
     ///
     /// **Default**: `null`
-    #[serde(default)]
     pub(super) height: Option<i32>,
 
     /// Fixed width of the menu.
@@ -93,23 +90,19 @@ pub struct MenuModule {
     /// to customise how item labels are truncated.
     ///
     /// **Default**: `null`
-    #[serde(default)]
     pub(super) width: Option<i32>,
 
     /// Label to show on the menu button on the bar.
     ///
     /// **Default**: `≡`
-    #[serde(default = "default_menu_popup_label")]
     pub(super) label: Option<String>,
 
     /// Icon to show on the menu button on the bar.
     ///
     /// **Default**: `null`
-    #[serde(default)]
     pub(super) label_icon: Option<String>,
 
     /// Size of the `label_icon` image.
-    #[serde(default = "default_menu_popup_icon_size")]
     pub(super) label_icon_size: i32,
 
     // -- common --
@@ -118,7 +111,6 @@ pub struct MenuModule {
     /// See [truncate options](module-level-options#truncate-mode).
     ///
     /// **Default**: `Auto (end)`
-    #[serde(default)]
     pub(super) truncate: TruncateMode,
 
     /// See [common options](module-level-options#common-options).
@@ -128,7 +120,6 @@ pub struct MenuModule {
     /// Command used to launch applications.
     ///
     /// **Default**: `gtk-launch`
-    #[serde(default = "default_launch_command")]
     pub launch_command: String,
 }
 
@@ -141,12 +132,11 @@ impl Default for MenuModule {
             height: None,
             width: None,
             truncate: TruncateMode::default(),
-            // max_label_length: default_length(),
-            label: default_menu_popup_label(),
+            label: Some("≡".to_string()),
             label_icon: None,
-            label_icon_size: default_menu_popup_icon_size(),
+            label_icon_size: default::IconSize::Tiny as i32,
             common: Some(CommonConfig::default()),
-            launch_command: default_launch_command(),
+            launch_command: default::launch_command(),
         }
     }
 }
@@ -219,14 +209,6 @@ fn default_menu() -> Vec<MenuConfig> {
             categories: vec!["Settings".to_string(), "Screensaver".to_string()],
         }),
     ]
-}
-
-fn default_menu_popup_label() -> Option<String> {
-    Some("≡".to_string())
-}
-
-const fn default_menu_popup_icon_size() -> i32 {
-    16
 }
 
 pub const OTHER_LABEL: &str = "Other";

--- a/src/modules/menu/mod.rs
+++ b/src/modules/menu/mod.rs
@@ -195,7 +195,7 @@ impl Module<Button> for MenuModule {
         main_menu.set_vexpand(false);
         main_menu.add_css_class("main");
 
-        let max_width = self.width.map(|w| w / 2).unwrap_or(-1);
+        let max_width = self.width.map_or(-1, |w| w / 2);
 
         if let Some(max_height) = self.height {
             container.set_height_request(max_height);

--- a/src/modules/music/config.rs
+++ b/src/modules/music/config.rs
@@ -1,74 +1,7 @@
-use crate::config::{CommonConfig, LayoutConfig, TruncateMode};
+use crate::config::{CommonConfig, LayoutConfig, TruncateMode, default};
 use dirs::{audio_dir, home_dir};
 use serde::Deserialize;
 use std::path::PathBuf;
-
-#[derive(Debug, Deserialize, Clone)]
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-pub struct Icons {
-    /// Icon to display when playing.
-    ///
-    /// **Default**: ``
-    #[serde(default = "default_icon_play")]
-    pub(crate) play: String,
-
-    /// Icon to display when paused.
-    ///
-    /// **Default**: ``
-    #[serde(default = "default_icon_pause")]
-    pub(crate) pause: String,
-
-    /// Icon to display for previous button.
-    ///
-    /// **Default**: `󰒮`
-    #[serde(default = "default_icon_prev")]
-    pub(crate) prev: String,
-
-    /// Icon to display for next button.
-    ///
-    /// **Default**: `󰒭`
-    #[serde(default = "default_icon_next")]
-    pub(crate) next: String,
-
-    /// Icon to display under volume slider.
-    ///
-    /// **Default**: `󰕾`
-    #[serde(default = "default_icon_volume")]
-    pub(crate) volume: String,
-
-    /// Icon to display nex to track title.
-    ///
-    /// **Default**: `󰎈`
-    #[serde(default = "default_icon_track")]
-    pub(crate) track: String,
-
-    /// Icon to display nex to album name.
-    ///
-    /// **Default**: `󰀥`
-    #[serde(default = "default_icon_album")]
-    pub(crate) album: String,
-
-    /// Icon to display nex to artist name.
-    ///
-    /// **Default**: `󰠃`
-    #[serde(default = "default_icon_artist")]
-    pub(crate) artist: String,
-}
-
-impl Default for Icons {
-    fn default() -> Self {
-        Self {
-            pause: default_icon_pause(),
-            play: default_icon_play(),
-            prev: default_icon_prev(),
-            next: default_icon_next(),
-            volume: default_icon_volume(),
-            track: default_icon_track(),
-            album: default_icon_album(),
-            artist: default_icon_artist(),
-        }
-    }
-}
 
 #[derive(Debug, Deserialize, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
@@ -96,6 +29,7 @@ impl Default for PlayerType {
 
 #[derive(Debug, Deserialize, Clone)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(default)]
 pub struct MusicModule {
     /// Type of player to connect to
     #[serde(default)]
@@ -106,32 +40,27 @@ pub struct MusicModule {
     /// Info on formatting tokens [below](#formatting-tokens).
     ///
     /// **Default**: `{title} / {artist}`
-    #[serde(default = "default_format")]
     pub(crate) format: String,
 
     /// Player state icons.
     ///
     /// See [icons](#icons).
-    #[serde(default)]
     pub(crate) icons: Icons,
 
     /// Whether to show the play/pause status icon
     /// on the bar.
     ///
     /// **Default**: `true`
-    #[serde(default = "crate::config::default_true")]
     pub(crate) show_status_icon: bool,
 
     /// Size to render the icons at, in pixels (image icons only).
     ///
     /// **Default** `32`
-    #[serde(default = "default_icon_size")]
     pub(crate) icon_size: i32,
 
     /// Size to render the album art image at inside the popup, in pixels.
     ///
     /// **Default**: `128`
-    #[serde(default = "default_cover_image_size")]
     pub(crate) cover_image_size: i32,
 
     // -- MPD --
@@ -140,7 +69,6 @@ pub struct MusicModule {
     /// For TCP, this should include the port number.
     ///
     /// **Default**: `localhost:6600`
-    #[serde(default = "default_socket")]
     pub(crate) host: String,
 
     /// *[MPD Only]*
@@ -148,7 +76,6 @@ pub struct MusicModule {
     /// This is required for displaying album art.
     ///
     /// **Default**: `$HOME/Music`
-    #[serde(default = "default_music_dir")]
     pub(crate) music_dir: PathBuf,
 
     // -- Common --
@@ -173,7 +100,7 @@ pub struct MusicModule {
     pub(crate) truncate_popup_title: Option<TruncateMode>,
 
     /// See [layout options](module-level-options#layout)
-    #[serde(default, flatten)]
+    #[serde(flatten)]
     pub(crate) layout: LayoutConfig,
 
     /// See [common options](module-level-options#common-options).
@@ -181,54 +108,87 @@ pub struct MusicModule {
     pub common: Option<CommonConfig>,
 }
 
-fn default_socket() -> String {
-    String::from("localhost:6600")
+impl Default for MusicModule {
+    fn default() -> Self {
+        Self {
+            player_type: PlayerType::default(),
+            format: "{title} / {artist}".to_string(),
+            icons: Icons::default(),
+            show_status_icon: true,
+            icon_size: default::IconSize::Normal as i32,
+            cover_image_size: 128,
+            host: "localhost:6600".to_string(),
+            music_dir: default_music_dir(),
+            truncate: None,
+            truncate_popup_artist: None,
+            truncate_popup_album: None,
+            truncate_popup_title: None,
+            layout: LayoutConfig::default(),
+            common: Some(CommonConfig::default()),
+        }
+    }
 }
 
-fn default_format() -> String {
-    String::from("{title} / {artist}")
+#[derive(Debug, Deserialize, Clone)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(default)]
+pub struct Icons {
+    /// Icon to display when playing.
+    ///
+    /// **Default**: ``
+    pub(crate) play: String,
+
+    /// Icon to display when paused.
+    ///
+    /// **Default**: ``
+    pub(crate) pause: String,
+
+    /// Icon to display for previous button.
+    ///
+    /// **Default**: `󰒮`
+    pub(crate) prev: String,
+
+    /// Icon to display for next button.
+    ///
+    /// **Default**: `󰒭`
+    pub(crate) next: String,
+
+    /// Icon to display under volume slider.
+    ///
+    /// **Default**: `󰕾`
+    pub(crate) volume: String,
+
+    /// Icon to display nex to track title.
+    ///
+    /// **Default**: `󰎈`
+    pub(crate) track: String,
+
+    /// Icon to display nex to album name.
+    ///
+    /// **Default**: `󰀥`
+    pub(crate) album: String,
+
+    /// Icon to display nex to artist name.
+    ///
+    /// **Default**: `󰠃`
+    pub(crate) artist: String,
 }
 
-fn default_icon_play() -> String {
-    String::from("")
-}
-
-fn default_icon_pause() -> String {
-    String::from("")
-}
-
-fn default_icon_prev() -> String {
-    String::from("󰒮")
-}
-
-fn default_icon_next() -> String {
-    String::from("󰒭")
-}
-
-fn default_icon_volume() -> String {
-    String::from("󰕾")
-}
-
-fn default_icon_track() -> String {
-    String::from("󰎈")
-}
-
-fn default_icon_album() -> String {
-    String::from("󰀥")
-}
-
-fn default_icon_artist() -> String {
-    String::from("󰠃")
+impl Default for Icons {
+    fn default() -> Self {
+        Self {
+            pause: "".to_string(),
+            play: "".to_string(),
+            prev: "󰒮".to_string(),
+            next: "󰒭".to_string(),
+            volume: "󰕾".to_string(),
+            track: "󰎈".to_string(),
+            album: "󰀥".to_string(),
+            artist: "󰠃".to_string(),
+        }
+    }
 }
 
 fn default_music_dir() -> PathBuf {
     audio_dir().unwrap_or_else(|| home_dir().map(|dir| dir.join("Music")).unwrap_or_default())
-}
-
-const fn default_icon_size() -> i32 {
-    24
-}
-
-const fn default_cover_image_size() -> i32 {
-    128
 }

--- a/src/modules/networkmanager.rs
+++ b/src/modules/networkmanager.rs
@@ -1,6 +1,6 @@
 use crate::channels::{AsyncSenderExt, BroadcastReceiverExt};
 use crate::clients::networkmanager::{Client, ClientState};
-use crate::config::CommonConfig;
+use crate::config::{CommonConfig, default};
 use crate::modules::{Module, ModuleInfo, ModuleParts, WidgetContext};
 use crate::{module_impl, spawn};
 use color_eyre::Result;
@@ -13,16 +13,21 @@ use tokio::sync::mpsc::Receiver;
 
 #[derive(Debug, Deserialize, Clone)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(default)]
 pub struct NetworkManagerModule {
-    #[serde(default = "default_icon_size")]
     icon_size: i32,
 
     #[serde(flatten)]
     pub common: Option<CommonConfig>,
 }
 
-const fn default_icon_size() -> i32 {
-    24
+impl Default for NetworkManagerModule {
+    fn default() -> Self {
+        Self {
+            icon_size: default::IconSize::Small as i32,
+            common: Some(CommonConfig::default()),
+        }
+    }
 }
 
 impl Module<GtkBox> for NetworkManagerModule {

--- a/src/modules/notifications.rs
+++ b/src/modules/notifications.rs
@@ -12,17 +12,16 @@ use tracing::error;
 
 #[derive(Debug, Deserialize, Clone)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(default)]
 pub struct NotificationsModule {
     /// Whether to show the current notification count.
     ///
     /// **Default**: `true`
-    #[serde(default = "crate::config::default_true")]
     show_count: bool,
 
     /// SwayNC state icons.
     ///
     /// See [icons](#icons).
-    #[serde(default)]
     icons: Icons,
 
     /// See [common options](module-level-options#common-options).
@@ -30,83 +29,64 @@ pub struct NotificationsModule {
     pub common: Option<CommonConfig>,
 }
 
+impl Default for NotificationsModule {
+    fn default() -> Self {
+        Self {
+            show_count: true,
+            icons: Icons::default(),
+            common: Some(CommonConfig::default()),
+        }
+    }
+}
+
 #[derive(Debug, Deserialize, Clone)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(default)]
 struct Icons {
     /// Icon to show when the panel is closed, with no notifications.
     ///
     /// **Default**: `󰍥`
-    #[serde(default = "default_icon_closed_none")]
     closed_none: String,
 
     /// Icon to show when the panel is closed, with notifications.
     ///
     /// **Default**: `󱥂`
-    #[serde(default = "default_icon_closed_some")]
     closed_some: String,
 
     /// Icon to show when the panel is closed, with DnD enabled.
     /// Takes higher priority than count-based icons.
     ///
     /// **Default**: `󱅯`
-    #[serde(default = "default_icon_closed_dnd")]
     closed_dnd: String,
 
     /// Icon to show when the panel is open, with no notifications.
     ///
     /// **Default**: `󰍡`
-    #[serde(default = "default_icon_open_none")]
     open_none: String,
 
     /// Icon to show when the panel is open, with notifications.
     ///
     /// **Default**: `󱥁`
-    #[serde(default = "default_icon_open_some")]
     open_some: String,
 
     /// Icon to show when the panel is open, with DnD enabled.
     /// Takes higher priority than count-based icons.
     ///
     /// **Default**: `󱅮`
-    #[serde(default = "default_icon_open_dnd")]
     open_dnd: String,
 }
 
 impl Default for Icons {
     fn default() -> Self {
         Self {
-            closed_none: default_icon_closed_none(),
-            closed_some: default_icon_closed_some(),
-            closed_dnd: default_icon_closed_dnd(),
-            open_none: default_icon_open_none(),
-            open_some: default_icon_open_some(),
-            open_dnd: default_icon_open_dnd(),
+            closed_none: "󰍥".to_string(),
+            closed_some: "󱥂".to_string(),
+            closed_dnd: "󱅯".to_string(),
+            open_none: "󰍡".to_string(),
+            open_some: "󱥁".to_string(),
+            open_dnd: "󱅮".to_string(),
         }
     }
-}
-
-fn default_icon_closed_none() -> String {
-    String::from("󰍥")
-}
-
-fn default_icon_closed_some() -> String {
-    String::from("󱥂")
-}
-
-fn default_icon_closed_dnd() -> String {
-    String::from("󱅯")
-}
-
-fn default_icon_open_none() -> String {
-    String::from("󰍡")
-}
-
-fn default_icon_open_some() -> String {
-    String::from("󱥁")
-}
-
-fn default_icon_open_dnd() -> String {
-    String::from("󱅮")
 }
 
 impl Icons {

--- a/src/modules/script.rs
+++ b/src/modules/script.rs
@@ -12,6 +12,7 @@ use tracing::error;
 
 #[derive(Debug, Deserialize, Clone)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(default)]
 pub struct ScriptModule {
     /// Path to script to execute.
     ///
@@ -27,18 +28,16 @@ pub struct ScriptModule {
     /// **Valid options**: `poll`, `watch`
     /// <br />
     /// **Default**: `poll`
-    #[serde(default = "default_mode")]
     mode: ScriptMode,
 
     /// Time in milliseconds between executions.
     ///
     /// **Default**: `5000`
-    #[serde(default = "default_interval")]
     interval: u64,
 
     // -- Common --
     /// See [layout options](module-level-options#layout)
-    #[serde(default, flatten)]
+    #[serde(flatten)]
     layout: LayoutConfig,
 
     /// See [common options](module-level-options#common-options).
@@ -46,14 +45,16 @@ pub struct ScriptModule {
     pub common: Option<CommonConfig>,
 }
 
-/// `Mode::Poll`
-const fn default_mode() -> ScriptMode {
-    ScriptMode::Poll
-}
-
-/// 5000ms
-const fn default_interval() -> u64 {
-    5000
+impl Default for ScriptModule {
+    fn default() -> Self {
+        Self {
+            cmd: String::new(),
+            mode: ScriptMode::Poll,
+            interval: 5000,
+            layout: LayoutConfig::default(),
+            common: Some(CommonConfig::default()),
+        }
+    }
 }
 
 impl From<&ScriptModule> for Script {

--- a/src/modules/sysinfo/mod.rs
+++ b/src/modules/sysinfo/mod.rs
@@ -19,6 +19,7 @@ use tokio::time::sleep;
 
 #[derive(Debug, Deserialize, Clone)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(default)]
 pub struct SysInfoModule {
     /// List of strings including formatting tokens.
     /// For available tokens, see [below](#formatting-tokens).
@@ -32,7 +33,6 @@ pub struct SysInfoModule {
     /// or passed as an object to customize the interval per-system.
     ///
     /// **Default**: `5`
-    #[serde(default = "Interval::default")]
     interval: Interval,
 
     /// The orientation by which the labels are laid out.
@@ -44,7 +44,7 @@ pub struct SysInfoModule {
 
     // -- common --
     /// See [layout options](module-level-options#layout)
-    #[serde(default, flatten)]
+    #[serde(flatten)]
     layout: LayoutConfig,
 
     /// See [common options](module-level-options#common-options).
@@ -52,44 +52,64 @@ pub struct SysInfoModule {
     pub common: Option<CommonConfig>,
 }
 
+impl Default for SysInfoModule {
+    fn default() -> Self {
+        Self {
+            format: vec![],
+            interval: Interval::default(),
+            direction: None,
+            layout: LayoutConfig::default(),
+            common: Some(CommonConfig::default()),
+        }
+    }
+}
+
 #[derive(Debug, Deserialize, Copy, Clone)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(default)]
 pub struct Intervals {
     /// The number of seconds between refreshing memory data.
     ///
     /// **Default**: `5`
-    #[serde(default = "default_interval")]
     memory: u64,
 
     /// The number of seconds between refreshing CPU data.
     ///
     /// **Default**: `5`
-    #[serde(default = "default_interval")]
     cpu: u64,
 
     /// The number of seconds between refreshing temperature data.
     ///
     /// **Default**: `5`
-    #[serde(default = "default_interval")]
     temps: u64,
 
     /// The number of seconds between refreshing disk data.
     ///
     /// **Default**: `5`
-    #[serde(default = "default_interval")]
     disks: u64,
 
     /// The number of seconds between refreshing network data.
     ///
     /// **Default**: `5`
-    #[serde(default = "default_interval")]
     networks: u64,
 
     /// The number of seconds between refreshing system data.
     ///
     /// **Default**: `5`
-    #[serde(default = "default_interval")]
     system: u64,
+}
+
+impl Default for Intervals {
+    fn default() -> Self {
+        Self {
+            memory: 5,
+            cpu: 5,
+            temps: 5,
+            disks: 5,
+            networks: 5,
+            system: 5,
+        }
+    }
 }
 
 #[derive(Debug, Deserialize, Copy, Clone)]
@@ -102,7 +122,7 @@ pub enum Interval {
 
 impl Default for Interval {
     fn default() -> Self {
-        Self::All(default_interval())
+        Self::All(5)
     }
 }
 
@@ -148,10 +168,6 @@ impl Interval {
             Self::Individual(intervals) => intervals.system,
         }
     }
-}
-
-const fn default_interval() -> u64 {
-    5
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]

--- a/src/modules/tray/mod.rs
+++ b/src/modules/tray/mod.rs
@@ -3,7 +3,7 @@ mod interface;
 
 use crate::channels::{AsyncSenderExt, BroadcastReceiverExt};
 use crate::clients::tray;
-use crate::config::{CommonConfig, ModuleOrientation};
+use crate::config::{CommonConfig, ModuleOrientation, default};
 use crate::modules::{Module, ModuleInfo, ModuleParts, WidgetContext};
 use crate::{lock, module_impl, spawn};
 use color_eyre::{Report, Result};
@@ -19,18 +19,17 @@ use tracing::{debug, error, trace, warn};
 
 #[derive(Debug, Deserialize, Clone)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(default)]
 pub struct TrayModule {
     /// Requests that icons from the theme be used over the item-provided item.
     /// Most items only provide one or the other so this will have no effect in most circumstances.
     ///
     /// **Default**: `true`
-    #[serde(default = "crate::config::default_true")]
     prefer_theme_icons: bool,
 
     /// Size in pixels to display the tray icons as.
     ///
     /// **Default**: `16`
-    #[serde(default = "default_icon_size")]
     icon_size: u32,
 
     /// The direction in which to pack tray icons.
@@ -38,7 +37,6 @@ pub struct TrayModule {
     /// **Valid options**: `horizontal`, `vertical`
     /// <br>
     /// **Default**: `horizontal` for horizontal bars, `vertical` for vertical bars
-    #[serde(default)]
     direction: Option<ModuleOrientation>,
 
     /// See [common options](module-level-options#common-options).
@@ -46,8 +44,15 @@ pub struct TrayModule {
     pub common: Option<CommonConfig>,
 }
 
-const fn default_icon_size() -> u32 {
-    16
+impl Default for TrayModule {
+    fn default() -> Self {
+        Self {
+            prefer_theme_icons: true,
+            icon_size: default::IconSize::Tiny as u32,
+            direction: None,
+            common: Some(CommonConfig::default()),
+        }
+    }
 }
 
 impl Module<gtk::Box> for TrayModule {

--- a/src/modules/volume.rs
+++ b/src/modules/volume.rs
@@ -21,25 +21,23 @@ use tracing::trace;
 
 #[derive(Debug, Clone, Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(default)]
 pub struct VolumeModule {
     /// The format string to use for the widget button label.
     /// For available tokens, see [below](#formatting-tokens).
     ///
     /// **Default**: `{icon} {percentage}%`
-    #[serde(default = "default_format")]
     format: String,
 
     /// Maximum value to allow volume sliders to reach.
     /// Pulse supports values > 100 but this may result in distortion.
     ///
     /// **Default**: `100`
-    #[serde(default = "default_max_volume")]
     max_volume: f64,
 
     /// Volume state icons.
     ///
     /// See [icons](#icons).
-    #[serde(default)]
     icons: Icons,
 
     // -- Common --
@@ -57,36 +55,53 @@ pub struct VolumeModule {
     pub common: Option<CommonConfig>,
 }
 
-fn default_format() -> String {
-    String::from("{icon} {percentage}%")
+impl Default for VolumeModule {
+    fn default() -> Self {
+        Self {
+            format: "{icon} {percentage}%".to_string(),
+            max_volume: 100.0,
+            icons: Icons::default(),
+            truncate: None,
+            layout: LayoutConfig::default(),
+            common: Some(CommonConfig::default()),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(default)]
 pub struct Icons {
     /// Icon to show for high volume levels.
     ///
     /// **Default**: `󰕾`
-    #[serde(default = "default_icon_volume_high")]
     volume_high: String,
 
     /// Icon to show for medium volume levels.
     ///
     /// **Default**: `󰖀`
-    #[serde(default = "default_icon_volume_medium")]
     volume_medium: String,
 
     /// Icon to show for low volume levels.
     ///
     /// **Default**: `󰕿`
-    #[serde(default = "default_icon_volume_low")]
     volume_low: String,
 
     /// Icon to show for muted outputs.
     ///
     /// **Default**: `󰝟`
-    #[serde(default = "default_icon_muted")]
     muted: String,
+}
+
+impl Default for Icons {
+    fn default() -> Self {
+        Self {
+            volume_high: "󰕾".to_string(),
+            volume_medium: "󰖀".to_string(),
+            volume_low: "󰕿".to_string(),
+            muted: "󰝟".to_string(),
+        }
+    }
 }
 
 impl Icons {
@@ -97,37 +112,6 @@ impl Icons {
             67.. => &self.volume_high,
         }
     }
-}
-
-impl Default for Icons {
-    fn default() -> Self {
-        Self {
-            volume_high: default_icon_volume_high(),
-            volume_medium: default_icon_volume_medium(),
-            volume_low: default_icon_volume_low(),
-            muted: default_icon_muted(),
-        }
-    }
-}
-
-const fn default_max_volume() -> f64 {
-    100.0
-}
-
-fn default_icon_volume_high() -> String {
-    String::from("󰕾")
-}
-
-fn default_icon_volume_medium() -> String {
-    String::from("󰖀")
-}
-
-fn default_icon_volume_low() -> String {
-    String::from("󰕿")
-}
-
-fn default_icon_muted() -> String {
-    String::from("󰝟")
 }
 
 #[derive(Debug, Clone)]

--- a/src/modules/workspaces/mod.rs
+++ b/src/modules/workspaces/mod.rs
@@ -5,7 +5,7 @@ mod open_state;
 use self::button::Button;
 use crate::channels::{AsyncSenderExt, BroadcastReceiverExt};
 use crate::clients::compositor::{Workspace, WorkspaceClient, WorkspaceUpdate};
-use crate::config::{CommonConfig, LayoutConfig};
+use crate::config::{CommonConfig, LayoutConfig, default};
 use crate::gtk_helpers::IronbarGtkExt;
 use crate::modules::workspaces::button_map::{ButtonMap, Identifier};
 use crate::modules::workspaces::open_state::OpenState;
@@ -60,6 +60,7 @@ impl Default for Favorites {
 
 #[derive(Debug, Deserialize, Clone)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(default)]
 pub struct WorkspacesModule {
     /// Map of actual workspace names to custom names.
     ///
@@ -107,7 +108,6 @@ pub struct WorkspacesModule {
     /// When false, only shows workspaces on the current monitor.
     ///
     /// **Default**: `false`
-    #[serde(default = "crate::config::default_false")]
     all_monitors: bool,
 
     /// The method used for sorting workspaces.
@@ -125,7 +125,6 @@ pub struct WorkspacesModule {
     /// The size to render icons at (image icons only).
     ///
     /// **Default**: `32`
-    #[serde(default = "default_icon_size")]
     icon_size: i32,
 
     // -- Common --
@@ -138,8 +137,19 @@ pub struct WorkspacesModule {
     pub common: Option<CommonConfig>,
 }
 
-const fn default_icon_size() -> i32 {
-    32
+impl Default for WorkspacesModule {
+    fn default() -> Self {
+        Self {
+            name_map: HashMap::default(),
+            favorites: Favorites::default(),
+            hidden: vec![],
+            all_monitors: false,
+            sort: SortOrder::default(),
+            icon_size: default::IconSize::Normal as i32,
+            layout: LayoutConfig::default(),
+            common: Some(CommonConfig::default()),
+        }
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/src/script.rs
+++ b/src/script.rs
@@ -79,23 +79,18 @@ impl ScriptMode {
 
 #[derive(Debug, Deserialize, Clone)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(default)]
 pub struct Script {
-    #[serde(default = "ScriptMode::default")]
     pub(crate) mode: ScriptMode,
     pub cmd: String,
-    #[serde(default = "default_interval")]
     pub(crate) interval: u64,
-}
-
-const fn default_interval() -> u64 {
-    5000
 }
 
 impl Default for Script {
     fn default() -> Self {
         Self {
             mode: ScriptMode::default(),
-            interval: default_interval(),
+            interval: 5000,
             cmd: String::new(),
         }
     }
@@ -344,11 +339,13 @@ mod tests {
 
     #[test]
     fn test_parse_basic() {
+        let default_script = Script::default();
+
         let cmd = "echo 'hello'";
         let script = Script::from(cmd);
 
         assert_eq!(script.cmd, cmd);
-        assert_eq!(script.interval, default_interval());
+        assert_eq!(script.interval, default_script.interval);
         assert_eq!(script.mode, ScriptMode::default());
     }
 
@@ -381,6 +378,8 @@ mod tests {
 
     #[test]
     fn test_parse_mode_and_cmd() {
+        let default_script = Script::default();
+
         let cmd = "echo 'hello'";
         let mode = ScriptMode::Watch;
 
@@ -388,17 +387,19 @@ mod tests {
         let script = Script::from(full_cmd.as_str());
 
         assert_eq!(script.cmd, cmd);
-        assert_eq!(script.interval, default_interval());
+        assert_eq!(script.interval, default_script.interval);
         assert_eq!(script.mode, mode);
     }
 
     #[test]
     fn test_parse_cmd_with_colon() {
+        let default_script = Script::default();
+
         let cmd = "uptime | awk '{print \"Uptime: \" $1}'";
         let script = Script::from(cmd);
 
         assert_eq!(script.cmd, cmd);
-        assert_eq!(script.interval, default_interval());
+        assert_eq!(script.interval, default_script.interval);
         assert_eq!(script.mode, ScriptMode::default());
     }
 


### PR DESCRIPTION
This removes a lot of default-oriented code, instead replacing it with a proper `Default` implementation and using `#[serde(default)]` at the struct level, instead of per-field.