### PR TITLE
fix(gtk4): set display on icon theme (fixes #1213)

### DIFF
--- a/src/image/provider.rs
+++ b/src/image/provider.rs
@@ -343,12 +343,16 @@ impl Provider {
     pub fn set_icon_theme(&self, theme: Option<&str>) {
         trace!("Setting icon theme to {:?}", theme);
 
-        *self.icon_theme.borrow_mut() = if theme.is_some() {
+        let icon_theme = if theme.is_some() {
             let icon_theme = IconTheme::new();
             icon_theme.set_theme_name(theme);
-            Some(icon_theme)
+            icon_theme
         } else {
-            Some(IconTheme::default())
+            IconTheme::default()
         };
+
+        icon_theme.set_display(Some(crate::get_display()).as_ref());
+
+        *self.icon_theme.borrow_mut() = Some(icon_theme);
     }
 }


### PR DESCRIPTION
You might think that `IconTheme::for_display` would make more sense. Unfortunately per GTK3 docs:

> This function cannot be called on the icon theme objects returned from gtk_icon_theme_get_for_display()

https://docs.gtk.org/gtk4/method.IconTheme.set_theme_name.html

Fixes #1213