### PR TITLE
chore(nix): add nixpkgs override for naersk

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,10 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     flake-compat.url = "github:edolstra/flake-compat";
-    naersk.url = "github:nix-community/naersk";
+    naersk = {
+      url = "github:nix-community/naersk";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
     nix-systems.url = "github:nix-systems/default-linux";
   };
 


### PR DESCRIPTION
Makes sure we are using our nixpkgs version to avoid nixpkgs duplication