### PR TITLE
feat(workspaces): implement urgency for niri

### DIFF
--- a/src/clients/compositor/niri/connection.rs
+++ b/src/clients/compositor/niri/connection.rs
@@ -71,6 +71,7 @@ impl From<&Workspace> for IronWorkspace {
 pub enum Event {
     WorkspacesChanged { workspaces: Vec<Workspace> },
     WorkspaceActivated { id: u64, focused: bool },
+    WorkspaceUrgencyChanged { id: u64, urgent: bool },
     Other,
 }
 

--- a/src/clients/compositor/niri/mod.rs
+++ b/src/clients/compositor/niri/mod.rs
@@ -163,6 +163,12 @@ impl Client {
                             vec![]
                         }
                     }
+                    Ok(Event::WorkspaceUrgencyChanged { id, urgent }) => {
+                        vec![WorkspaceUpdate::Urgent {
+                            id: id as i64,
+                            urgent,
+                        }]
+                    }
                     Ok(Event::Other) => {
                         vec![]
                     }


### PR DESCRIPTION
Extend the implementation at #735 for Niri. Niri keeps track of a `urgent` flag per workspace and window, like sway.

Sample niri_ipc events:

```json
{"WindowOpenedOrChanged":{"window":{"id":24,"title":"sleep 2; tput bel ~/r/ironbar2","app_id":"Alacritty","pid":64809,"workspace_id":4,"is_focused":true,"is_floating":false,"is_urgent":false,"layout":{"pos_in_scrolling_layout":[1,1],"tile_size":[1257.0,1042.0],"window_size":[1257,1042],"tile_pos_in_workspace_view":null,"window_offset_in_tile":[0.0,0.0]}}}}
{"WorkspaceActivated":{"id":2,"focused":true}}
{"WindowFocusChanged":{"id":30}}
{"WorkspaceUrgencyChanged":{"id":4,"urgent":true}}
{"WindowUrgencyChanged":{"id":24,"urgent":true}}
{"WindowOpenedOrChanged":{"window":{"id":24,"title":"~/r/ironbar2","app_id":"Alacritty","pid":64809,"workspace_id":4,"is_focused":false,"is_floating":false,"is_urgent":true,"layout":{"pos_in_scrolling_layout":[1,1],"tile_size":[1257.0,1042.0],"window_size":[1257,1042],"tile_pos_in_workspace_view":null,"window_offset_in_tile":[0.0,0.0]}}}}
{"WorkspaceUrgencyChanged":{"id":4,"urgent":false}}
{"WorkspaceActivated":{"id":4,"focused":true}}
{"WindowFocusChanged":{"id":24}}
{"WindowUrgencyChanged":{"id":24,"urgent":false}}
{"WorkspaceActivated":{"id":2,"focused":true}}
{"WindowFocusChanged":{"id":30}}

```