### PR TITLE
Fix typos and improve clarity in Scripts.md

### DIFF
--- a/docs/Scripts.md
+++ b/docs/Scripts.md
@@ -22,8 +22,8 @@ type.
 ## Writing script configs
 
 There are two available config formats for scripts: shorthand, as a string, or longhand, as an object.
-Shorthand can be used in all cases, but there are some cases (such as embedding scripts inside strings) where longhand
-cannot be used.
+There are some cases (such as embedding scripts inside strings) where longhand cannot be used.
+Shorthand can be used in all cases.
 
 In both formats, `mode` is one of `poll` or `watch` and `interval` is the number of milliseconds to wait between
 spawning the script.


### PR DESCRIPTION
- Fixed some grammatical mistakes here and there
- Fixed the TOML config being written as YAML

> Shorthand can be used in all cases, but there are some cases (such as embedding scripts inside strings) where longhand
cannot be used.

I was not sure whether or how to fix the above line. I am not sure if longhand is a typo or not and if not, then there is no need for a "but".