### PR TITLE
feat: add marquee effect to volume popup's audio inputs

### DIFF
--- a/docs/modules/Volume.md
+++ b/docs/modules/Volume.md
@@ -1,7 +1,7 @@
 Displays the current volume level.
 Clicking on the widget opens a volume mixer, which allows you to change the device output level,
 the default playback device, and control application volume levels individually.
-Use `truncate` option to control the display of application titles in the volume mixer.
+Use `truncate` or `marquee` options to control the display of application titles in the volume mixer.
 
 This requires PulseAudio to function (`pipewire-pulse` is supported).
 
@@ -11,18 +11,25 @@ This requires PulseAudio to function (`pipewire-pulse` is supported).
 
 > Type: `volume`
 
-| Name                  | Type                                                 | Default                | Description                                                                                                    |
-|-----------------------|------------------------------------------------------|------------------------|----------------------------------------------------------------------------------------------------------------|
-| `format`              | `string`                                             | `{icon} {percentage}%` | Format string to use for the widget button label.                                                              |
-| `max_volume`          | `float`                                              | `100`                  | Maximum value to allow volume sliders to reach. Pulse supports values > 100 but this may result in distortion. |
-| `icons.volume_high`   | `string`                                             | `󰕾`                    | Icon to show for high volume levels.                                                                           |
-| `icons.volume_medium` | `string`                                             | `󰖀`                    | Icon to show for medium volume levels.                                                                         |
-| `icons.volume_low`    | `string`                                             | `󰕿`                    | Icon to show for low volume levels.                                                                            |
-| `icons.muted`         | `string`                                             | `󰝟`                    | Icon to show for muted outputs.                                                                                |
-| `truncate`            | `'start'` or `'middle'` or `'end'` or `off` or `Map` | `off`                  | The location of the ellipses and where to truncate text from. Leave null to avoid truncating. Use the long-hand `Map` version if specifying a length. |
-| `truncate.mode`       | `'start'` or `'middle'` or `'end'` or `off`          | `off`                  | The location of the ellipses and where to truncate text from. Leave null to avoid truncating.                                                         |
-| `truncate.length`     | `integer`                                            | `null`                 | The fixed width (in chars) of the widget. Leave blank to let GTK automatically handle.                                                                |
-| `truncate.max_length` | `integer`                                            | `null`                 | The maximum number of characters before truncating. Leave blank to let GTK automatically handle.                                                      |
+| Name                            | Type                                                 | Default                | Description                                                                                                                       |
+|---------------------------------|------------------------------------------------------|------------------------|-----------------------------------------------------------------------------------------------------------------------------------|
+| `format`                        | `string`                                             | `{icon} {percentage}%` | Format string to use for the widget button label.                                                                                 |
+| `max_volume`                    | `float`                                              | `100`                  | Maximum value to allow volume sliders to reach. Pulse supports values > 100 but this may result in distortion.                    |
+| `icons.volume_high`             | `string`                                             | `󰕾`                    | Icon to show for high volume levels.                                                                                              |
+| `icons.volume_medium`           | `string`                                             | `󰖀`                    | Icon to show for medium volume levels.                                                                                            |
+| `icons.volume_low`              | `string`                                             | `󰕿`                    | Icon to show for low volume levels.                                                                                               |
+| `icons.muted`                   | `string`                                             | `󰝟`                    | Icon to show for muted outputs.                                                                                                   |
+| `truncate`                      | `'start'` or `'middle'` or `'end'` or `off` or `Map` | `off`                  | The location of the ellipses and where to truncate text from. Leave null to avoid truncating. Use the long-hand `Map` version if specifying a length. Takes precedence over `marquee` if both are configured. |
+| `truncate.mode`                 | `'start'` or `'middle'` or `'end'` or `off`          | `off`                  | The location of the ellipses and where to truncate text from. Leave null to avoid truncating.                                     |
+| `truncate.length`               | `integer`                                            | `null`                 | The fixed width (in chars) of the widget. Leave blank to let GTK automatically handle.                                            |
+| `truncate.max_length`           | `integer`                                            | `null`                 | The maximum number of characters before truncating. Leave blank to let GTK automatically handle.                                  |
+| `marquee`                       | `Map`                                                | `false`                | Options for enabling and configuring a marquee (scrolling) effect for long text. Ignored if `truncate` is configured.             |
+| `marquee.enable`                | `bool`                                               | `false`                | Whether to enable a marquee effect.                                                                                               |
+| `marquee.max_length`            | `integer`                                            | `null`                 | The maximum length of text (roughly, in characters) before it gets truncated and starts scrolling.                                |
+| `marquee.scroll_speed`          | `float`                                              | `0.5`                  | Scroll speed in pixels per frame. Higher values scroll faster.                                                                    |
+| `marquee.pause_duration`        | `integer`                                            | `5000`                 | Duration in milliseconds to pause at each loop point.                                                                             |
+| `marquee.separator`             | `string`                                             | `"    "`               | String displayed between the end and beginning of text as it loops.                                                               |
+| `marquee.on_hover`              | `'none'` or `'pause'` or `'play'`                    | `'none'`               | Controls marquee behavior on hover: `'none'` (always scroll), `'pause'` (pause on hover), or `'play'` (only scroll on hover).     |
 
 <details>
 <summary>JSON</summary>

--- a/src/clients/volume/sink_input.rs
+++ b/src/clients/volume/sink_input.rs
@@ -131,17 +131,22 @@ fn update(
 
     trace!("updating {info:?}");
 
+    let input_info: SinkInput = info.into();
+
     {
         let mut inputs = lock!(inputs);
-        let Some(pos) = inputs.iter().position(|input| input.index == info.index) else {
+        if let Some(pos) = inputs
+            .iter()
+            .position(|input| input.index == input_info.index)
+        {
+            inputs[pos] = input_info.clone();
+        } else {
             error!("received update to untracked sink input");
             return;
-        };
-
-        inputs[pos] = info.into();
+        }
     }
 
-    tx.send_expect(Event::UpdateInput(info.into()));
+    tx.send_expect(Event::UpdateInput(input_info));
 }
 
 fn remove(index: u32, inputs: &ArcMutVec<SinkInput>, tx: &broadcast::Sender<Event>) {

--- a/src/config/marquee.rs
+++ b/src/config/marquee.rs
@@ -1,0 +1,74 @@
+use serde::Deserialize;
+
+/// Defines the behavior of marquee scrolling on hover.
+#[derive(Debug, Deserialize, Clone, Copy, Default, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+#[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
+pub enum MarqueeOnHover {
+    /// Scrolling is always active, hover has no effect.
+    #[default]
+    None,
+    /// Scrolling pauses when the widget is hovered.
+    Pause,
+    /// Scrolling only occurs when the widget is hovered.
+    Play,
+}
+
+/// Some modules provide options for scrolling text (marquee effect).
+/// This is controlled using a common `MarqueeMode` type,
+/// which is defined below.
+///
+#[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
+#[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
+pub struct MarqueeMode {
+    /// Whether to enable scrolling on long lines of text.
+    /// This may not be supported by all modules.
+    ///
+    /// **Default**: `false`
+    pub enable: bool,
+
+    /// The maximum length of text (roughly, in characters) before it gets truncated and starts scrolling.
+    ///
+    /// **Default**: `null`
+    pub max_length: Option<i32>,
+
+    /// Scroll speed in pixels per frame.
+    /// Higher values scroll faster.
+    ///
+    /// **Default**: `0.5`
+    pub scroll_speed: f64,
+
+    /// Duration in milliseconds to pause at each loop point.
+    ///
+    /// **Default**: `5000` (5 seconds)
+    pub pause_duration: u64,
+
+    /// String displayed between the end and beginning of text as it loops.
+    ///
+    /// **Default**: `"    "` (4 spaces)
+    pub separator: String,
+
+    /// Controls marquee behavior on hover.
+    ///
+    /// **Options**:
+    /// - `"none"`: Always scroll (default)
+    /// - `"pause"`: Pause scrolling on hover
+    /// - `"play"`: Only scroll on hover
+    ///
+    /// **Default**: `"none"`
+    pub on_hover: MarqueeOnHover,
+}
+
+impl Default for MarqueeMode {
+    fn default() -> Self {
+        Self {
+            enable: false,
+            max_length: None,
+            scroll_speed: 0.5,
+            pause_duration: 5000,
+            separator: "    ".to_string(),
+            on_hover: MarqueeOnHover::default(),
+        }
+    }
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2,6 +2,7 @@ mod common;
 pub mod default;
 mod r#impl;
 mod layout;
+mod marquee;
 mod truncate;
 
 #[cfg(feature = "battery")]
@@ -49,6 +50,7 @@ use crate::modules::workspaces::WorkspacesModule;
 
 pub use self::common::{CommonConfig, ModuleJustification, ModuleOrientation, TransitionType};
 pub use self::layout::LayoutConfig;
+pub use self::marquee::{MarqueeMode, MarqueeOnHover};
 pub use self::truncate::{EllipsizeMode, TruncateMode};
 
 use gtk::prelude::ObjectExt;


### PR DESCRIPTION
Part of #1011. Based on #1066 - GTK4 actually fixes that scrollbars bug, so pretty much no changes aside from updating to GTK4 and expanding what's configurable.

### Overview

- Wraps the label in a ScrolledWindow with hidden scrollbars
- Configurable max length before marquee starts
- Configurable scrolling speed
- Configurable inter-loop pause duration
- Configurable separator
- Optional pause on hover or play on hover

### Known issues

None so far.

### Limitations and future considerations

It's **opt-in so no breaking changes**, but anyone wishing to use might need to update their CSS (implementation details leak a bit):

```css
/* Before */
.volume .app-box > .title {
  ...
}

/* After: target both */
.volume .app-box > .title,
.volume .app-box > scrolledwindow > viewport > .title {
  ...
}

/* But 'any child' selector stays the same, works for both */
.volume .app-box .title {
  ...
}
```

For future extensions of other modules, even aside from just music (and its popup) I could see a lot of use-cases for making every Label scrollable like this. But this will necessarily mean replicating the same less-than-perfect UX pattern with regards to user CSS - wanted to hear your thoughts @JakeStanger on this.
