### PR TITLE
fix(launcher): close popup when mouse leaves

### DIFF
--- a/src/modules/launcher/mod.rs
+++ b/src/modules/launcher/mod.rs
@@ -17,7 +17,7 @@ use crate::modules::launcher::pagination::{IconContext, Pagination};
 use crate::{arc_mut, lock, module_impl, rc_mut, spawn, write_lock};
 use color_eyre::Report;
 use gtk::prelude::*;
-use gtk::{Button, Orientation};
+use gtk::{Button, EventControllerMotion, Orientation};
 use indexmap::IndexMap;
 use serde::Deserialize;
 use std::rc::Rc;
@@ -611,6 +611,12 @@ impl Module<gtk::Box> for LauncherModule {
         const MAX_WIDTH: i32 = 250;
 
         let container = gtk::Box::new(Orientation::Vertical, 0);
+
+        // Close popup when mouse leaves the popup container
+        let tx = context.tx.clone();
+        let event_controller = EventControllerMotion::new();
+        event_controller.connect_leave(move |_| tx.send_spawn(ModuleUpdateEvent::ClosePopup));
+        container.add_controller(event_controller);
 
         // we need some content to force the container to have a size
         let placeholder = Button::with_label("PLACEHOLDER");


### PR DESCRIPTION
Currently when I have few windows open in firefox, it shows me options of windows to switch to when I mouseover. When mouse leaves (no click, move mouse down over entries, away from bar) its still there till I click on one of them.

Possibly related to #224.