### PR TITLE
ci: add jobs to label PRs on review/push

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,0 +1,20 @@
+name: PR Review
+on:
+  pull_request_review:
+
+jobs:
+  label_pr:
+    name: Label PR
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    if: github.event.pull_request.draft == false
+    steps:
+      - run: |
+          gh pr edit "$NUMBER" --remove-label "Z:Review Required"
+          gh pr edit "$NUMBER" --add-label "Z:Changes Requested"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/pr-update.yml
+++ b/.github/workflows/pr-update.yml
@@ -1,0 +1,20 @@
+name: PR Update
+on:
+  pull_request:
+
+jobs:
+  label_pr:
+    name: Label PR
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    if: github.event.pull_request.draft == false
+    steps:
+      - run: |
+          gh pr edit "$NUMBER" --add-label "Z:Review Required"
+          gh pr edit "$NUMBER" --remove-label "Z:Changes Requested"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
Add two new jobs: one that runs on PR push, and another that runs on PR review submission. These alternate the labels **Z:Review Required** and **Z:Changes Requested** to make it easier to track which PRs need attention.