### PR TITLE
fix(sway): fix keyboard layout update for sway

### DIFF
--- a/src/clients/compositor/sway.rs
+++ b/src/clients/compositor/sway.rs
@@ -225,7 +225,7 @@ impl TryFrom<InputEvent> for KeyboardLayoutUpdate {
 
     fn try_from(value: InputEvent) -> Result<Self, Self::Error> {
         match value.change {
-            InputChange::XkbLayout => {
+            InputChange::XkbLayout | InputChange::XkbKeymap => {
                 if let Some(layout) = value.input.xkb_active_layout_name {
                     Ok(KeyboardLayoutUpdate(layout))
                 } else {


### PR DESCRIPTION
This fixes parsing the keyboard layout update event in sway (using sway v1.9).

When using these commands to switch between layouts I didn't get any updates before.

```
swaymsg input "type:keyboard" xkb_layout de
swaymsg input "type:keyboard" xkb_layout en
```

Not sure why I get `XkbKeymap` instead of `XkbLayout` for this event. Will still try to find out more about this. But maybe a sway expert is available for review.