### PR TITLE
fix(tray): redraw icon when name or pixmap changes

### DIFF
--- a/src/modules/tray/mod.rs
+++ b/src/modules/tray/mod.rs
@@ -360,10 +360,13 @@ fn on_update(
                     icon_name,
                     icon_pixmap,
                 } => {
-                    menu_item.icon_pixmap = icon_pixmap;
+                    let name_changed = icon_name.as_ref() != menu_item.icon_name();
+                    let pixmap_changed = icon_pixmap != menu_item.icon_pixmap;
 
-                    if icon_name.as_ref() != menu_item.icon_name() {
+                    if name_changed || pixmap_changed {
+                        menu_item.icon_pixmap = icon_pixmap;
                         menu_item.set_icon_name(icon_name);
+
                         match icon::get_image(
                             menu_item,
                             icon_config.size,


### PR DESCRIPTION
### Summary
Redraw tray icons when either `IconName` or `IconPixmap` changes.

### Motivation
Some SNI clients (e.g. Electron apps, nm-applet) update only one of these fields or omit `IconPixmap`, which caused icons not to refresh.

### Notes
- Tested with nm-applet animation (high-frequency icon updates)
- Duplicate updates are filtered; no menu re-rendering observed
- `cargo build --no-default-features` emits existing dead-code warnings due to disabled features; no new warnings introduced

Fixes #1279
