### PR TITLE
feat(battery): allow config to show/hide icon or label

### DIFF
--- a/docs/modules/Battery.md
+++ b/docs/modules/Battery.md
@@ -17,6 +17,8 @@ Displays system power information such as the battery percentage, and estimated 
 | `format`     | `string`             | `{percentage}%` | Format string to use for the widget button label.                                                                                                    |
 | `icon_size`  | `integer`            | `24`            | Size to render icon at.                                                                                                                              |
 | `thresholds` | `Map<string, float>` | `{}`            | Map of threshold names to apply as classes against the percentage at which to apply them. The nearest value above the current percentage is applied. |
+| `show_icon`  | `boolean`            | `true`          | Whether to show the icon.                                                                                                                            |
+| `show_label` | `boolean`            | `true`          | Whether to show the label.                                                                                                                           |
 
 <details>
 <summary>JSON</summary>


### PR DESCRIPTION
Fixes: #1272

Hopefully that is what the author of the issue (@gurgelgubbe) wanted.

Examples:

```toml
[[end]]
type = "battery"
format = "BTR [{percentage}%]\n{state}"
show_label = false
```

<img width="1920" height="85" alt="screenshot-2025-12-20-14-31-33" src="https://github.com/user-attachments/assets/9b0e5a87-8a06-482d-9553-92f2ebc8b9a4" />

```toml
[[end]]
type = "battery"
format = "BTR [{percentage}%]\n{state}"
show_icon = false
```

<img width="1920" height="84" alt="screenshot-2025-12-20-14-30-07" src="https://github.com/user-attachments/assets/71c2cb84-10b3-4f4e-a073-a967e48aa4f2" />