### PR TITLE
feat(nix): add sccache to devshell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -44,6 +44,7 @@
             libinput
             libevdev
             luajit
+            sccache
             ;
           inherit (pkgs.luajitPackages) lgi;
         };


### PR DESCRIPTION
It's not _required_ to build ironbar, but if one does want to use it, then having to add it each time, having the flake.nix be dirty, checking if tools correctly have access to it, etc, is a minor annoyance, so given it's a small package I think it's easier to just add it.