### PR TITLE
fix(music): better seek behavior

### DIFF
--- a/src/modules/music/mod.rs
+++ b/src/modules/music/mod.rs
@@ -394,6 +394,20 @@ impl Module<Button> for MusicModule {
             let tx = context.controller_tx.clone();
             let was_dragging = Rc::new(Cell::new(false));
 
+            // Update progress label while dragging
+            let progress_label_clone = progress_label.clone();
+            progress.connect_value_changed(move |scale| {
+                if scale.has_css_class("dragging") {
+                    let value = scale.value();
+                    let range = scale.adjustment().upper();
+                    progress_label_clone.set_label_escaped(&format!(
+                        "{}/{}",
+                        format_time(Duration::from_secs_f64(value)),
+                        format_time(Duration::from_secs_f64(range))
+                    ));
+                }
+            });
+
             // Seek only when dragging ends (when "dragging" CSS class is removed)
             progress.connect_notify_local(Some("css-classes"), move |scale, _| {
                 let is_dragging = scale.has_css_class("dragging");
@@ -498,14 +512,12 @@ impl Module<Button> for MusicModule {
                     if let (Some(elapsed), Some(duration)) =
                         (progress_tick.elapsed, progress_tick.duration)
                     {
-                        progress_label.set_label_escaped(&format!(
-                            "{}/{}",
-                            format_time(elapsed),
-                            format_time(duration)
-                        ));
-
-                        // Don't update slider position while user is dragging
                         if !progress.has_css_class("dragging") {
+                            progress_label.set_label_escaped(&format!(
+                                "{}/{}",
+                                format_time(elapsed),
+                                format_time(duration)
+                            ));
                             progress.set_value(elapsed.as_secs_f64());
                             progress.set_range(0.0, duration.as_secs_f64());
                         }


### PR DESCRIPTION
Just seek on drag+release. This matches gtk3 ironbar and about every other player UI I tried. Also update elapsed/total duration according to the slider value when dragged.