### PR TITLE
fix(launcher): popup flicker when `popup_autohide` enabled

### DIFF
--- a/src/modules/launcher/mod.rs
+++ b/src/modules/launcher/mod.rs
@@ -5,7 +5,8 @@ mod pagination;
 use self::item::{AppearanceOptions, Item, ItemButton, Window};
 use self::open_state::OpenState;
 use super::{
-    Module, ModuleInfo, ModuleParts, ModulePopup, ModuleUpdateEvent, PopupButton, WidgetContext,
+    Module, ModuleInfo, ModuleParts, ModulePopup, ModulePopupParts, ModuleUpdateEvent, PopupButton,
+    WidgetContext,
 };
 use crate::channels::{AsyncSenderExt, BroadcastReceiverExt};
 use crate::clients::wayland::{self, ToplevelEvent};
@@ -595,7 +596,8 @@ impl Module<gtk::Box> for LauncherModule {
                     .values()
                     .find(|b| b.button.button.popup_id() == id)
                     .map(|b| b.button.button.clone())
-            }));
+            }))
+            .map(ModulePopupParts::disable_autohide);
 
         Ok(ModuleParts {
             widget: container,

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -198,8 +198,18 @@ pub struct ModulePopupParts {
     /// An array of buttons which can be used for opening the popup.
     /// For most modules, this will only be a single button.
     pub buttons: Vec<Button>,
+    /// Whether this module disallows the popover widget from using autohide.
+    /// Where popups are controlled via hover, autohide can cause issues.
+    pub disable_autohide: bool,
 
     pub button_finder: Option<Rc<ButtonFinder>>,
+}
+
+impl ModulePopupParts {
+    fn disable_autohide(mut self) -> Self {
+        self.disable_autohide = true;
+        self
+    }
 }
 
 impl Debug for ModulePopupParts {
@@ -229,6 +239,7 @@ impl ModulePopup for Option<gtk::Box> {
             container,
             buttons,
             button_finder: None,
+            disable_autohide: false,
         })
     }
 
@@ -237,6 +248,7 @@ impl ModulePopup for Option<gtk::Box> {
             container,
             buttons: vec![],
             button_finder: Some(finder),
+            disable_autohide: false,
         })
     }
 }


### PR DESCRIPTION
Enabling `popup_autohide` steals focus from the bar when the popup opens, causing the mouse exit event to trigger. This closes the popup, returning focus, triggering the enter event, opening the popup...

This adds a new option modules can set to disable popup autohide behaviour, and enables it for the launcher. As popup behaviour is controlled by mouse enter/exit and not clicks, this should have no drawbacks