### PR TITLE
fix(tray): Handle tray race + Event::Remove. Maybe: #1222

### DIFF
--- a/src/clients/tray.rs
+++ b/src/clients/tray.rs
@@ -61,6 +61,9 @@ impl Client {
                                 entry.menu = Some(menu.clone());
                             }
                         }
+                        Event::Remove(address) => {
+                            lock!(menus).remove(address.as_str());
+                        }
                         _ => {}
                     }
 


### PR DESCRIPTION
1. Fixed UI Duplicate Bug: src/modules/tray/mod.rs to handle duplicate Event::Add messages from snapshot + subscription.
2. Fixed Client Memory Leak: src/clients/tray.rs process Event::Remove.

Possible fix for #1222 - hard to say since I see different manifestation