### PR TITLE
fix(inhibit): Replace infinity symbol with nerd font for readability

### DIFF
--- a/src/modules/inhibit/mod.rs
+++ b/src/modules/inhibit/mod.rs
@@ -25,7 +25,7 @@ pub struct State {
 
 fn format_duration(d: Duration) -> String {
     if d == Duration::MAX {
-        return "∞".to_string();
+        return "".to_string();
     }
     let s = d.as_secs();
     let (h, m, s) = (s / 3600, s % 3600 / 60, s % 60);


### PR DESCRIPTION
The unicode symbol is too small in hindsight.