### PR TITLE
fix(examples): wrong battery detection logic in some config files

### DIFF
--- a/examples/desktop/config.corn
+++ b/examples/desktop/config.corn
@@ -4,7 +4,7 @@ let {
     $launcher = { type = "launcher" favorites = [ "firefox" ] truncate.mode = "end" truncate.max_length = 30 }
 
     $music = { type = "music" player_type = "mpd" }
-    $battery = { type = "battery" show_if = "[ -f /sys/class/power_supply/BAT0 ]" }
+    $battery = { type = "battery" show_if = "ls /sys/class/power_supply/ | grep --quiet '^BAT'" }
     $sys_info = { type = "sys_info" format = ["{cpu_percent}% " "{memory_percent}% "] interval.cpu = 1 }
     $clipboard = { type = "clipboard" max_items = 5 truncate.mode = "end" truncate.length = 30 }
     $volume = { type = "volume" }

--- a/examples/desktop/config.json
+++ b/examples/desktop/config.json
@@ -28,7 +28,7 @@
   "end": [
     {
       "type": "battery",
-      "show_if": "[ -f /sys/class/power_supply/BAT0 ]"
+      "show_if": "ls /sys/class/power_supply/ | grep --quiet '^BAT'"
     },
     {
       "type": "sys_info",

--- a/examples/desktop/config.toml
+++ b/examples/desktop/config.toml
@@ -21,7 +21,7 @@ player_type = "mpd"
 
 [[end]]
 type = "battery"
-show_if = "[ -f /sys/class/power_supply/BAT0 ]"
+show_if = "ls /sys/class/power_supply/ | grep --quiet '^BAT'"
 
 [[end]]
 type = "sys_info"

--- a/examples/desktop/config.yaml
+++ b/examples/desktop/config.yaml
@@ -14,7 +14,8 @@ center:
   player_type: mpd
 end:
 - type: battery
-  show_if: '[ -f /sys/class/power_supply/BAT0 ]'
+  show_if: |
+    ls /sys/class/power_supply/ | grep --quiet '^BAT'
 - type: sys_info
   format:
   - '{cpu_percent}% '

--- a/examples/minimal/config.corn
+++ b/examples/minimal/config.corn
@@ -3,7 +3,7 @@ let {
 
     $focused = { type = "focused" icon_size = 16 }
 
-    $battery = { type = "battery" show_if = "[ -f /sys/class/power_supply/BAT0 ]" }
+    $battery = { type = "battery" show_if = "ls /sys/class/power_supply/ | grep --quiet '^BAT'" }
     $sys_info = { type = "sys_info" format = ["{cpu_percent}% " "{memory_percent}% "] interval.cpu = 1 }
     $tray = { type = "tray" }
     $clock = { type = "clock" }

--- a/examples/minimal/config.json
+++ b/examples/minimal/config.json
@@ -15,7 +15,7 @@
   "end": [
     {
       "type": "battery",
-      "show_if": "[ -f /sys/class/power_supply/BAT0 ]"
+      "show_if": "ls /sys/class/power_supply/ | grep --quiet '^BAT'"
     },
     {
       "type": "sys_info",

--- a/examples/minimal/config.toml
+++ b/examples/minimal/config.toml
@@ -10,7 +10,7 @@ icon_size = 16
 
 [[end]]
 type = "battery"
-show_if = "[ -f /sys/class/power_supply/BAT0 ]"
+show_if = "ls /sys/class/power_supply/ | grep --quiet '^BAT'"
 
 [[end]]
 type = "sys_info"

--- a/examples/minimal/config.yaml
+++ b/examples/minimal/config.yaml
@@ -7,7 +7,8 @@ center:
   icon_size: 16
 end:
 - type: battery
-  show_if: '[ -f /sys/class/power_supply/BAT0 ]'
+  show_if: |
+    ls /sys/class/power_supply/ | grep --quiet '^BAT'
 - type: sys_info
   format:
   - '{cpu_percent}% '


### PR DESCRIPTION
The current used condition is `[ -f /sys/class/power_supply/BAT0 ]` always returns `1` (exit code) as `/sys/class/power_supply/BAT0` is a directory, not a file. It seems to be a omission because I notice you mentioned the corrected command in #698.

However, it still doesn't work with my laptop. There's only one internal battery, and it's labeled as `BAT1` rather than `BAT0`.

<details>
<summary>Some checks:</summary>

  ```cmd
  > ls /sys/class/power_supply
  ACAD  BAT1
  
  > sudo dmesg | grep 'BAT'                                                                            
  [    0.466610] ACPI: battery: Slot [BAT1] (battery present)
  
  > upower -e                                              
  /org/freedesktop/UPower/devices/battery_BAT1
  /org/freedesktop/UPower/devices/line_power_ACAD
  /org/freedesktop/UPower/devices/DisplayDevice
  ```
</details>

Thus, I suggest another check condition to make it work:
```
ls /sys/class/power_supply/ | grep --quiet '^BAT'
```

(Additional affected file: [docs](https://github.com/JakeStanger/ironbar/blob/112ff0fb2989e1bb536840b44a85c843c94fe5b9/docs/Dynamic%20values.md?plain=1#L60))