### PR TITLE
feat(config): dynamic hot reloading

### DIFF
--- a/docs/Configuration guide.md
+++ b/docs/Configuration guide.md
@@ -300,6 +300,9 @@ The following table lists each of the top-level bar config options:
 | `icon_theme`        | `string`                                | `null`  | Name of the GTK icon theme to use. Leave blank to use default.                                                                 |
 | `icon_overrides`    | `Map<string, string>`                   | `{}`    | Map of image inputs to override names. Usually used for app IDs (or classes) to icon names, overriding the app's default icon. |
 | `double_click_time` | `integer` or `"gtk"`                    | `250`   | Time in milliseconds to wait for a double-click. Set to `"gtk"` to use GTK's setting.                                          |
+| `hot_reload`        | `boolean` or `HotReload`                | `true`  | Whether to hot-reload config and style changes. Can also take object format to toggle separately.                              |
+| `hot_reload.config` | `boolean`                               | `true`  | Whether to hot-reload config changes.                                                                                          |
+| `hot_reload.style`  | `boolean`                               | `true`  | Whether to hot-reload style changes.                                                                                           |
 
 > [!TIP]
 > `monitors` is only required if you are following **2b** or **2c** (ie not the same bar across all monitors).

--- a/docs/Development guide.md
+++ b/docs/Development guide.md
@@ -235,7 +235,7 @@ When the `extras` feature is enabled, it must also derive `schemars::JsonSchema`
 An extract of the Clock module is shown below as an example:
 
 ```rust
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, PartialEq)]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct ClockModule {

--- a/src/clients/outputs.rs
+++ b/src/clients/outputs.rs
@@ -75,14 +75,14 @@ impl MonitorProxy {
                 tx.send_expect(MonitorEvent {
                     connector: self.connector.clone(),
                     state: MonitorState::Disconnected,
-                })
+                });
             }
             InternalMonitorState::BothConnected(wl_output, gdk_output) => {
                 info!("Monitor {} connected", self.connector);
                 tx.send_expect(MonitorEvent {
                     connector: self.connector.clone(),
                     state: MonitorState::Connected(wl_output.clone(), gdk_output.clone()),
-                })
+                });
             }
             _ => {}
         }
@@ -112,7 +112,7 @@ impl Client {
         }
     }
 
-    pub(crate) fn start(&self, ironbar: &Rc<Ironbar>) {
+    pub(crate) fn start(&self, ironbar: Rc<Ironbar>) {
         let mut rx_wl_outputs = ironbar.clients.borrow_mut().wayland().subscribe_outputs();
 
         let monitors = arc_mut!(HashMap::new());
@@ -133,13 +133,13 @@ impl Client {
                         });
                         match event.event_type {
                             wayland::OutputEventType::New => {
-                                entry.connect_wayland(&event.output).maybe_send(&output_tx)
+                                entry.connect_wayland(&event.output).maybe_send(&output_tx);
                             }
                             wayland::OutputEventType::Destroyed => {
-                                entry.disconnect().maybe_send(&output_tx)
+                                entry.disconnect().maybe_send(&output_tx);
                             }
                             wayland::OutputEventType::Update => {}
-                        };
+                        }
                     }
                 }
             });

--- a/src/config/common.rs
+++ b/src/config/common.rs
@@ -19,7 +19,7 @@ use tracing::trace;
 /// For information on the Script type, and embedding scripts in strings,
 /// see [here](script).
 /// For information on styling, please see the [styling guide](styling-guide).
-#[derive(Debug, Default, Deserialize, Clone)]
+#[derive(Debug, Default, Deserialize, Clone, PartialEq)]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 pub struct CommonConfig {
     /// Sets the unique widget name,
@@ -208,7 +208,7 @@ pub struct CommonConfig {
     pub disable_popup: bool,
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 pub enum TransitionType {
@@ -218,7 +218,7 @@ pub enum TransitionType {
     SlideEnd,
 }
 
-#[derive(Debug, Default, Deserialize, Clone, Copy)]
+#[derive(Debug, Default, Deserialize, Clone, Copy, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 pub enum ModuleOrientation {
@@ -247,7 +247,7 @@ impl From<ModuleOrientation> for Orientation {
     }
 }
 
-#[derive(Debug, Default, Deserialize, Clone, Copy)]
+#[derive(Debug, Default, Deserialize, Clone, Copy, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 pub enum ModuleJustification {

--- a/src/config/diff.rs
+++ b/src/config/diff.rs
@@ -1,0 +1,215 @@
+use super::{BarConfig, Config, MonitorConfig};
+use std::collections::HashMap;
+
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
+pub enum Diff<T> {
+    Added,
+    Removed,
+    Updated(T),
+    #[default]
+    NoChange,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ConfigDiff {
+    pub icon_theme: Diff<()>,
+    pub bar_diff: Diff<BarDiff>,
+    pub monitor_diff: Diff<MonitorDiffDetails>,
+}
+
+#[derive(Debug, Clone)]
+pub enum MonitorDiff {
+    Recreate,
+    UpdateSingle(BarDiff),
+    UpdateMultiple(Vec<BarDiff>),
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct MonitorDiffDetails {
+    pub added: Vec<String>,
+    pub removed: Vec<String>,
+    pub updated: HashMap<String, MonitorDiff>,
+}
+
+impl MonitorDiffDetails {
+    fn is_empty(&self) -> bool {
+        self.added.is_empty() && self.removed.is_empty() && self.updated.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum BarDiff {
+    Recreate,
+    Reload(BarDiffDetails),
+}
+
+impl BarDiff {
+    fn is_empty(&self) -> bool {
+        match self {
+            BarDiff::Recreate => false,
+            BarDiff::Reload(diff) => diff.is_empty(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct BarDiffDetails {
+    pub start: Vec<usize>,
+    pub center: Vec<usize>,
+    pub end: Vec<usize>,
+}
+
+impl BarDiffDetails {
+    fn is_empty(&self) -> bool {
+        self.start.is_empty() && self.center.is_empty() && self.end.is_empty()
+    }
+}
+
+impl ConfigDiff {
+    pub fn diff(old: &Config, new: &Config) -> ConfigDiff {
+        let mut diff = ConfigDiff::default();
+
+        if old.icon_theme != new.icon_theme {
+            diff.icon_theme = Diff::Updated(());
+        }
+
+        diff.bar_diff = {
+            let diff = BarDiff::diff(&old.bar, &new.bar);
+            if diff.is_empty() {
+                Diff::NoChange
+            } else {
+                Diff::Updated(diff)
+            }
+        };
+
+        diff.monitor_diff = match (&old.monitors, &new.monitors) {
+            (Some(old_monitors), Some(new_monitors)) => {
+                if old_monitors == new_monitors {
+                    Diff::NoChange
+                } else {
+                    let mut diff = MonitorDiffDetails::default();
+
+                    for (old_key, old) in old_monitors {
+                        if let Some(new) = new_monitors.get(old_key) {
+                            let monitor_diff = MonitorDiff::diff(old, new);
+                            diff.updated.insert(old_key.clone(), monitor_diff);
+                        } else {
+                            diff.removed.push(old_key.clone());
+                        }
+                    }
+
+                    for new_key in new_monitors.keys() {
+                        if !old_monitors.contains_key(new_key) {
+                            diff.added.push(new_key.clone());
+                        }
+                    }
+
+                    if diff.is_empty() {
+                        Diff::NoChange
+                    } else {
+                        Diff::Updated(diff)
+                    }
+                }
+            }
+            (Some(_), None) => Diff::Removed,
+            (None, Some(_)) => Diff::Added,
+            (None, None) => Diff::NoChange,
+        };
+
+        diff
+    }
+}
+
+impl MonitorDiff {
+    fn diff(old: &MonitorConfig, new: &MonitorConfig) -> Self {
+        match (old, new) {
+            (MonitorConfig::Single(old), MonitorConfig::Single(new)) => {
+                Self::UpdateSingle(BarDiff::diff(old, new))
+            }
+            (MonitorConfig::Multiple(old_bars), MonitorConfig::Multiple(new_bars)) => {
+                if old_bars.len() == new_bars.len() {
+                    let diffs = old_bars
+                        .iter()
+                        .zip(new_bars)
+                        .map(|(old, new)| BarDiff::diff(old, new))
+                        .collect();
+
+                    Self::UpdateMultiple(diffs)
+                } else {
+                    Self::Recreate
+                }
+            }
+            _ => Self::Recreate,
+        }
+    }
+}
+
+impl BarDiff {
+    pub fn diff(old: &BarConfig, new: &BarConfig) -> Self {
+        let start_len_eq = old.start.as_ref().map(Vec::len).unwrap_or_default()
+            == new.start.as_ref().map(Vec::len).unwrap_or_default();
+
+        let center_len_eq = old.center.as_ref().map(Vec::len).unwrap_or_default()
+            == new.center.as_ref().map(Vec::len).unwrap_or_default();
+
+        let end_len_eq = old.end.as_ref().map(Vec::len).unwrap_or_default()
+            == new.end.as_ref().map(Vec::len).unwrap_or_default();
+
+        // TODO: Don't like that this needs manually maintaining
+        let recreate_required = old.autohide != new.autohide
+            || old.popup_autohide != new.popup_autohide
+            || old.anchor_to_edges != new.anchor_to_edges
+            || old.exclusive_zone != new.exclusive_zone
+            || old.start_hidden != new.start_hidden
+            || old.position != new.position
+            || old.height != new.height
+            || old.layer != new.layer
+            || old.name != new.name
+            || old.popup_gap != new.popup_gap
+            || old.margin != new.margin
+            || !start_len_eq
+            || !center_len_eq
+            || !end_len_eq;
+
+        if recreate_required {
+            BarDiff::Recreate
+        } else {
+            let mut diff = BarDiffDetails::default();
+
+            if let (Some(modules_old), Some(modules_new)) = (old.start.as_ref(), new.start.as_ref())
+            {
+                diff.start = modules_old
+                    .iter()
+                    .zip(modules_new)
+                    .enumerate()
+                    .filter(|(_, (old, new))| old != new)
+                    .map(|(i, _)| i)
+                    .collect();
+            }
+
+            if let (Some(modules_old), Some(modules_new)) =
+                (old.center.as_ref(), new.center.as_ref())
+            {
+                diff.center = modules_old
+                    .iter()
+                    .zip(modules_new)
+                    .enumerate()
+                    .filter(|(_, (old, new))| old != new)
+                    .map(|(i, _)| i)
+                    .collect();
+            }
+
+            if let (Some(modules_old), Some(modules_new)) = (old.end.as_ref(), new.end.as_ref()) {
+                diff.end = modules_old
+                    .iter()
+                    .zip(modules_new)
+                    .enumerate()
+                    .filter(|(_, (old, new))| old != new)
+                    .map(|(i, _)| i)
+                    .collect();
+            }
+
+            BarDiff::Reload(diff)
+        }
+    }
+}

--- a/src/config/hot_reload.rs
+++ b/src/config/hot_reload.rs
@@ -1,0 +1,287 @@
+use crate::bar::create_bar;
+use crate::channels::{AsyncSenderExt, MpscReceiverExt};
+use crate::config::diff::{BarDiff, ConfigDiff, Diff, MonitorDiff};
+use crate::config::{BarConfig, Config, MonitorConfig};
+use crate::{Ironbar, find_monitor_for_output, load_output_bars_for, spawn};
+use gtk::Application;
+use gtk::gdk::Monitor;
+use notify::event::{DataChange, ModifyKind};
+use notify::{Event, EventKind, Result, Watcher, recommended_watcher};
+use smithay_client_toolkit::output::OutputInfo;
+use std::cell::RefCell;
+use std::path::Path;
+use std::rc::Rc;
+use tracing::{debug, error, info};
+
+pub fn install(path: &Path, app: &Application, ironbar: &Rc<Ironbar>) {
+    let (tx, rx) = tokio::sync::mpsc::channel(8);
+
+    spawn({
+        let path = path.to_path_buf();
+        let dir_path = path
+            .parent()
+            .expect("parent path should exist")
+            .to_path_buf();
+
+        async move {
+            let is_conf_change = move |event: &Event| {
+                event
+                    .paths
+                    .first()
+                    .is_some_and(|p| p.file_stem() == path.file_stem())
+                    && event.kind == EventKind::Modify(ModifyKind::Data(DataChange::Any))
+            };
+
+            let watcher = recommended_watcher(move |res: Result<Event>| match res {
+                Ok(event) if is_conf_change(&event) => {
+                    tx.send_spawn(());
+                }
+                Ok(_) => {}
+                Err(err) => error!("{err:?}"),
+            });
+
+            let Ok(mut watcher) = watcher else {
+                error!("failed to start config watcher");
+                return;
+            };
+
+            if let Err(err) = watcher.watch(&dir_path, notify::RecursiveMode::NonRecursive) {
+                error!("{err:?}");
+            }
+
+            // avoid watcher from dropping
+            loop {
+                tokio::time::sleep(core::time::Duration::from_secs(1)).await;
+            }
+        }
+    });
+
+    let wl = ironbar.clients.borrow_mut().wayland();
+    let outputs = wl.output_info_all();
+
+    let ironbar = ironbar.clone();
+
+    rx.recv_glib(app, move |app, ()| {
+        let old_config = <RefCell<Config> as Clone>::clone(&ironbar.config).into_inner();
+
+        ironbar.reload_config();
+
+        let new_config = ironbar.config.clone();
+
+        let diff = ConfigDiff::diff(&old_config, &new_config.borrow());
+
+        // TODO: handle other changes (icon theme, ...)
+
+        let apply_bar_diff = {
+            let ironbar = ironbar.clone();
+
+            move |diff: BarDiff,
+                  position: usize,
+                  bar_config: BarConfig,
+                  mon_name: &str,
+                  monitor: &Monitor| {
+                let mut bars = ironbar.bars.borrow_mut();
+                let Some(bar) = bars.get_mut(position) else {
+                    error!("failed to find bar for monitor {mon_name}");
+                    return;
+                };
+
+                debug!(
+                    "updating single bar for {mon_name} (bar={}) | {diff:?}",
+                    bar.name()
+                );
+
+                match diff {
+                    BarDiff::Recreate => {
+                        info!("recreating bar {}", bar.name());
+
+                        let new_bar = create_bar(
+                            app,
+                            monitor,
+                            mon_name.to_string(),
+                            bar_config,
+                            ironbar.clone(),
+                        );
+
+                        let old = std::mem::replace(bar, new_bar);
+                        old.close();
+                    }
+                    BarDiff::Reload(diff) => {
+                        info!("hot-reloading bar {}", bar.name());
+
+                        bar.apply_diff(diff, bar_config, monitor);
+                    }
+                }
+            }
+        };
+
+        if let Diff::Updated(bar_diff) = diff.bar_diff {
+            let config = &new_config.borrow().bar;
+
+            for output in &outputs {
+                let mon_name = output.name.clone().unwrap_or_default();
+
+                let Some(monitor) = find_monitor_for_output(output) else {
+                    error!("failed to find matching monitor for {mon_name}");
+                    continue;
+                };
+
+                let Some(position) = ironbar
+                    .bars
+                    .borrow()
+                    .iter()
+                    .position(|b| b.monitor_name() == mon_name)
+                else {
+                    error!("failed to find bar for monitor {mon_name}");
+                    continue;
+                };
+
+                apply_bar_diff(
+                    bar_diff.clone(),
+                    position,
+                    config.clone(),
+                    &mon_name,
+                    &monitor,
+                );
+            }
+
+            // TODO - apply diff to every monitor
+        }
+
+        if let Diff::Updated(monitor_diff) = diff.monitor_diff {
+            let add = |output: &OutputInfo, monitor: &Monitor| match load_output_bars_for(
+                &ironbar, app, output, monitor,
+            ) {
+                Ok(mut bars) => ironbar.bars.borrow_mut().append(&mut bars),
+                Err(err) => error!("{err:?}"),
+            };
+
+            let remove = |name: &str| {
+                let to_remove = ironbar.bars_by_monitor_name(name);
+
+                ironbar
+                    .bars
+                    .borrow_mut()
+                    .retain(|b| b.monitor_name() != name);
+
+                for bar in to_remove {
+                    bar.close();
+                }
+            };
+
+            for added in monitor_diff.added {
+                let Some(output) = outputs.iter().find(|&output| {
+                    output.name.clone().unwrap_or_default() == added
+                        || output
+                            .description
+                            .clone()
+                            .unwrap_or_default()
+                            .starts_with(&added)
+                }) else {
+                    error!("failed to find output for '{added}'");
+                    continue;
+                };
+
+                let Some(monitor) = find_monitor_for_output(output) else {
+                    error!("failed to find matching monitor for {added}");
+                    continue;
+                };
+
+                add(output, &monitor);
+            }
+
+            for removed in monitor_diff.removed {
+                remove(&removed);
+            }
+
+            for (mon_name, diff) in monitor_diff.updated {
+                let Some(output) = outputs.iter().find(|&output| {
+                    output.name.clone().unwrap_or_default() == mon_name
+                        || output
+                            .description
+                            .clone()
+                            .unwrap_or_default()
+                            .starts_with(&mon_name)
+                }) else {
+                    error!("failed to find output for '{mon_name}'");
+                    continue;
+                };
+
+                let Some(monitor) = find_monitor_for_output(output) else {
+                    error!("failed to find matching monitor for {mon_name}");
+                    continue;
+                };
+
+                match diff {
+                    MonitorDiff::Recreate => {
+                        info!("Recreating all bars for {mon_name}");
+                        remove(&mon_name);
+                        add(output, &monitor);
+                    }
+                    MonitorDiff::UpdateSingle(diff) => {
+                        let Some(position) = ironbar
+                            .bars
+                            .borrow()
+                            .iter()
+                            .position(|b| b.monitor_name() == mon_name)
+                        else {
+                            error!("failed to find bar for monitor {mon_name}");
+                            continue;
+                        };
+
+                        let Some(bar_config) = new_config
+                            .borrow()
+                            .monitors
+                            .as_ref()
+                            .and_then(|monitors| monitors.get(&mon_name))
+                            .map(|config| match config {
+                                MonitorConfig::Single(config) => config.clone(),
+                                MonitorConfig::Multiple(_) => unreachable!(),
+                            })
+                        else {
+                            error!("failed to find config for bar on {mon_name}");
+                            return;
+                        };
+
+                        apply_bar_diff(diff, position, bar_config, &mon_name, &monitor);
+                    }
+                    MonitorDiff::UpdateMultiple(diffs) => {
+                        debug!("Updating multiple bars for {mon_name} | {diffs:?}");
+
+                        let positions = ironbar
+                            .bars
+                            .borrow()
+                            .iter()
+                            .enumerate()
+                            .filter_map(|(i, bar)| {
+                                if bar.monitor_name() == mon_name {
+                                    Some(i)
+                                } else {
+                                    None
+                                }
+                            })
+                            .collect::<Vec<_>>();
+
+                        for (i, (diff, position)) in diffs.into_iter().zip(positions).enumerate() {
+                            let Some(bar_config) = new_config
+                                .borrow()
+                                .monitors
+                                .as_ref()
+                                .and_then(|monitors| monitors.get(&mon_name))
+                                .and_then(|config| match config {
+                                    MonitorConfig::Single(_) => unreachable!(),
+                                    MonitorConfig::Multiple(configs) => configs.get(i).cloned(),
+                                })
+                            else {
+                                error!("failed to find config for bar on {mon_name}");
+                                return;
+                            };
+
+                            apply_bar_diff(diff, position, bar_config, &mon_name, &monitor);
+                        }
+                    }
+                }
+            }
+        }
+    });
+}

--- a/src/config/layout.rs
+++ b/src/config/layout.rs
@@ -2,7 +2,7 @@ use crate::config::{ModuleJustification, ModuleOrientation};
 use crate::modules::ModuleInfo;
 use serde::Deserialize;
 
-#[derive(Clone, Debug, Deserialize, Default)]
+#[derive(Clone, Debug, Deserialize, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 pub struct LayoutConfig {
     /// The orientation to display the widget contents.

--- a/src/config/marquee.rs
+++ b/src/config/marquee.rs
@@ -18,7 +18,7 @@ pub enum MarqueeOnHover {
 /// This is controlled using a common `MarqueeMode` type,
 /// which is defined below.
 ///
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, PartialEq)]
 #[serde(default)]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 pub struct MarqueeMode {

--- a/src/config/profiles.rs
+++ b/src/config/profiles.rs
@@ -87,7 +87,7 @@ impl State for f64 {}
 /// to the field to avoid `profiles.profiles` syntax.
 ///
 /// `S` = State, `T` = Configuration data.
-#[derive(Debug, Default, Clone, Deserialize)]
+#[derive(Debug, Default, Clone, Deserialize, PartialEq)]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct Profiles<S, T>
@@ -109,7 +109,7 @@ where
 /// Serde will attempt to match in order,
 /// which will incorrectly resolve all objects as `Simple`
 /// due to `Default` constraint.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, PartialEq)]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 #[serde(untagged)]
 pub enum ProfileEntry<S, T>
@@ -162,7 +162,7 @@ where
 /// An individual profile.
 /// This represents the threshold at which it should be activated,
 /// and the configuration associated with it.
-#[derive(Debug, Default, Clone, Deserialize)]
+#[derive(Debug, Default, Clone, Deserialize, PartialEq)]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 pub struct Profile<S, T>
 where

--- a/src/config/truncate.rs
+++ b/src/config/truncate.rs
@@ -1,7 +1,7 @@
 use gtk::pango::EllipsizeMode as GtkEllipsizeMode;
 use serde::Deserialize;
 
-#[derive(Debug, Deserialize, Clone, Copy, Default)]
+#[derive(Debug, Deserialize, Clone, Copy, Default, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 pub enum EllipsizeMode {
@@ -31,7 +31,7 @@ impl From<EllipsizeMode> for GtkEllipsizeMode {
 ///
 /// **Default**: `Auto (end)`
 ///
-#[derive(Debug, Deserialize, Clone, Copy)]
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
 #[serde(untagged)]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 pub enum TruncateMode {

--- a/src/dynamic_value/dynamic_bool.rs
+++ b/src/dynamic_value/dynamic_bool.rs
@@ -7,7 +7,7 @@ use cfg_if::cfg_if;
 use serde::Deserialize;
 use tokio::sync::mpsc;
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, PartialEq)]
 #[serde(untagged)]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 pub enum DynamicBool {

--- a/src/ipc/server/bar.rs
+++ b/src/ipc/server/bar.rs
@@ -2,9 +2,8 @@ use super::Response;
 use crate::Ironbar;
 use crate::bar::Bar;
 use crate::ipc::{BarCommand, BarCommandType};
-use std::rc::Rc;
 
-pub fn handle_command(command: &BarCommand, ironbar: &Rc<Ironbar>) -> Response {
+pub fn handle_command(command: &BarCommand, ironbar: &Ironbar) -> Response {
     use BarCommandType::*;
 
     let bars = ironbar.bars_by_name(&command.name);

--- a/src/ipc/server/style.rs
+++ b/src/ipc/server/style.rs
@@ -9,7 +9,8 @@ pub fn handle_command(command: StyleCommand, ironbar: &Ironbar) -> Response {
     match command {
         StyleCommand::LoadCss { path } => {
             if path.exists() {
-                load_css(&CssSource::File(path));
+                let hot_reload = ironbar.config.borrow().hot_reload.is_styles_enabled();
+                load_css(&CssSource::File(path), hot_reload);
                 Response::Ok
             } else {
                 Response::error("File not found")

--- a/src/modules/battery.rs
+++ b/src/modules/battery.rs
@@ -55,7 +55,7 @@ impl State for ProfileState {
     }
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, PartialEq)]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 #[serde(default)]
 struct BatteryProfile {
@@ -66,7 +66,7 @@ struct BatteryProfile {
     format: String,
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, PartialEq)]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct BatteryModule {

--- a/src/modules/bindmode.rs
+++ b/src/modules/bindmode.rs
@@ -11,7 +11,7 @@ use serde::Deserialize;
 use tokio::sync::mpsc;
 use tracing::{info, trace};
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, PartialEq)]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 pub struct Bindmode {
     // -- Common --

--- a/src/modules/bluetooth/config.rs
+++ b/src/modules/bluetooth/config.rs
@@ -5,7 +5,7 @@ use crate::{
     config::CommonConfig,
 };
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, PartialEq)]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct BluetoothModule {
@@ -44,7 +44,7 @@ impl Default for BluetoothModule {
     }
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, PartialEq)]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct FormatConfig {
@@ -86,7 +86,7 @@ impl Default for FormatConfig {
     }
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 #[serde(rename_all = "lowercase")]
 pub enum SizeLimit {
@@ -94,7 +94,7 @@ pub enum SizeLimit {
     Pixels(i32),
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, PartialEq)]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct PopupConfig {
@@ -130,7 +130,7 @@ impl Default for PopupConfig {
     }
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, PartialEq)]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct AdapterStatus {
@@ -172,7 +172,7 @@ impl Default for AdapterStatus {
     }
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, PartialEq)]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct DeviceStatus {
@@ -208,7 +208,7 @@ impl Default for DeviceStatus {
     }
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, PartialEq)]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct PopupDeviceConfig {

--- a/src/modules/brightness.rs
+++ b/src/modules/brightness.rs
@@ -14,7 +14,7 @@ use serde::Deserialize;
 use tokio::sync::mpsc;
 use tokio::time::sleep;
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum BrightnessDataSource {
@@ -34,7 +34,7 @@ pub enum BrightnessDataSource {
     },
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct BrightnessProfile {
@@ -85,7 +85,7 @@ fn default_profiles() -> Profiles<f64, BrightnessProfile> {
     )
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, PartialEq)]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct BrightnessModule {

--- a/src/modules/cairo.rs
+++ b/src/modules/cairo.rs
@@ -17,7 +17,7 @@ use tokio::sync::mpsc::Receiver;
 use tokio::time::sleep;
 use tracing::{debug, error};
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, PartialEq)]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct CairoModule {

--- a/src/modules/clipboard.rs
+++ b/src/modules/clipboard.rs
@@ -18,7 +18,7 @@ use std::ops::Deref;
 use tokio::sync::mpsc;
 use tracing::{debug, error};
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, PartialEq)]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct ClipboardModule {

--- a/src/modules/clock.rs
+++ b/src/modules/clock.rs
@@ -15,7 +15,7 @@ use crate::modules::{
 };
 use crate::{module_impl, spawn};
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, PartialEq)]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct ClockModule {

--- a/src/modules/custom/box.rs
+++ b/src/modules/custom/box.rs
@@ -5,7 +5,7 @@ use crate::modules::custom::WidgetConfig;
 use gtk::prelude::*;
 use serde::Deserialize;
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 pub enum ModuleAlignment {
@@ -30,7 +30,7 @@ impl From<ModuleAlignment> for gtk::Align {
     }
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, PartialEq)]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 pub struct BoxWidget {
     /// Widget name.

--- a/src/modules/custom/button.rs
+++ b/src/modules/custom/button.rs
@@ -10,7 +10,7 @@ use crate::dynamic_value::dynamic_string;
 use crate::gtk_helpers::IronbarLabelExt;
 use crate::modules::PopupButton;
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, PartialEq)]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 pub struct ButtonWidget {
     /// Widget name.

--- a/src/modules/custom/image.rs
+++ b/src/modules/custom/image.rs
@@ -6,7 +6,7 @@ use gtk::prelude::*;
 use gtk::{ContentFit, Picture};
 use serde::Deserialize;
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, PartialEq)]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct ImageWidget {

--- a/src/modules/custom/label.rs
+++ b/src/modules/custom/label.rs
@@ -8,7 +8,7 @@ use crate::config::{LayoutConfig, TruncateMode};
 use crate::dynamic_value::dynamic_string;
 use crate::gtk_helpers::IronbarLabelExt;
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, PartialEq)]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 pub struct LabelWidget {
     /// Widget name.

--- a/src/modules/custom/mod.rs
+++ b/src/modules/custom/mod.rs
@@ -28,7 +28,7 @@ use std::rc::Rc;
 use tokio::sync::mpsc;
 use tracing::{debug, error};
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, PartialEq)]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 pub struct CustomModule {
     /// Modules and widgets to add to the bar container.
@@ -46,7 +46,7 @@ pub struct CustomModule {
     pub common: Option<CommonConfig>,
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, PartialEq)]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 pub struct WidgetConfig {
     /// One of a custom module native Ironbar module.
@@ -58,7 +58,7 @@ pub struct WidgetConfig {
     common: CommonConfig,
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, PartialEq)]
 #[serde(untagged)]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 pub enum WidgetOrModule {
@@ -69,7 +69,7 @@ pub enum WidgetOrModule {
     Module(ModuleConfig),
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, PartialEq)]
 #[serde(tag = "type", rename_all = "snake_case")]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 pub enum Widget {

--- a/src/modules/custom/progress.rs
+++ b/src/modules/custom/progress.rs
@@ -12,7 +12,7 @@ use crate::modules::custom::set_length;
 use crate::script::{OutputStream, Script, ScriptInput};
 use crate::{build, spawn};
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, PartialEq)]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct ProgressWidget {

--- a/src/modules/custom/slider.rs
+++ b/src/modules/custom/slider.rs
@@ -15,7 +15,7 @@ use crate::modules::custom::set_length;
 use crate::script::{OutputStream, Script, ScriptInput};
 use crate::{build, spawn};
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, PartialEq)]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct SliderWidget {

--- a/src/modules/focused.rs
+++ b/src/modules/focused.rs
@@ -11,7 +11,7 @@ use serde::Deserialize;
 use tokio::sync::mpsc;
 use tracing::debug;
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, PartialEq)]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct FocusedModule {

--- a/src/modules/inhibit/config.rs
+++ b/src/modules/inhibit/config.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 /// Command to control inhibit state.
 ///
 /// **Valid options**: `toggle`, `cycle`
-#[derive(Debug, Clone, Copy, Deserialize)]
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 #[serde(rename_all = "lowercase")]
 pub enum InhibitCommand {
@@ -17,7 +17,7 @@ pub enum InhibitCommand {
     Cycle,
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, PartialEq)]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct InhibitModule {
@@ -97,7 +97,7 @@ fn parse_duration(s: &str) -> Result<Duration, String> {
         .map(|time| Duration::from_secs(time.num_seconds_from_midnight() as u64))
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 pub(super) struct DurationSpec {
     #[cfg_attr(feature = "extras", schemars(with = "Vec<String>"))]

--- a/src/modules/keyboard.rs
+++ b/src/modules/keyboard.rs
@@ -14,7 +14,7 @@ use crate::config::{CommonConfig, LayoutConfig};
 use crate::image::{IconButton, IconLabel};
 use crate::{module_impl, spawn};
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, PartialEq)]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct KeyboardModule {
@@ -80,7 +80,7 @@ impl Default for KeyboardModule {
     }
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, PartialEq)]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 #[serde(default)]
 struct Icons {

--- a/src/modules/label.rs
+++ b/src/modules/label.rs
@@ -9,7 +9,7 @@ use gtk::Label;
 use serde::Deserialize;
 use tokio::sync::mpsc;
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, PartialEq)]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 pub struct LabelModule {
     /// The text to show on the label.

--- a/src/modules/launcher/mod.rs
+++ b/src/modules/launcher/mod.rs
@@ -26,7 +26,7 @@ use std::sync::Arc;
 use tokio::sync::mpsc;
 use tracing::{debug, error, trace, warn};
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, PartialEq)]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct LauncherModule {
@@ -139,7 +139,7 @@ impl Default for LauncherModule {
     }
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 #[serde(default)]
 struct Icons {

--- a/src/modules/menu/config.rs
+++ b/src/modules/menu/config.rs
@@ -5,7 +5,7 @@ use indexmap::IndexMap;
 use serde::Deserialize;
 
 /// An individual entry in the main menu section.
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, PartialEq)]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum MenuConfig {
@@ -17,7 +17,7 @@ pub enum MenuConfig {
     Custom(CustomEntry),
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, PartialEq)]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 pub struct XdgEntry {
     /// Text to display on the button.
@@ -34,7 +34,7 @@ pub struct XdgEntry {
 }
 
 /// Individual shell command entry.
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, PartialEq)]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 pub struct CustomEntry {
     /// Text to display on the button.
@@ -52,7 +52,7 @@ pub struct CustomEntry {
     pub on_click: String,
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, PartialEq)]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct MenuModule {

--- a/src/modules/menu/mod.rs
+++ b/src/modules/menu/mod.rs
@@ -180,8 +180,8 @@ impl Module<Button> for MenuModule {
                 BarPosition::Bottom => Align::End,
 
                 _ => match &info.location {
-                    &ModuleLocation::Left | &ModuleLocation::Center => Align::Start,
-                    &ModuleLocation::Right => Align::End,
+                    &ModuleLocation::Start | &ModuleLocation::Center => Align::Start,
+                    &ModuleLocation::End => Align::End,
                 },
             }
         };

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -67,11 +67,11 @@ pub mod volume;
 #[cfg(feature = "workspaces")]
 pub mod workspaces;
 
-#[derive(Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum ModuleLocation {
-    Left,
+    Start,
     Center,
-    Right,
+    End,
 }
 
 #[derive(Clone)]
@@ -156,6 +156,7 @@ pub struct ModuleRef {
     pub name: String,
     pub root_widget: Widget,
     pub popup: Option<ModulePopupParts>,
+    pub location: ModuleLocation,
 }
 
 pub struct ModuleParts<W: IsA<Widget>> {
@@ -403,6 +404,7 @@ pub trait ModuleFactory {
             name: instance_name,
             root_widget: module_parts.widget.upcast(),
             popup: module_parts.popup,
+            location: info.location,
         })
     }
 

--- a/src/modules/music/config.rs
+++ b/src/modules/music/config.rs
@@ -3,7 +3,7 @@ use dirs::{audio_dir, home_dir};
 use serde::Deserialize;
 use std::path::PathBuf;
 
-#[derive(Debug, Deserialize, Clone, Copy)]
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 pub enum PlayerType {
@@ -28,7 +28,7 @@ impl Default for PlayerType {
     }
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, PartialEq)]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct MusicModule {
@@ -150,7 +150,7 @@ impl Default for MusicModule {
     }
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct Icons {

--- a/src/modules/networkmanager/config.rs
+++ b/src/modules/networkmanager/config.rs
@@ -4,7 +4,7 @@ use crate::config::{CommonConfig, Profiles, State, default};
 use crate::profiles;
 use serde::Deserialize;
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, PartialEq)]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct NetworkManagerModule {
@@ -135,7 +135,7 @@ impl State for ProfileState {
     }
 }
 
-#[derive(Clone, Default, Deserialize, Debug)]
+#[derive(Clone, Default, Deserialize, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct NetworkManagerProfile {

--- a/src/modules/notifications.rs
+++ b/src/modules/notifications.rs
@@ -10,7 +10,7 @@ use serde::Deserialize;
 use tokio::sync::mpsc::Receiver;
 use tracing::error;
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, PartialEq)]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct NotificationsModule {
@@ -39,7 +39,7 @@ impl Default for NotificationsModule {
     }
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 #[serde(default)]
 struct Icons {

--- a/src/modules/script.rs
+++ b/src/modules/script.rs
@@ -10,7 +10,7 @@ use serde::Deserialize;
 use tokio::sync::mpsc;
 use tracing::error;
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, PartialEq)]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct ScriptModule {

--- a/src/modules/sysinfo/mod.rs
+++ b/src/modules/sysinfo/mod.rs
@@ -17,7 +17,7 @@ use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio::time::sleep;
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, PartialEq)]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct SysInfoModule {
@@ -64,7 +64,7 @@ impl Default for SysInfoModule {
     }
 }
 
-#[derive(Debug, Deserialize, Copy, Clone)]
+#[derive(Debug, Deserialize, Copy, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct Intervals {
@@ -112,7 +112,7 @@ impl Default for Intervals {
     }
 }
 
-#[derive(Debug, Deserialize, Copy, Clone)]
+#[derive(Debug, Deserialize, Copy, Clone, PartialEq, Eq)]
 #[serde(untagged)]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 pub enum Interval {

--- a/src/modules/tray/mod.rs
+++ b/src/modules/tray/mod.rs
@@ -51,7 +51,7 @@ pub enum TrayClickAction {
 }
 
 /// Click action handlers for tray icons
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, PartialEq)]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct TrayClickHandlers {
@@ -138,7 +138,7 @@ impl Default for TrayClickAction {
     }
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, PartialEq)]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct TrayModule {

--- a/src/modules/volume/config.rs
+++ b/src/modules/volume/config.rs
@@ -4,7 +4,7 @@ use crate::config::{
 use crate::profiles;
 use serde::Deserialize;
 
-#[derive(Debug, Default, Clone, Deserialize)]
+#[derive(Debug, Default, Clone, Deserialize, PartialEq)]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct VolumeProfile {
@@ -29,7 +29,7 @@ pub(super) fn default_profiles() -> Profiles<f64, VolumeProfile> {
     )
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, PartialEq)]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct VolumeModule {
@@ -121,7 +121,7 @@ impl Default for VolumeModule {
     }
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct Icons {

--- a/src/modules/workspaces/mod.rs
+++ b/src/modules/workspaces/mod.rs
@@ -47,7 +47,7 @@ pub enum SortOrder {
     Index,
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, PartialEq)]
 #[serde(untagged)]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 pub enum Favorites {
@@ -61,7 +61,7 @@ impl Default for Favorites {
     }
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
 #[serde(untagged)]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 pub enum Format {
@@ -89,7 +89,7 @@ impl Format {
     }
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, PartialEq)]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct WorkspacesModule {

--- a/src/script.rs
+++ b/src/script.rs
@@ -13,7 +13,7 @@ use tokio::sync::mpsc;
 use tokio::time::sleep;
 use tracing::{debug, error, trace, warn};
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, PartialEq)]
 #[serde(untagged)]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 pub enum ScriptInput {
@@ -72,7 +72,7 @@ impl ScriptMode {
     }
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, PartialEq)]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct Script {

--- a/src/style.rs
+++ b/src/style.rs
@@ -22,7 +22,7 @@ pub enum CssSource {
 ///
 /// Installs a file watcher and reloads CSS when
 /// write changes are detected on the file.
-pub fn load_css(source: &CssSource) {
+pub fn load_css(source: &CssSource, hot_reload: bool) {
     let provider = CssProvider::new();
 
     let path = match source {
@@ -55,7 +55,7 @@ pub fn load_css(source: &CssSource) {
     );
 
     // install file watcher
-    if let Some(style_path) = path {
+    if hot_reload && let Some(style_path) = path {
         let (tx, rx) = mpsc::channel(8);
 
         spawn(async move {


### PR DESCRIPTION
At long last, config hot reloading! This introduces a config diffing system that tries to minimise the amount of reloading that needs to take place, according to the following rules:

- Monitors switching from single <--> multiple bars will perform a full reload of all bars.
- Bars with non-module configuration changes (ie changing position etc), or a change to the number of modules are fully reloaded.
- Changes at a module level replace just that module.

This means that you can add, remove and change entire monitor configurations, individual bars, and modules and Ironbar will do its best to minimise the impact.

Hot-reloading does not currently support top-level config options other than `bar` and `monitors`. Some of these are likely to never be supported but this still requires exploration.

This also adds a new top-level `hot_reload` option, which takes two formats:

- `hot_reload: <true/false>` - enables/disables for both config and styles.
- `hot_reload.config` and `hot_reload.style` which can be used to toggle each system separately.

---

The code for this is still a little messy and prototypal, and I'm not sure I've caught every edge case yet, so leaving as draft for now. This does work for the most part though, so publishing for others to test and play with.