### PR TITLE
fix: typo in ModuleConfig::name()

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -220,7 +220,7 @@ impl ModuleConfig {
             #[cfg(feature = "bindmode")]
             ModuleConfig::Bindmode(_) => "Bindmode",
             #[cfg(feature = "cairo")]
-            ModuleConfig::Cairo(_) => "Cario",
+            ModuleConfig::Cairo(_) => "Cairo",
             #[cfg(feature = "clipboard")]
             ModuleConfig::Clipboard(_) => "Clipboard",
             #[cfg(feature = "clock")]


### PR DESCRIPTION
Fix typo: Cario -> Cairo in ModuleConfig::name()

This was causing confusing error messages.

**Note:** Same typo in `docs/examples/custom/Cpu-Cores-Graph.md` but requires renaming the file.