### PR TITLE
Add ironbar systemd service

### DIFF
--- a/ironbar.service
+++ b/ironbar.service
@@ -1,0 +1,8 @@
+[Unit]
+PartOf=graphical-session.target
+After=graphical-session.target
+Requisite=graphical-session.target
+
+[Service]
+ExecStart=/usr/bin/ironbar
+Restart=on-failure


### PR DESCRIPTION
Adds a systemd service for better integration on such systems. This allows restarting ironbar independently of the Wayland compositor.

For example, on my system:
```
systemctl --user add-wants niri.service ironbar.service
```

This starts ironbar with niri but also allows me to independently restart or stop it with:
```
systemctl --user restart ironbar.service  
```

Packagers can easily add support with:
```
install -Dm644 ironbar.service ${DESTDIR}${PREFIX}/lib/systemd/user/ironbar.service
```

Code has been adapted from piri and what I currently do on my system:
- https://github.com/morr0ne/piri/blob/main/resources/piri.service
- https://github.com/morr0ne/piri/blob/main/justfile