### PR TITLE
build: add optimised tagged release profile

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,18 @@
+rustflags= [
+    "-Clinker-plugin-lto",
+    "-Clink-arg=-Wl,-z,pack-relative-relocs",
+    "-Clink-arg=-Wl,-O1",
+    "-Clink-arg=-Wl,--gc-sections",
+    "-Clink-arg=-Wl,--as-needed",
+    "-Clink-arg=-Wl,-z,now",
+    "-Clink-arg=-Wl,-z,relro",
+]
+
+[profile.release]
+strip = true
+codegen-units = 16
+
+[profile.tagged-release]
+inherits = "release"
+codegen-units = 1
+lto = true

--- a/.github/workflows/binary.yml
+++ b/.github/workflows/binary.yml
@@ -43,7 +43,7 @@ jobs:
         run: cargo add openssl --features vendored
 
       - name: Build Release
-        run: cargo build --locked --release
+        run: cargo build --locked --profile tagged-release
 
       - name: Compress the built binary
         run: tar -zcvf ironbar-${{needs.get_last_release.outputs.latest_release_tag}}-${{matrix.platform.name}}.tar.gz -C target/release ironbar


### PR DESCRIPTION
A new `tagged-release` build profile has been added with all optimisations enabled. This slows builds in the region of 3-4x for marginal performance gains, so is not included in the regular release profile used by `-git` packages.