### PR TITLE
feat(workspaces): style based upon workspace having windows

### DIFF
--- a/docs/modules/Workspaces.md
+++ b/docs/modules/Workspaces.md
@@ -124,6 +124,7 @@ end:
 | `.workspaces .item.visible`    | Workspace button (workspace visible, including focused) |
 | `.workspaces .item.urgent`     | Workspace button (workspace contains urgent window)     |
 | `.workspaces .item.inactive`   | Workspace button (favourite, not currently open)        |
+| `.workspaces .item.notempty`   | Workspace button (workspace contains windows)           |
 | `.workspaces .item .icon`      | Workspace button icon (any type)                        |
 | `.workspaces .item .text-icon` | Workspace button icon (textual only)                    |
 | `.workspaces .item .image`     | Workspace button icon (image only)                      |

--- a/src/clients/compositor/hyprland.rs
+++ b/src/clients/compositor/hyprland.rs
@@ -182,7 +182,6 @@ impl Client {
                         error!("Unable to locate workspace");
                     }
                     Err(e) => error!("Failed to get workspace: {e:#}"),
-                    _ => {}
                 }
             });
         }

--- a/src/clients/compositor/hyprland.rs
+++ b/src/clients/compositor/hyprland.rs
@@ -177,6 +177,98 @@ impl Client {
             let lock = lock.clone();
             let active = active.clone();
 
+            event_listener.add_window_opened_handler(move |event| {
+                let _lock = lock!(lock);
+
+                let prev_workspace = lock!(active);
+
+                debug!("Received window open: {event:?}",);
+
+                let workspace =
+                    Self::get_workspace(event.workspace_name.as_str(), prev_workspace.as_ref());
+
+                match workspace {
+                    Ok(Some(workspace)) => Self::send_windows_change(workspace, &tx),
+                    Ok(None) => {
+                        error!("Unable to locate workspace");
+                    }
+                    Err(e) => error!("Failed to get workspace: {e:#}"),
+                    _ => {}
+                }
+            });
+        }
+
+        {
+            let tx = tx.clone();
+            let lock = lock.clone();
+            let active = active.clone();
+
+            event_listener.add_window_closed_handler(move |event| {
+                let _lock = lock!(lock);
+
+                let prev_workspace = lock!(active);
+
+                debug!("Received window close: {event:?}",);
+
+                let workspaces = match Workspaces::get() {
+                    Ok(workspaces) => workspaces,
+                    Err(_) => {
+                        error!("Unable to locate workspaces");
+                        return;
+                    }
+                };
+
+                for hworkspace in workspaces.iter() {
+                    let vis = Visibility::from((
+                        hworkspace,
+                        prev_workspace.as_ref().map(|w| w.name.as_ref()),
+                        &|w| create_is_visible()(w),
+                    ));
+
+                    let workspace = Workspace::from((vis, hworkspace.clone()));
+                    Self::send_windows_change(workspace, &tx);
+                }
+            });
+        }
+
+        {
+            let tx = tx.clone();
+            let lock = lock.clone();
+            let active = active.clone();
+
+            event_listener.add_window_moved_handler(move |event| {
+                let _lock = lock!(lock);
+
+                let prev_workspace = lock!(active);
+
+                debug!("Received window moved: {event:?}",);
+
+                let workspaces = match Workspaces::get() {
+                    Ok(workspaces) => workspaces,
+                    Err(_) => {
+                        error!("Unable to locate workspaces");
+                        return;
+                    }
+                };
+
+                for hworkspace in workspaces.iter() {
+                    let vis = Visibility::from((
+                        hworkspace,
+                        prev_workspace.as_ref().map(|w| w.name.as_ref()),
+                        &|w| create_is_visible()(w),
+                    ));
+
+                    let workspace = Workspace::from((vis, hworkspace.clone()));
+                    Self::send_windows_change(workspace, &tx);
+                }
+            });
+        }
+
+        {
+            let tx = tx.clone();
+            let lock = lock.clone();
+            let active = active.clone();
+
             event_listener.add_active_monitor_changed_handler(move |event_data| {
                 let _lock = lock!(lock);
                 let Some(workspace_type) = event_data.workspace_name else {
@@ -389,6 +481,15 @@ impl Client {
         prev_workspace.replace(workspace);
     }
 
+    /// Sends a `WorkspaceUpdate::Windows` event
+    #[cfg(feature = "workspaces+hyprland")]
+    fn send_windows_change(workspace: Workspace, tx: &Sender<WorkspaceUpdate>) {
+        tx.send_expect(WorkspaceUpdate::Windows {
+            id: workspace.id,
+            windows: workspace.windows,
+        });
+    }
+
     /// Gets a workspace by name from the server, given the active workspace if known.
     #[cfg(feature = "workspaces+hyprland")]
     fn get_workspace(name: &str, active: Option<&Workspace>) -> Result<Option<Workspace>> {
@@ -573,6 +674,7 @@ impl From<(Visibility, HWorkspace)> for Workspace {
             name: workspace.name,
             monitor: workspace.monitor,
             visibility,
+            windows: workspace.windows,
         }
     }
 }

--- a/src/clients/compositor/hyprland.rs
+++ b/src/clients/compositor/hyprland.rs
@@ -193,7 +193,6 @@ impl Client {
                         error!("Unable to locate workspace");
                     }
                     Err(e) => error!("Failed to get workspace: {e:#}"),
-                    _ => {}
                 }
             });
         }

--- a/src/clients/compositor/mod.rs
+++ b/src/clients/compositor/mod.rs
@@ -152,6 +152,8 @@ pub struct Workspace {
     pub monitor: String,
     /// How visible the workspace is
     pub visibility: Visibility,
+    /// How many windows does the workspace have
+    pub windows: u16,
 }
 
 /// Indicates workspace visibility.
@@ -212,6 +214,11 @@ pub enum WorkspaceUpdate {
     Urgent {
         id: i64,
         urgent: bool,
+    },
+
+    Windows {
+        id: i64,
+        windows: u16,
     },
 
     /// An update was triggered by the compositor but this was not mapped by Ironbar.

--- a/src/clients/compositor/niri/connection.rs
+++ b/src/clients/compositor/niri/connection.rs
@@ -64,6 +64,7 @@ impl From<&Workspace> for IronWorkspace {
             } else {
                 Visibility::Hidden
             },
+            windows: 0,
         }
     }
 }

--- a/src/clients/compositor/sway.rs
+++ b/src/clients/compositor/sway.rs
@@ -76,6 +76,7 @@ impl From<Node> for Workspace {
             name: node.name.unwrap_or_default(),
             monitor: node.output.unwrap_or_default(),
             visibility,
+            windows: 0,
         }
     }
 }
@@ -90,6 +91,7 @@ impl From<swayipc_async::Workspace> for Workspace {
             name: workspace.name,
             monitor: workspace.output,
             visibility,
+            windows: 0,
         }
     }
 }

--- a/src/clients/compositor/sway.rs
+++ b/src/clients/compositor/sway.rs
@@ -89,6 +89,7 @@ impl From<Node> for Workspace {
             name: node.name.unwrap_or_default(),
             monitor: node.output.unwrap_or_default(),
             visibility,
+            windows: 0,
         }
     }
 }
@@ -103,6 +104,7 @@ impl From<swayipc_async::Workspace> for Workspace {
             name: workspace.name,
             monitor: workspace.output,
             visibility,
+            windows: 0,
         }
     }
 }

--- a/src/modules/workspaces/button.rs
+++ b/src/modules/workspaces/button.rs
@@ -101,6 +101,14 @@ impl Button {
         }
     }
 
+    pub fn set_empty(&self, empty: bool) {
+        if empty {
+            self.button.add_css_class("empty");
+        } else {
+            self.button.remove_css_class("empty");
+        }
+    }
+
     pub fn workspace_id(&self) -> i64 {
         self.workspace_id
     }

--- a/src/modules/workspaces/mod.rs
+++ b/src/modules/workspaces/mod.rs
@@ -394,11 +394,13 @@ impl Module<gtk::Box> for WorkspacesModule {
                         btn.set_label(&label);
 
                         btn.button().set_tag("workspace_index", workspace.index);
+                        btn.set_empty(workspace.windows == 0);
                     } else if let Some(btn) = button_map.find_button_mut(&workspace) {
                         let label = item_context.format_label(&workspace.name, workspace.index);
                         btn.set_label(&label);
                         btn.set_monitor(&workspace.monitor);
                         btn.button().set_tag("workspace_index", workspace.index);
+                        btn.set_empty(workspace.windows == 0);
                     } else {
                         let btn = Button::new(
                             workspace.id,
@@ -410,6 +412,7 @@ impl Module<gtk::Box> for WorkspacesModule {
                         );
 
                         btn.button().set_tag("workspace_index", workspace.index);
+                        btn.set_empty(workspace.windows == 0);
 
                         container.append(btn.button());
                         btn.button().set_visible(true);
@@ -540,6 +543,14 @@ impl Module<gtk::Box> for WorkspacesModule {
                             .or_else(|| button_map.find_button_by_id(id))
                         {
                             button.set_urgent(urgent);
+                        }
+                    }
+                    WorkspaceUpdate::Windows { id, windows } => {
+                        if let Some(button) = button_map
+                            .get(&Identifier::Id(id))
+                            .or_else(|| button_map.find_button_by_id(id))
+                        {
+                            button.set_empty(windows == 0);
                         }
                     }
                     WorkspaceUpdate::Unknown if has_initialized => {


### PR DESCRIPTION
Adds the ability to style workspaces based upon it containing any windows using the `empty` css class.

Example:
```css
.workspaces .item:not(.empty) label {
    font-weight: bold;
}
```

I've only implemented this for hyprland so far. I wanted to open up this draft PR to see if this is a desired feature before continuing on implementing it for sway and niri.