### PR TITLE
fix(script): scripts get terminated and launched again upon reload

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@
 #![deny(clippy::unwrap_used)]
 
 use std::cell::RefCell;
+use std::collections::HashMap;
 use std::env;
 use std::future::Future;
 use std::process::exit;
@@ -18,6 +19,7 @@ use gtk::gdk::{Display, Monitor};
 use gtk::prelude::*;
 use smithay_client_toolkit::output::OutputInfo;
 use tokio::runtime::Runtime;
+use tokio::sync::oneshot::Sender;
 use tokio::task::{JoinHandle, block_in_place};
 use tracing::{debug, error, info};
 
@@ -150,7 +152,7 @@ pub struct Ironbar {
     css_source: Rc<CssSource>,
     config_location: ConfigLocation,
     css_location: Option<ConfigLocation>,
-
+    scripts: Rc<RefCell<HashMap<String, Sender<()>>>>,
     desktop_files: DesktopFiles,
     image_provider: image::Provider,
 }
@@ -178,6 +180,7 @@ impl Ironbar {
             css_source: Rc::new(css_source),
             config_location,
             css_location,
+            scripts: rc_mut!(HashMap::new()),
             desktop_files,
             image_provider,
         }
@@ -346,6 +349,23 @@ impl Ironbar {
             .filter(|&bar| bar.name() == name)
             .cloned()
             .collect()
+    }
+
+    /// Associates the command (`cmd`) of a script with a sender meant to
+    /// remotely kill the process.
+    ///
+    /// When ran it will terminate the previous script (if present) and register
+    /// this as the "new" script.
+    pub fn register_or_terminate_script(&self, cmd: &str, send: Sender<()>) {
+        let mut set = self.scripts.borrow_mut();
+
+        if let Some(removed) = set.remove(cmd) {
+            if removed.send(()).is_err() {
+                error!("failed to send signal to script child process")
+            };
+        }
+
+        set.insert(cmd.to_owned(), send);
     }
 
     /// Re-reads the config file from disk and replaces the active config.

--- a/src/main.rs
+++ b/src/main.rs
@@ -356,7 +356,10 @@ impl Ironbar {
     ///
     /// When ran it will terminate the previous script (if present) and register
     /// this as the "new" script.
-    pub fn register_or_terminate_script(&self, cmd: &str, send: Sender<()>) {
+    ///
+    /// The passed sender (`tx_terminate`) is used to remotely signal to a process
+    /// that it should terminate.
+    pub fn register_script(&self, cmd: &str, tx_terminate: Sender<()>) {
         let mut set = self.scripts.borrow_mut();
 
         if let Some(removed) = set.remove(cmd)
@@ -365,7 +368,7 @@ impl Ironbar {
             error!("failed to send signal to script child process")
         }
 
-        set.insert(cmd.to_owned(), send);
+        set.insert(cmd.to_owned(), tx_terminate);
     }
 
     /// Re-reads the config file from disk and replaces the active config.

--- a/src/main.rs
+++ b/src/main.rs
@@ -359,10 +359,10 @@ impl Ironbar {
     pub fn register_or_terminate_script(&self, cmd: &str, send: Sender<()>) {
         let mut set = self.scripts.borrow_mut();
 
-        if let Some(removed) = set.remove(cmd) {
-            if removed.send(()).is_err() {
-                error!("failed to send signal to script child process")
-            };
+        if let Some(removed) = set.remove(cmd)
+            && removed.send(()).is_err()
+        {
+            error!("failed to send signal to script child process")
         }
 
         set.insert(cmd.to_owned(), send);

--- a/src/modules/script.rs
+++ b/src/modules/script.rs
@@ -83,7 +83,9 @@ impl Module<Label> for ScriptModule {
         let (send, recv) = channel::<()>();
 
         if matches!(self.mode, ScriptMode::Watch) {
-            context.ironbar.register_or_terminate_script(&self.cmd, send)
+            context
+                .ironbar
+                .register_or_terminate_script(&self.cmd, send)
         }
 
         let script: Script = self.into();

--- a/src/modules/script.rs
+++ b/src/modules/script.rs
@@ -83,9 +83,7 @@ impl Module<Label> for ScriptModule {
         let (send, recv) = channel::<()>();
 
         if matches!(self.mode, ScriptMode::Watch) {
-            context
-                .ironbar
-                .register_or_terminate_script(&self.cmd, send)
+            context.ironbar.register_script(&self.cmd, send)
         }
 
         let script: Script = self.into();

--- a/src/script.rs
+++ b/src/script.rs
@@ -10,6 +10,7 @@ use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command;
 use tokio::select;
 use tokio::sync::mpsc;
+use tokio::sync::oneshot::{Receiver, channel};
 use tokio::time::sleep;
 use tracing::{debug, error, trace, warn};
 
@@ -193,24 +194,36 @@ impl Script {
     where
         F: Fn(OutputStream, bool),
     {
-        loop {
-            match self.mode {
-                ScriptMode::Poll => match self.get_output(args).await {
+        let (send, recv) = channel::<()>();
+        std::mem::forget(send);
+        self.run_with_recv(args, recv, callback).await
+    }
+
+    /// Runs the script, passing `args` if provided.
+    /// Uses the flag to determine if the script should be terminated.
+    /// Runs `f`, passing the output stream and whether the command returned 0.
+    pub async fn run_with_recv<F>(&self, args: Option<&[String]>, recv: Receiver<()>, callback: F)
+    where
+        F: Fn(OutputStream, bool),
+    {
+        match self.mode {
+            ScriptMode::Poll => loop {
+                match self.get_output(args).await {
                     Ok(output) => callback(output.0, output.1),
                     Err(err) => error!("{err:?}"),
-                },
-                ScriptMode::Watch => match self.spawn() {
-                    Ok(mut rx) => {
-                        while let Some(msg) = rx.recv().await {
-                            callback(msg, true);
-                        }
+                }
+            },
+            ScriptMode::Watch => match self.spawn(recv) {
+                Ok(mut rx) => {
+                    while let Some(msg) = rx.recv().await {
+                        callback(msg, true);
                     }
-                    Err(err) => error!("{err:?}"),
-                },
-            }
-
-            sleep(tokio::time::Duration::from_millis(self.interval)).await;
+                }
+                Err(err) => error!("{err:?}"),
+            },
         }
+
+        sleep(tokio::time::Duration::from_millis(self.interval)).await;
     }
 
     /// Attempts to execute a given command,
@@ -258,7 +271,7 @@ impl Script {
     /// Spawns a long-running process.
     /// Returns a `mpsc::Receiver` that sends a message
     /// every time a new line is written to `stdout` or `stderr`.
-    pub fn spawn(&self) -> Result<mpsc::Receiver<OutputStream>> {
+    pub fn spawn(&self, recv: Receiver<()>) -> Result<mpsc::Receiver<OutputStream>> {
         let mut handle = Command::new("/bin/sh")
             .args(["-c", &self.cmd])
             .stdout(Stdio::piped())
@@ -288,9 +301,17 @@ impl Script {
         let (tx, rx) = mpsc::channel(32);
 
         spawn(async move {
+            let mut recv = recv;
             loop {
                 select! {
                     _ = handle.wait() => break,
+                    _ = &mut recv => {
+                        if let Err(err) = handle.kill().await {
+                            error!("failed to terminate child process: {err:?}")
+                        };
+
+                        break;
+                    },
                     Ok(Some(line)) = stdout_lines.next_line() => {
                         debug!("sending stdout line: '{line}'");
                         tx.send_expect(OutputStream::Stdout(line)).await;


### PR DESCRIPTION
made the script module register and terminate scripts, recreating them on reload and preventing the problem with leftover processes.

fixes #1102 