### PR TITLE
fix(tray): preserve tooltip when icon widget changes

### DIFF
--- a/src/modules/tray/interface.rs
+++ b/src/modules/tray/interface.rs
@@ -248,6 +248,8 @@ impl TrayMenu {
 
     /// Updates the image, and shows it in favour of the label.
     pub fn set_image(&mut self, image: &Picture) {
+        let tooltip = self.widget.tooltip_text();
+
         if let Some(label) = self.label_widget.take() {
             label.set_visible(false);
         }
@@ -257,6 +259,7 @@ impl TrayMenu {
         }
 
         self.box_content.append(image);
+        image.set_tooltip_text(tooltip.as_deref());
     }
 
     pub fn label_widget(&self) -> Option<&Label> {
@@ -276,13 +279,16 @@ impl TrayMenu {
 
     pub fn set_tooltip(&self, tooltip: Option<Tooltip>) {
         let title = tooltip.map(|t| t.title);
+        let title = title.as_deref();
+
+        self.widget.set_tooltip_text(title);
 
         if let Some(widget) = &self.image_widget {
-            widget.set_tooltip_text(title.as_deref());
+            widget.set_tooltip_text(title);
         }
 
         if let Some(widget) = &self.label_widget {
-            widget.set_tooltip_text(title.as_deref());
+            widget.set_tooltip_text(title);
         }
     }
 


### PR DESCRIPTION
`UpdateEvent::Icon` rebuilds the tray image widget via `set_image()`.
When that happens, the old widget is removed and the new `Picture` does not inherit the existing tooltip.
As a result, tray item tooltips can disappear after an icon change and stop appearing on later hover events.

## What this changes

- Preserves the current tooltip before replacing the image widget.
- Reapplies that tooltip to the new `Picture`.
- Also sets the tooltip on the root tray `Button` so tooltip state survives child widget replacement.

## Reproduction

- Run a `StatusNotifierItem` that updates `IconName` dynamically.
- Hover the tray item and confirm the tooltip is visible.
- Change the icon at runtime, for example:
  - mute/unmute a volume tray item
  - cross a volume icon threshold
- Before this patch, the tooltip can disappear after the icon update and never return on later hover.
- After this patch, the tooltip remains available after icon changes.

