### PR TITLE
refactor(logging): update tracing-subscriber, tidy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2204,11 +2204,11 @@ checksum = "baee0bbc17ce759db233beb01648088061bf678383130602a298e6998eedb2d8"
 
 [[package]]
 name = "matchers"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
- "regex-automata 0.1.10",
+ "regex-automata",
 ]
 
 [[package]]
@@ -2409,12 +2409,11 @@ dependencies = [
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.46.0"
+version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "overload",
- "winapi",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -2513,12 +2512,6 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
 ]
-
-[[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "owo-colors"
@@ -2888,27 +2881,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "1.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata 0.4.13",
- "regex-syntax 0.8.5",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax 0.6.29",
-]
-
-[[package]]
 name = "regex-automata"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2916,14 +2888,8 @@ checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.5",
+ "regex-syntax",
 ]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -3938,14 +3904,14 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.19"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
- "regex",
+ "regex-automata",
  "sharded-slab",
  "smallvec",
  "thread_local",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,7 +142,7 @@ tokio = { version = "1.50.0", features = [
     "fs"
 ] }
 tracing = "0.1.44"
-tracing-subscriber = { version = "=0.3.19", features = ["env-filter"] } # pinned: https://github.com/tokio-rs/tracing/issues/3378
+tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 tracing-error = { version = "0.2.1", default-features = false }
 tracing-appender = "0.2.4"
 strip-ansi-escapes = "0.2.0"

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -7,7 +7,7 @@ use tracing::{debug, error, info, warn};
 use tracing_appender::non_blocking::{NonBlocking, WorkerGuard};
 use tracing_appender::rolling::Rotation;
 use tracing_error::ErrorLayer;
-use tracing_subscriber::fmt::{Layer, MakeWriter};
+use tracing_subscriber::fmt::MakeWriter;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::{EnvFilter, fmt};
 
@@ -56,7 +56,6 @@ fn install_tracing(debug: bool) -> Result<WorkerGuard> {
 
     let default_log = if debug { "debug" } else { "info" };
 
-    let fmt_layer = fmt::layer().with_target(true).with_line_number(true);
     let filter_layer =
         EnvFilter::try_from_env("IRONBAR_LOG").or_else(|_| EnvFilter::try_new(default_log))?;
 
@@ -74,16 +73,26 @@ fn install_tracing(debug: bool) -> Result<WorkerGuard> {
 
     let (file_writer, guard) = tracing_appender::non_blocking(appender);
 
+    macro_rules! base_layer {
+        () => {
+            fmt::layer()
+                .with_target(true)
+                .with_line_number(true)
+                .with_ansi_sanitization(false)
+        };
+    }
+
+    let console_layer = base_layer!().with_ansi(true);
+
+    let file_layer = base_layer!()
+        .with_writer(MakeFileWriter::new(file_writer))
+        .with_filter(file_filter_layer);
+
     tracing_subscriber::registry()
         .with(filter_layer)
-        .with(fmt_layer)
         .with(ErrorLayer::default())
-        .with(
-            Layer::default()
-                .with_writer(MakeFileWriter::new(file_writer))
-                .with_ansi(false)
-                .with_filter(file_filter_layer),
-        )
+        .with(file_layer)
+        .with(console_layer)
         .init();
 
     glib::log_set_writer_func(|level, fields| {


### PR DESCRIPTION
Finally updates `tracing-subscriber` to the latest version using the new `ansi_sanitization` option. Clean logging in both console and file output.