### PR TITLE
Add cargo-binstall metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,9 @@ repository = "https://github.com/jakestanger/ironbar"
 categories = ["gui"]
 keywords = ["gtk", "bar", "wayland", "wlroots", "gtk-layer-shell"]
 
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-v{ version }-{ target-arch }{ archive-suffix }"
+
 [features]
 default = [
     "battery",


### PR DESCRIPTION
This allows the package to be easily installable with `cargo-binstall`

This can be smoke tested with

```shell
cargo binstall --pkg-url="{ repo }/releases/download/v{ version }/{ name }-v{ version }-{ target-arch }{ archive-suffix }" ironbar
# Optionally use arguments: --force -v --dry-run
```