### PR TITLE
`ext-workspace` support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1917,6 +1917,7 @@ dependencies = [
  "tracing-subscriber",
  "walkdir",
  "wayland-client",
+ "wayland-protocols",
  "wayland-protocols-wlr",
  "zbus",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,6 +157,7 @@ dirs = "6.0.0"
 walkdir = "2.5.0"
 notify = { version = "8.2.0", default-features = false }
 wayland-client = "0.31.1"
+wayland-protocols = { version = "0.32.9", features = ["client"] }
 wayland-protocols-wlr = { version = "0.3.12", features = ["client"] }
 smithay-client-toolkit = { version = "0.20.0", default-features = false, features = [
     "calloop",

--- a/src/clients/compositor/mod.rs
+++ b/src/clients/compositor/mod.rs
@@ -32,6 +32,8 @@ pub enum Compositor {
     Hyprland,
     #[cfg(feature = "niri")]
     Niri,
+    #[cfg(feature = "workspaces")]
+    Workspaces,
     Unsupported,
 }
 
@@ -47,6 +49,8 @@ impl Display for Compositor {
                 Self::Hyprland => "Hyprland",
                 #[cfg(feature = "workspaces+niri")]
                 Self::Niri => "Niri",
+                #[cfg(feature = "workspaces")]
+                Self::Workspaces => "ext-workspace",
                 Self::Unsupported => "Unsupported",
             }
         )
@@ -72,6 +76,11 @@ impl Compositor {
                 if #[cfg(feature = "niri")] { Self::Niri }
                 else {tracing::error!("Not compiled with Niri support"); Self::Unsupported }
             }
+        } else if std::env::var("WAYLAND_DISPLAY").is_ok() {
+            cfg_if! {
+                if #[cfg(feature = "workspaces")] { Self::Workspaces }
+                else {tracing::error!("Not compiled with waylands ext-workspace support"); Self::Unsupported }
+            }
         } else {
             Self::Unsupported
         }
@@ -90,6 +99,7 @@ impl Compositor {
             Self::Hyprland => Ok(clients.hyprland()),
             #[cfg(feature = "niri")]
             Self::Niri => Err(Error::Unsupported("bindmode", &["sway", "hyprland"])),
+            Self::Workspaces => Err(Error::Unsupported("bindmode", &["sway", "hyprland"])),
             Self::Unsupported => Err(Error::Unsupported("bindmode", &["sway", "hyprland"])),
             #[allow(unreachable_patterns)]
             _ => Err(Error::Disabled("bindmode")),
@@ -109,6 +119,7 @@ impl Compositor {
             Self::Hyprland => Ok(clients.hyprland()),
             #[cfg(feature = "niri")]
             Self::Niri => Err(Error::Unsupported("keyboard", &["sway", "hyprland"])),
+            Self::Workspaces => Err(Error::Unsupported("keyboard", &["sway", "hyprland"])),
             Self::Unsupported => Err(Error::Unsupported("keyboard", &["sway", "hyprland"])),
             #[allow(unreachable_patterns)]
             _ => Err(Error::Disabled("keyboard")),
@@ -121,6 +132,11 @@ impl Compositor {
     pub fn create_workspace_client(
         clients: &mut super::Clients,
     ) -> Result<Arc<dyn WorkspaceClient + Send + Sync>> {
+        if std::env::var("WAYLAND_DISPLAY").is_ok() {
+            debug!("Getting workspace client for: ext-workspace");
+            return Ok(clients.wayland());
+        }
+
         let current = Self::get_current();
         debug!("Getting workspace client for: {current}");
         match current {
@@ -130,9 +146,10 @@ impl Compositor {
             Self::Hyprland => Ok(clients.hyprland()),
             #[cfg(feature = "workspaces+niri")]
             Self::Niri => Ok(Arc::new(niri::Client::new())),
+            Self::Workspaces => Ok(clients.wayland()),
             Self::Unsupported => Err(Error::Unsupported(
                 "workspaces",
-                &["sway", "hyprland", "niri"],
+                &["sway", "hyprland", "niri", "ext-workspace"],
             )),
             #[allow(unreachable_patterns)]
             _ => Err(Error::Disabled("workspaces")),
@@ -234,6 +251,24 @@ pub struct BindModeUpdate {
 pub trait WorkspaceClient: Debug + Send + Sync {
     /// Requests the workspace with this id is focused.
     fn focus(&self, id: i64);
+
+    /// Activates a workspace.
+    fn activate(&self, id: i64) {
+        self.focus(id);
+    }
+
+    /// Deactivates a workspace if supported by the backend.
+    fn deactivate(&self, _id: i64) {}
+
+    /// Toggles workspace activation if supported by the backend.
+    fn toggle(&self, id: i64) {
+        self.focus(id);
+    }
+
+    /// Activates this workspace and deactivates others on the same output if supported.
+    fn activate_exclusive(&self, id: i64) {
+        self.focus(id);
+    }
 
     /// Creates a new to workspace event receiver.
     fn subscribe(&self) -> broadcast::Receiver<WorkspaceUpdate>;

--- a/src/clients/compositor/mod.rs
+++ b/src/clients/compositor/mod.rs
@@ -219,6 +219,8 @@ pub enum WorkspaceUpdate {
         old: Option<Workspace>,
         new: Workspace,
     },
+    /// used by systems that can have more than 1 focused workspace, e.g. ext-workspace
+    Unfocus(Workspace),
 
     Rename {
         id: i64,

--- a/src/clients/wayland/ext_workspace/group_handle.rs
+++ b/src/clients/wayland/ext_workspace/group_handle.rs
@@ -1,6 +1,8 @@
 use super::manager::WorkspaceManagerState;
+use crate::lock;
 use std::sync::{Arc, Mutex};
-use tracing::error;
+use tracing::{error, trace};
+use wayland_client::protocol::wl_output::WlOutput;
 use wayland_client::{Connection, Dispatch, QueueHandle};
 use wayland_protocols::ext::workspace::v1::client::ext_workspace_group_handle_v1::{
     Event, ExtWorkspaceGroupHandleV1,
@@ -26,37 +28,141 @@ pub struct WorkspaceGroupHandleData {
 
 impl WorkspaceGroupHandleData {}
 
+impl WorkspaceGroupHandleData {
+    pub fn outputs(&self) -> Vec<WlOutput> {
+        lock!(self.inner).outputs.clone()
+    }
+}
+
 #[derive(Debug, Default)]
-pub struct WorkspaceGroupHandleDataInner {}
+pub struct WorkspaceGroupHandleDataInner {
+    outputs: Vec<WlOutput>,
+}
 
-pub trait WorkspaceGroupHandleDataExt {}
+pub trait WorkspaceGroupHandleDataExt {
+    fn workspace_group_handle_data(&self) -> &WorkspaceGroupHandleData;
+}
 
-impl WorkspaceGroupHandleDataExt for WorkspaceGroupHandleData {}
+impl WorkspaceGroupHandleDataExt for WorkspaceGroupHandleData {
+    fn workspace_group_handle_data(&self) -> &WorkspaceGroupHandleData {
+        self
+    }
+}
 
-pub trait WorkspaceGroupHandleHandler: Sized {}
+pub trait WorkspaceGroupHandleHandler: Sized {
+    fn workspace_group_output_enter(
+        &mut self,
+        conn: &Connection,
+        qh: &QueueHandle<Self>,
+        group: WorkspaceGroupHandle,
+        output: WlOutput,
+    );
+    fn workspace_group_output_leave(
+        &mut self,
+        conn: &Connection,
+        qh: &QueueHandle<Self>,
+        group: WorkspaceGroupHandle,
+        output: WlOutput,
+    );
+    fn workspace_group_workspace_enter(
+        &mut self,
+        conn: &Connection,
+        qh: &QueueHandle<Self>,
+        group: WorkspaceGroupHandle,
+        workspace: wayland_protocols::ext::workspace::v1::client::ext_workspace_handle_v1::ExtWorkspaceHandleV1,
+    );
+    fn workspace_group_workspace_leave(
+        &mut self,
+        conn: &Connection,
+        qh: &QueueHandle<Self>,
+        group: WorkspaceGroupHandle,
+        workspace: wayland_protocols::ext::workspace::v1::client::ext_workspace_handle_v1::ExtWorkspaceHandleV1,
+    );
+    fn workspace_group_removed(
+        &mut self,
+        conn: &Connection,
+        qh: &QueueHandle<Self>,
+        group: WorkspaceGroupHandle,
+    );
+}
 
 impl<D, U> Dispatch<ExtWorkspaceGroupHandleV1, U, D> for WorkspaceManagerState
 where
-    D: Dispatch<ExtWorkspaceGroupHandleV1, U> + 'static,
+    D: Dispatch<ExtWorkspaceGroupHandleV1, U> + WorkspaceGroupHandleHandler + 'static,
     U: WorkspaceGroupHandleDataExt,
 {
     fn event(
-        _state: &mut D,
+        state: &mut D,
         proxy: &ExtWorkspaceGroupHandleV1,
         event: Event,
-        _data: &U,
-        _conn: &Connection,
-        _qhandle: &QueueHandle<D>,
+        data: &U,
+        conn: &Connection,
+        qhandle: &QueueHandle<D>,
     ) {
-        println!("GROUP HANDLE EVENT: {event:?}");
+        let data = data.workspace_group_handle_data();
 
         match event {
-            Event::Capabilities { capabilities } => {}
-            Event::OutputEnter { output } => {}
-            Event::OutputLeave { output } => {}
-            Event::WorkspaceEnter { workspace } => {}
-            Event::WorkspaceLeave { workspace } => {}
-            Event::Removed => proxy.destroy(),
+            Event::Capabilities { capabilities } => {
+                trace!("workspace group capabilities: {capabilities:?}");
+            }
+            Event::OutputEnter { output } => {
+                let mut inner = lock!(data.inner);
+                if !inner.outputs.iter().any(|existing| existing == &output) {
+                    inner.outputs.push(output.clone());
+                }
+                drop(inner);
+                state.workspace_group_output_enter(
+                    conn,
+                    qhandle,
+                    WorkspaceGroupHandle {
+                        handle: proxy.clone(),
+                    },
+                    output,
+                );
+            }
+            Event::OutputLeave { output } => {
+                lock!(data.inner)
+                    .outputs
+                    .retain(|existing| existing != &output);
+                state.workspace_group_output_leave(
+                    conn,
+                    qhandle,
+                    WorkspaceGroupHandle {
+                        handle: proxy.clone(),
+                    },
+                    output,
+                );
+            }
+            Event::WorkspaceEnter { workspace } => {
+                state.workspace_group_workspace_enter(
+                    conn,
+                    qhandle,
+                    WorkspaceGroupHandle {
+                        handle: proxy.clone(),
+                    },
+                    workspace,
+                );
+            }
+            Event::WorkspaceLeave { workspace } => {
+                state.workspace_group_workspace_leave(
+                    conn,
+                    qhandle,
+                    WorkspaceGroupHandle {
+                        handle: proxy.clone(),
+                    },
+                    workspace,
+                );
+            }
+            Event::Removed => {
+                state.workspace_group_removed(
+                    conn,
+                    qhandle,
+                    WorkspaceGroupHandle {
+                        handle: proxy.clone(),
+                    },
+                );
+                proxy.destroy();
+            }
             _ => {
                 error!("received unimplemented event {event:?}");
             }

--- a/src/clients/wayland/ext_workspace/group_handle.rs
+++ b/src/clients/wayland/ext_workspace/group_handle.rs
@@ -1,0 +1,65 @@
+use super::manager::WorkspaceManagerState;
+use std::sync::{Arc, Mutex};
+use tracing::error;
+use wayland_client::{Connection, Dispatch, QueueHandle};
+use wayland_protocols::ext::workspace::v1::client::ext_workspace_group_handle_v1::{
+    Event, ExtWorkspaceGroupHandleV1,
+};
+
+#[derive(Debug, Clone)]
+pub struct WorkspaceGroupHandle {
+    pub handle: ExtWorkspaceGroupHandleV1,
+}
+
+impl PartialEq for WorkspaceGroupHandle {
+    fn eq(&self, other: &Self) -> bool {
+        self.handle == other.handle
+    }
+}
+
+impl WorkspaceGroupHandle {}
+
+#[derive(Debug, Default)]
+pub struct WorkspaceGroupHandleData {
+    pub inner: Arc<Mutex<WorkspaceGroupHandleDataInner>>,
+}
+
+impl WorkspaceGroupHandleData {}
+
+#[derive(Debug, Default)]
+pub struct WorkspaceGroupHandleDataInner {}
+
+pub trait WorkspaceGroupHandleDataExt {}
+
+impl WorkspaceGroupHandleDataExt for WorkspaceGroupHandleData {}
+
+pub trait WorkspaceGroupHandleHandler: Sized {}
+
+impl<D, U> Dispatch<ExtWorkspaceGroupHandleV1, U, D> for WorkspaceManagerState
+where
+    D: Dispatch<ExtWorkspaceGroupHandleV1, U> + 'static,
+    U: WorkspaceGroupHandleDataExt,
+{
+    fn event(
+        _state: &mut D,
+        proxy: &ExtWorkspaceGroupHandleV1,
+        event: Event,
+        _data: &U,
+        _conn: &Connection,
+        _qhandle: &QueueHandle<D>,
+    ) {
+        println!("GROUP HANDLE EVENT: {event:?}");
+
+        match event {
+            Event::Capabilities { capabilities } => {}
+            Event::OutputEnter { output } => {}
+            Event::OutputLeave { output } => {}
+            Event::WorkspaceEnter { workspace } => {}
+            Event::WorkspaceLeave { workspace } => {}
+            Event::Removed => proxy.destroy(),
+            _ => {
+                error!("received unimplemented event {event:?}");
+            }
+        }
+    }
+}

--- a/src/clients/wayland/ext_workspace/handle.rs
+++ b/src/clients/wayland/ext_workspace/handle.rs
@@ -1,0 +1,128 @@
+use crate::clients::wayland::ext_workspace::manager::WorkspaceManagerState;
+use crate::lock;
+use bluer::adv::Capabilities;
+use std::sync::{Arc, Mutex};
+use tracing::{error, warn};
+use wayland_client::{Connection, Dispatch, QueueHandle, WEnum};
+use wayland_protocols::ext::workspace::v1::client::{
+    ext_workspace_group_handle_v1::ExtWorkspaceGroupHandleV1,
+    ext_workspace_handle_v1::{Event, ExtWorkspaceHandleV1},
+};
+
+pub use wayland_protocols::ext::workspace::v1::client::ext_workspace_handle_v1::{
+    State, WorkspaceCapabilities,
+};
+
+#[derive(Debug, Clone)]
+pub struct WorkspaceHandle {
+    pub handle: ExtWorkspaceHandleV1,
+}
+
+impl PartialEq for WorkspaceHandle {
+    fn eq(&self, other: &Self) -> bool {
+        self.handle == other.handle
+    }
+}
+
+impl WorkspaceHandle {
+    fn activate(&self) {
+        self.handle.activate();
+    }
+
+    fn deactivate(&self) {
+        self.handle.deactivate();
+    }
+
+    fn assign(&self, group: &ExtWorkspaceGroupHandleV1) {
+        self.handle.assign(group);
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct WorkspaceHandleData {
+    pub inner: Arc<Mutex<WorkspaceHandleDataInner>>,
+}
+
+impl WorkspaceHandleData {}
+
+#[derive(Debug)]
+pub struct WorkspaceHandleDataInner {
+    id: String,
+    name: String,
+    coordinates: Vec<u32>,
+    state: State,
+    capabilities: WorkspaceCapabilities,
+}
+
+impl Default for WorkspaceHandleDataInner {
+    fn default() -> Self {
+        Self {
+            id: String::new(),
+            name: String::new(),
+            coordinates: vec![],
+            state: State::empty(),
+            capabilities: WorkspaceCapabilities::empty(),
+        }
+    }
+}
+
+pub trait WorkspaceHandleDataExt {
+    fn workspace_handle_data(&self) -> &WorkspaceHandleData;
+}
+
+impl WorkspaceHandleDataExt for WorkspaceHandleData {
+    fn workspace_handle_data(&self) -> &WorkspaceHandleData {
+        self
+    }
+}
+
+pub trait WorkspaceHandleHandler: Sized {}
+
+impl<D, U> Dispatch<ExtWorkspaceHandleV1, U, D> for WorkspaceManagerState
+where
+    D: Dispatch<ExtWorkspaceHandleV1, U> + WorkspaceHandleHandler,
+    U: WorkspaceHandleDataExt,
+{
+    fn event(
+        state: &mut D,
+        proxy: &ExtWorkspaceHandleV1,
+        event: Event,
+        data: &U,
+        _conn: &Connection,
+        _qhandle: &QueueHandle<D>,
+    ) {
+        println!("HANDLE EVENT: {event:?}");
+
+        let data = data.workspace_handle_data();
+
+        match event {
+            Event::Id { id } => lock!(data.inner).id = id,
+            Event::Name { name } => lock!(data.inner).name = name,
+            Event::Coordinates { coordinates } => {
+                // received as a `Vec<u8>` where every 4 bytes make up a `u32`
+                assert_eq!(coordinates.len() % 4, 0);
+                let coordinates = (0..coordinates.len() / 4)
+                    .map(|i| {
+                        let slice: [u8; 4] = coordinates[i * 4..i * 4 + 4]
+                            .try_into()
+                            .expect("Received invalid state length");
+                        u32::from_le_bytes(slice)
+                    })
+                    .collect::<Vec<_>>();
+                lock!(data.inner).coordinates = coordinates;
+            }
+            Event::State { state } => match state {
+                WEnum::Value(state) => lock!(data.inner).state = state,
+                WEnum::Unknown(value) => warn!("received unknown state: {value}",),
+            },
+            Event::Capabilities { capabilities } => match capabilities {
+                WEnum::Value(capabilities) => lock!(data.inner).capabilities = capabilities,
+                WEnum::Unknown(value) => warn!("received unknown capabilities: {value}"),
+            },
+            Event::Removed => proxy.destroy(),
+            _ => {
+                error!("received unimplemented event {event:?}");
+            }
+        }
+    }
+}

--- a/src/clients/wayland/ext_workspace/handle.rs
+++ b/src/clients/wayland/ext_workspace/handle.rs
@@ -1,6 +1,5 @@
 use crate::clients::wayland::ext_workspace::manager::WorkspaceManagerState;
-use crate::lock;
-use bluer::adv::Capabilities;
+use crate::{Ironbar, lock};
 use std::sync::{Arc, Mutex};
 use tracing::{error, warn};
 use wayland_client::{Connection, Dispatch, QueueHandle, WEnum};
@@ -45,8 +44,33 @@ pub struct WorkspaceHandleData {
 
 impl WorkspaceHandleData {}
 
+impl WorkspaceHandleData {
+    pub fn info(&self) -> WorkspaceHandleInfo {
+        let data = lock!(self.inner);
+        WorkspaceHandleInfo {
+            internal_id: data.internal_id,
+            protocol_id: data.id.clone(),
+            name: data.name.clone(),
+            coordinates: data.coordinates.clone(),
+            state: data.state,
+            capabilities: data.capabilities,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct WorkspaceHandleInfo {
+    pub internal_id: i64,
+    pub protocol_id: String,
+    pub name: String,
+    pub coordinates: Vec<u32>,
+    pub state: State,
+    pub capabilities: WorkspaceCapabilities,
+}
+
 #[derive(Debug)]
 pub struct WorkspaceHandleDataInner {
+    internal_id: i64,
     id: String,
     name: String,
     coordinates: Vec<u32>,
@@ -57,6 +81,7 @@ pub struct WorkspaceHandleDataInner {
 impl Default for WorkspaceHandleDataInner {
     fn default() -> Self {
         Self {
+            internal_id: Ironbar::unique_id() as i64,
             id: String::new(),
             name: String::new(),
             coordinates: vec![],
@@ -76,7 +101,14 @@ impl WorkspaceHandleDataExt for WorkspaceHandleData {
     }
 }
 
-pub trait WorkspaceHandleHandler: Sized {}
+pub trait WorkspaceHandleHandler: Sized {
+    fn workspace_removed(
+        &mut self,
+        conn: &Connection,
+        qh: &QueueHandle<Self>,
+        handle: WorkspaceHandle,
+    );
+}
 
 impl<D, U> Dispatch<ExtWorkspaceHandleV1, U, D> for WorkspaceManagerState
 where
@@ -88,11 +120,9 @@ where
         proxy: &ExtWorkspaceHandleV1,
         event: Event,
         data: &U,
-        _conn: &Connection,
-        _qhandle: &QueueHandle<D>,
+        conn: &Connection,
+        qhandle: &QueueHandle<D>,
     ) {
-        println!("HANDLE EVENT: {event:?}");
-
         let data = data.workspace_handle_data();
 
         match event {
@@ -119,7 +149,16 @@ where
                 WEnum::Value(capabilities) => lock!(data.inner).capabilities = capabilities,
                 WEnum::Unknown(value) => warn!("received unknown capabilities: {value}"),
             },
-            Event::Removed => proxy.destroy(),
+            Event::Removed => {
+                state.workspace_removed(
+                    conn,
+                    qhandle,
+                    WorkspaceHandle {
+                        handle: proxy.clone(),
+                    },
+                );
+                proxy.destroy();
+            }
             _ => {
                 error!("received unimplemented event {event:?}");
             }

--- a/src/clients/wayland/ext_workspace/manager.rs
+++ b/src/clients/wayland/ext_workspace/manager.rs
@@ -1,0 +1,87 @@
+use super::group_handle::{WorkspaceGroupHandleData, WorkspaceGroupHandleHandler};
+use super::handle::{WorkspaceHandleData, WorkspaceHandleHandler};
+use super::{Workspace, WorkspaceGroup};
+use crate::arc_mut;
+use smithay_client_toolkit::error::GlobalError;
+use smithay_client_toolkit::globals::{GlobalData, ProvidesBoundGlobal};
+use std::sync::{Arc, Mutex};
+use tracing::{debug, error};
+use wayland_client::globals::{BindError, GlobalList};
+use wayland_client::{Connection, Dispatch, QueueHandle, event_created_child};
+use wayland_protocols::ext::workspace::v1::client::{
+    ext_workspace_group_handle_v1::ExtWorkspaceGroupHandleV1,
+    ext_workspace_handle_v1::ExtWorkspaceHandleV1,
+    ext_workspace_manager_v1::{Event, ExtWorkspaceManagerV1},
+};
+
+#[derive(Debug)]
+pub struct WorkspaceManagerState {
+    manager: ExtWorkspaceManagerV1,
+    pending: Vec<WorkspaceGroup>,
+}
+
+#[derive(Debug, Default)]
+struct PendingState {
+    groups: Vec<WorkspaceGroup>,
+    workspaces: Vec<Workspace>,
+}
+
+impl WorkspaceManagerState {
+    pub fn bind<State>(globals: &GlobalList, qh: &QueueHandle<State>) -> Result<Self, BindError>
+    where
+        State: Dispatch<ExtWorkspaceManagerV1, GlobalData, State> + 'static,
+    {
+        let manager = globals.bind(qh, 1..=1, GlobalData)?;
+        debug!("Bound to ExtWorkspaceManagerV1 global");
+
+        Ok(Self {
+            manager,
+            pending: vec![],
+        })
+    }
+}
+
+pub trait WorkspaceManagerHandler: Sized {}
+
+impl ProvidesBoundGlobal<ExtWorkspaceManagerV1, 1> for WorkspaceManagerState {
+    fn bound_global(&self) -> Result<ExtWorkspaceManagerV1, GlobalError> {
+        Ok(self.manager.clone())
+    }
+}
+
+impl<D> Dispatch<ExtWorkspaceManagerV1, GlobalData, D> for WorkspaceManagerState
+where
+    D: Dispatch<ExtWorkspaceManagerV1, GlobalData>
+        + Dispatch<ExtWorkspaceGroupHandleV1, WorkspaceGroupHandleData>
+        + Dispatch<ExtWorkspaceHandleV1, WorkspaceHandleData>
+        + WorkspaceManagerHandler
+        + WorkspaceGroupHandleHandler
+        + WorkspaceHandleHandler
+        + 'static,
+{
+    event_created_child!(D, ExtWorkspaceManagerV1, [
+        0 => (ExtWorkspaceGroupHandleV1, WorkspaceGroupHandleData::default()),
+        1 => (ExtWorkspaceHandleV1, WorkspaceHandleData::default())
+    ]);
+
+    fn event(
+        state: &mut D,
+        _proxy: &ExtWorkspaceManagerV1,
+        event: Event,
+        _data: &GlobalData,
+        _conn: &Connection,
+        _qhandle: &QueueHandle<D>,
+    ) {
+        println!("EVENT: {event:?}");
+
+        match event {
+            Event::WorkspaceGroup { workspace_group } => {}
+            Event::Workspace { workspace } => {}
+            Event::Done => {}
+            Event::Finished => {}
+            _ => {
+                error!("received unimplemented event {event:?}");
+            }
+        }
+    }
+}

--- a/src/clients/wayland/ext_workspace/manager.rs
+++ b/src/clients/wayland/ext_workspace/manager.rs
@@ -1,10 +1,7 @@
 use super::group_handle::{WorkspaceGroupHandleData, WorkspaceGroupHandleHandler};
 use super::handle::{WorkspaceHandleData, WorkspaceHandleHandler};
-use super::{Workspace, WorkspaceGroup};
-use crate::arc_mut;
 use smithay_client_toolkit::error::GlobalError;
 use smithay_client_toolkit::globals::{GlobalData, ProvidesBoundGlobal};
-use std::sync::{Arc, Mutex};
 use tracing::{debug, error};
 use wayland_client::globals::{BindError, GlobalList};
 use wayland_client::{Connection, Dispatch, QueueHandle, event_created_child};
@@ -17,13 +14,6 @@ use wayland_protocols::ext::workspace::v1::client::{
 #[derive(Debug)]
 pub struct WorkspaceManagerState {
     manager: ExtWorkspaceManagerV1,
-    pending: Vec<WorkspaceGroup>,
-}
-
-#[derive(Debug, Default)]
-struct PendingState {
-    groups: Vec<WorkspaceGroup>,
-    workspaces: Vec<Workspace>,
 }
 
 impl WorkspaceManagerState {
@@ -34,14 +24,30 @@ impl WorkspaceManagerState {
         let manager = globals.bind(qh, 1..=1, GlobalData)?;
         debug!("Bound to ExtWorkspaceManagerV1 global");
 
-        Ok(Self {
-            manager,
-            pending: vec![],
-        })
+        Ok(Self { manager })
+    }
+
+    pub fn commit(&self) {
+        self.manager.commit();
     }
 }
 
-pub trait WorkspaceManagerHandler: Sized {}
+pub trait WorkspaceManagerHandler: Sized {
+    fn workspace_group_created(
+        &mut self,
+        conn: &Connection,
+        qh: &QueueHandle<Self>,
+        group: ExtWorkspaceGroupHandleV1,
+    );
+    fn workspace_created(
+        &mut self,
+        conn: &Connection,
+        qh: &QueueHandle<Self>,
+        workspace: ExtWorkspaceHandleV1,
+    );
+    fn workspace_done(&mut self, conn: &Connection, qh: &QueueHandle<Self>);
+    fn workspace_finished(&mut self, conn: &Connection, qh: &QueueHandle<Self>);
+}
 
 impl ProvidesBoundGlobal<ExtWorkspaceManagerV1, 1> for WorkspaceManagerState {
     fn bound_global(&self) -> Result<ExtWorkspaceManagerV1, GlobalError> {
@@ -69,16 +75,18 @@ where
         _proxy: &ExtWorkspaceManagerV1,
         event: Event,
         _data: &GlobalData,
-        _conn: &Connection,
-        _qhandle: &QueueHandle<D>,
+        conn: &Connection,
+        qhandle: &QueueHandle<D>,
     ) {
-        println!("EVENT: {event:?}");
-
         match event {
-            Event::WorkspaceGroup { workspace_group } => {}
-            Event::Workspace { workspace } => {}
-            Event::Done => {}
-            Event::Finished => {}
+            Event::WorkspaceGroup { workspace_group } => {
+                state.workspace_group_created(conn, qhandle, workspace_group);
+            }
+            Event::Workspace { workspace } => {
+                state.workspace_created(conn, qhandle, workspace);
+            }
+            Event::Done => state.workspace_done(conn, qhandle),
+            Event::Finished => state.workspace_finished(conn, qhandle),
             _ => {
                 error!("received unimplemented event {event:?}");
             }

--- a/src/clients/wayland/ext_workspace/mod.rs
+++ b/src/clients/wayland/ext_workspace/mod.rs
@@ -1,0 +1,36 @@
+use super::{Client, Environment};
+use group_handle::WorkspaceGroupHandleHandler;
+use handle::WorkspaceHandleHandler;
+use manager::WorkspaceManagerHandler;
+
+pub use wayland_protocols::ext::workspace::v1::client::{
+    ext_workspace_group_handle_v1::GroupCapabilities,
+    ext_workspace_handle_v1::{State, WorkspaceCapabilities},
+};
+
+pub mod group_handle;
+pub mod handle;
+pub mod manager;
+
+#[derive(Debug, Default, Clone)]
+pub struct WorkspaceGroup {
+    pub output: Option<String>,
+    pub workspaces: Vec<Workspace>,
+}
+
+#[derive(Debug, Clone)]
+pub struct Workspace {
+    pub id: String,
+    pub name: String,
+    pub coordinates: Vec<u32>,
+    pub state: State,
+    pub capabilities: WorkspaceCapabilities,
+}
+
+impl Client {}
+
+impl WorkspaceManagerHandler for Environment {}
+
+impl WorkspaceGroupHandleHandler for Environment {}
+
+impl WorkspaceHandleHandler for Environment {}

--- a/src/clients/wayland/ext_workspace/mod.rs
+++ b/src/clients/wayland/ext_workspace/mod.rs
@@ -1,11 +1,9 @@
-use super::{Client, Environment};
-use group_handle::WorkspaceGroupHandleHandler;
-use handle::WorkspaceHandleHandler;
-use manager::WorkspaceManagerHandler;
+use super::{Client, Request, Response};
+use crate::channels::SyncSenderExt;
+use tokio::sync::broadcast;
 
-pub use wayland_protocols::ext::workspace::v1::client::{
-    ext_workspace_group_handle_v1::GroupCapabilities,
-    ext_workspace_handle_v1::{State, WorkspaceCapabilities},
+pub use wayland_protocols::ext::workspace::v1::client::ext_workspace_handle_v1::{
+    State, WorkspaceCapabilities,
 };
 
 pub mod group_handle;
@@ -27,10 +25,52 @@ pub struct Workspace {
     pub capabilities: WorkspaceCapabilities,
 }
 
-impl Client {}
+#[cfg(feature = "workspaces")]
+impl Client {
+    pub fn workspace_info_all(&self) -> Vec<crate::clients::compositor::Workspace> {
+        match self.send_request(Request::WorkspaceInfoAll) {
+            Response::WorkspaceInfoAll(workspaces) => workspaces,
+            _ => vec![],
+        }
+    }
 
-impl WorkspaceManagerHandler for Environment {}
+    pub fn subscribe_workspaces(
+        &self,
+    ) -> broadcast::Receiver<crate::clients::compositor::WorkspaceUpdate> {
+        self.workspace_channel.0.subscribe()
+    }
+}
 
-impl WorkspaceGroupHandleHandler for Environment {}
+#[cfg(feature = "workspaces")]
+impl crate::clients::compositor::WorkspaceClient for Client {
+    fn focus(&self, id: i64) {
+        self.activate_exclusive(id);
+    }
 
-impl WorkspaceHandleHandler for Environment {}
+    fn activate(&self, id: i64) {
+        self.send_request(Request::WorkspaceActivate(id));
+    }
+
+    fn deactivate(&self, id: i64) {
+        self.send_request(Request::WorkspaceDeactivate(id));
+    }
+
+    fn toggle(&self, id: i64) {
+        self.send_request(Request::WorkspaceToggle(id));
+    }
+
+    fn activate_exclusive(&self, id: i64) {
+        self.send_request(Request::WorkspaceActivateExclusive(id));
+    }
+
+    fn subscribe(&self) -> broadcast::Receiver<crate::clients::compositor::WorkspaceUpdate> {
+        let rx = self.subscribe_workspaces();
+        let workspaces = self.workspace_info_all();
+        self.workspace_channel
+            .0
+            .send_expect(crate::clients::compositor::WorkspaceUpdate::Init(
+                workspaces,
+            ));
+        rx
+    }
+}

--- a/src/clients/wayland/macros.rs
+++ b/src/clients/wayland/macros.rs
@@ -99,3 +99,52 @@ macro_rules! delegate_foreign_toplevel_handle {
         );
     };
 }
+
+// --- Workspace --- \\
+
+#[macro_export]
+macro_rules! delegate_workspace_manager {
+    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
+        wayland_client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty:
+            [
+                wayland_protocols::ext::workspace::v1::client::ext_workspace_manager_v1::ExtWorkspaceManagerV1: smithay_client_toolkit::globals::GlobalData
+            ] => $crate::clients::wayland::ext_workspace::manager::WorkspaceManagerState
+        );
+    };
+}
+
+#[macro_export]
+macro_rules! delegate_workspace_group_handle {
+    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty, udata: [$($udata: ty),*$(,)?]) => {
+        wayland_client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty:
+            [
+                wayland_protocols::ext::workspace::v1::client::ext_workspace_group_handle_v1::ExtWorkspaceGroupHandleV1: $udata,
+            ] => $crate::clients::wayland::ext_workspace::manager::WorkspaceManagerState
+        );
+    };
+    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
+        wayland_client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty:
+            [
+                wayland_protocols::ext::workspace::v1::client::ext_workspace_group_handle_v1::ExtWorkspaceGroupHandleV1: $crate::clients::wayland::ext_workspace::group_handle::WorkspaceGroupHandleData
+            ] => $crate::clients::wayland::ext_workspace::manager::WorkspaceManagerState
+        );
+    };
+}
+
+#[macro_export]
+macro_rules! delegate_workspace_handle {
+    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty, udata: [$($udata: ty),*$(,)?]) => {
+        wayland_client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty:
+            [
+                wayland_protocols::ext::workspace::v1::client::ext_workspace_handle_v1::ExtWorkspaceHandleV1: $udata,
+            ] => $crate::clients::wayland::ext_workspace::manager::WorkspaceManagerState
+        );
+    };
+    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
+        wayland_client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty:
+            [
+                wayland_protocols::ext::workspace::v1::client::ext_workspace_handle_v1::ExtWorkspaceHandleV1: $crate::clients::wayland::ext_workspace::handle::WorkspaceHandleData
+            ] => $crate::clients::wayland::ext_workspace::manager::WorkspaceManagerState
+        );
+    };
+}

--- a/src/clients/wayland/mod.rs
+++ b/src/clients/wayland/mod.rs
@@ -1,13 +1,18 @@
+mod ext_workspace;
 mod macros;
 mod wl_output;
 mod wl_seat;
 
 use crate::error::{ERR_CHANNEL_RECV, ExitCode};
-use crate::{arc_mut, lock, register_client, spawn, spawn_blocking};
+use crate::{
+    arc_mut, delegate_workspace_group_handle, delegate_workspace_handle,
+    delegate_workspace_manager, lock, register_client, spawn, spawn_blocking,
+};
 use std::process::exit;
 use std::sync::{Arc, Mutex};
 
 use crate::channels::SyncSenderExt;
+use crate::clients::wayland::ext_workspace::manager::WorkspaceManagerState;
 use calloop_channel::Event::Msg;
 use cfg_if::cfg_if;
 use smithay_client_toolkit::output::OutputState;
@@ -225,6 +230,9 @@ pub struct Environment {
     #[cfg(feature = "clipboard")]
     copy_paste_sources: Vec<CopyPasteSource>,
 
+    // -- workspaces
+    workspace_manager_state: Option<WorkspaceManagerState>,
+
     // local state
     #[cfg(feature = "clipboard")]
     clipboard: Arc<Mutex<Option<ClipboardItem>>>,
@@ -250,6 +258,10 @@ cfg_if! {
         delegate_data_control_source!(Environment);
     }
 }
+
+delegate_workspace_manager!(Environment);
+delegate_workspace_group_handle!(Environment);
+delegate_workspace_handle!(Environment);
 
 impl Environment {
     pub fn spawn(
@@ -305,12 +317,28 @@ impl Environment {
                 }
             };
 
+        let workspace_manager_state = match WorkspaceManagerState::bind(&globals, &qh) {
+            Ok(state) => Some(state),
+            Err(error) => {
+                error!(
+                    "{}",
+                    Error::UnsupportedProtocol {
+                        error,
+                        name: "ext_workspace",
+                        modules: &["workspaces"]
+                    }
+                );
+                None
+            }
+        };
+
         let mut env = Self {
             registry_state,
             output_state,
             seat_state,
             #[cfg(feature = "clipboard")]
             data_control_device_manager_state,
+            workspace_manager_state,
             queue_handle: qh,
             event_tx,
             response_tx,

--- a/src/clients/wayland/mod.rs
+++ b/src/clients/wayland/mod.rs
@@ -8,10 +8,24 @@ use crate::{
     arc_mut, delegate_workspace_group_handle, delegate_workspace_handle,
     delegate_workspace_manager, lock, register_client, spawn, spawn_blocking,
 };
+#[cfg(feature = "workspaces")]
+use std::collections::{HashMap, HashSet};
 use std::process::exit;
 use std::sync::{Arc, Mutex};
 
-use crate::channels::SyncSenderExt;
+use crate::channels::{AsyncSenderExt, SyncSenderExt};
+#[cfg(feature = "workspaces")]
+use crate::clients::compositor::{Visibility, Workspace, WorkspaceUpdate};
+#[cfg(feature = "workspaces")]
+use crate::clients::wayland::ext_workspace::group_handle::WorkspaceGroupHandleData;
+#[cfg(feature = "workspaces")]
+use crate::clients::wayland::ext_workspace::group_handle::WorkspaceGroupHandleHandler;
+#[cfg(feature = "workspaces")]
+use crate::clients::wayland::ext_workspace::handle::WorkspaceHandleData;
+#[cfg(feature = "workspaces")]
+use crate::clients::wayland::ext_workspace::handle::WorkspaceHandleHandler;
+#[cfg(feature = "workspaces")]
+use crate::clients::wayland::ext_workspace::manager::WorkspaceManagerHandler;
 use crate::clients::wayland::ext_workspace::manager::WorkspaceManagerState;
 use calloop_channel::Event::Msg;
 use cfg_if::cfg_if;
@@ -27,9 +41,18 @@ use smithay_client_toolkit::{
 };
 use thiserror::Error;
 use tokio::sync::{broadcast, mpsc};
-use tracing::{debug, error, trace};
+use tracing::{debug, error, trace, warn};
+#[cfg(feature = "workspaces")]
+use wayland_client::backend::ObjectId;
 use wayland_client::globals::{BindError, registry_queue_init};
-use wayland_client::{Connection, QueueHandle};
+#[cfg(feature = "workspaces")]
+use wayland_client::protocol::wl_output::WlOutput;
+use wayland_client::{Connection, Proxy, QueueHandle};
+#[cfg(feature = "workspaces")]
+use wayland_protocols::ext::workspace::v1::client::{
+    ext_workspace_group_handle_v1::ExtWorkspaceGroupHandleV1,
+    ext_workspace_handle_v1::ExtWorkspaceHandleV1,
+};
 pub use wl_output::{OutputEvent, OutputEventType};
 
 cfg_if! {
@@ -69,6 +92,8 @@ pub enum Event {
     Toplevel(ToplevelEvent),
     #[cfg(feature = "clipboard")]
     Clipboard(ClipboardItem),
+    #[cfg(feature = "workspaces")]
+    Workspace(WorkspaceUpdate),
 }
 
 #[derive(Debug)]
@@ -88,6 +113,17 @@ pub enum Request {
     CopyToClipboard(ClipboardItem),
     #[cfg(feature = "clipboard")]
     ClipboardItem,
+
+    #[cfg(feature = "workspaces")]
+    WorkspaceInfoAll,
+    #[cfg(feature = "workspaces")]
+    WorkspaceActivate(i64),
+    #[cfg(feature = "workspaces")]
+    WorkspaceDeactivate(i64),
+    #[cfg(feature = "workspaces")]
+    WorkspaceToggle(i64),
+    #[cfg(feature = "workspaces")]
+    WorkspaceActivateExclusive(i64),
 }
 
 #[derive(Debug)]
@@ -102,6 +138,9 @@ pub enum Response {
 
     #[cfg(feature = "clipboard")]
     ClipboardItem(Option<ClipboardItem>),
+
+    #[cfg(feature = "workspaces")]
+    WorkspaceInfoAll(Vec<Workspace>),
 }
 
 #[derive(Debug)]
@@ -112,6 +151,23 @@ impl<T> From<(broadcast::Sender<T>, broadcast::Receiver<T>)> for BroadcastChanne
     fn from(value: (broadcast::Sender<T>, broadcast::Receiver<T>)) -> Self {
         Self(value.0, arc_mut!(value.1))
     }
+}
+
+#[cfg(feature = "workspaces")]
+#[derive(Debug, Clone)]
+struct WorkspaceSnapshot {
+    workspace: Workspace,
+    urgent: bool,
+}
+
+#[cfg(feature = "workspaces")]
+#[derive(Debug, Default)]
+struct WorkspaceState {
+    groups: HashMap<ObjectId, ExtWorkspaceGroupHandleV1>,
+    workspaces: HashMap<ObjectId, ExtWorkspaceHandleV1>,
+    group_for_workspace: HashMap<ObjectId, ObjectId>,
+    last_snapshot: Vec<WorkspaceSnapshot>,
+    initialized: bool,
 }
 
 #[derive(Debug, Error)]
@@ -138,6 +194,8 @@ pub struct Client {
     toplevel_channel: BroadcastChannel<ToplevelEvent>,
     #[cfg(feature = "clipboard")]
     clipboard_channel: BroadcastChannel<ClipboardItem>,
+    #[cfg(feature = "workspaces")]
+    workspace_channel: BroadcastChannel<WorkspaceUpdate>,
 }
 
 impl Client {
@@ -153,6 +211,8 @@ impl Client {
 
         #[cfg(feature = "clipboard")]
         let clipboard_channel = broadcast::channel(32);
+        #[cfg(feature = "workspaces")]
+        let workspace_channel = broadcast::channel(32);
 
         spawn_blocking(move || {
             Environment::spawn(event_tx, request_rx, response_tx);
@@ -166,6 +226,8 @@ impl Client {
 
             #[cfg(feature = "clipboard")]
             let clipboard_tx = clipboard_channel.0.clone();
+            #[cfg(feature = "workspaces")]
+            let workspace_tx = workspace_channel.0.clone();
 
             spawn(async move {
                 while let Some(event) = event_rx.recv().await {
@@ -175,6 +237,8 @@ impl Client {
                         Event::Toplevel(event) => toplevel_tx.send_expect(event),
                         #[cfg(feature = "clipboard")]
                         Event::Clipboard(item) => clipboard_tx.send_expect(item),
+                        #[cfg(feature = "workspaces")]
+                        Event::Workspace(update) => workspace_tx.send_expect(update),
                     }
                 }
             });
@@ -189,14 +253,19 @@ impl Client {
             toplevel_channel: toplevel_channel.into(),
             #[cfg(feature = "clipboard")]
             clipboard_channel: clipboard_channel.into(),
+            #[cfg(feature = "workspaces")]
+            workspace_channel: workspace_channel.into(),
         }
     }
 
     /// Sends a request to the environment event loop,
     /// and returns the response.
     fn send_request(&self, request: Request) -> Response {
+        // Serialize request/response pairs so concurrent callers cannot
+        // consume each other's responses from the shared channel.
+        let rx = &mut *lock!(self.rx);
         self.tx.send_expect(request);
-        lock!(self.rx).recv().expect(ERR_CHANNEL_RECV)
+        rx.recv().expect(ERR_CHANNEL_RECV)
     }
 
     /// Sends a round-trip request to the client,
@@ -232,6 +301,8 @@ pub struct Environment {
 
     // -- workspaces
     workspace_manager_state: Option<WorkspaceManagerState>,
+    #[cfg(feature = "workspaces")]
+    workspace_state: WorkspaceState,
 
     // local state
     #[cfg(feature = "clipboard")]
@@ -318,7 +389,10 @@ impl Environment {
             };
 
         let workspace_manager_state = match WorkspaceManagerState::bind(&globals, &qh) {
-            Ok(state) => Some(state),
+            Ok(state) => {
+                debug!("ext-workspace manager is available");
+                Some(state)
+            }
             Err(error) => {
                 error!(
                     "{}",
@@ -339,6 +413,8 @@ impl Environment {
             #[cfg(feature = "clipboard")]
             data_control_device_manager_state,
             workspace_manager_state,
+            #[cfg(feature = "workspaces")]
+            workspace_state: WorkspaceState::default(),
             queue_handle: qh,
             event_tx,
             response_tx,
@@ -428,8 +504,470 @@ impl Environment {
                 let item = lock!(env.clipboard).clone();
                 env.response_tx.send_expect(Response::ClipboardItem(item));
             }
+            #[cfg(feature = "workspaces")]
+            Msg(Request::WorkspaceInfoAll) => {
+                let workspaces = env.workspace_info_all();
+                env.response_tx
+                    .send_expect(Response::WorkspaceInfoAll(workspaces));
+            }
+            #[cfg(feature = "workspaces")]
+            Msg(Request::WorkspaceActivate(id)) => {
+                env.workspace_activate(id);
+                env.response_tx.send_expect(Response::Ok);
+            }
+            #[cfg(feature = "workspaces")]
+            Msg(Request::WorkspaceDeactivate(id)) => {
+                env.workspace_deactivate(id);
+                env.response_tx.send_expect(Response::Ok);
+            }
+            #[cfg(feature = "workspaces")]
+            Msg(Request::WorkspaceToggle(id)) => {
+                env.workspace_toggle(id);
+                env.response_tx.send_expect(Response::Ok);
+            }
+            #[cfg(feature = "workspaces")]
+            Msg(Request::WorkspaceActivateExclusive(id)) => {
+                env.workspace_activate_exclusive(id);
+                env.response_tx.send_expect(Response::Ok);
+            }
             calloop_channel::Event::Closed => error!("request channel unexpectedly closed"),
         }
+    }
+}
+
+#[cfg(feature = "workspaces")]
+impl Environment {
+    fn workspace_info_all(&self) -> Vec<Workspace> {
+        if self.workspace_manager_state.is_none() {
+            debug!("workspace_info_all requested but ext-workspace manager is unavailable");
+        }
+        self.workspace_state
+            .last_snapshot
+            .iter()
+            .map(|snapshot| snapshot.workspace.clone())
+            .collect()
+    }
+
+    fn workspace_activate(&mut self, id: i64) {
+        let Some(manager) = self.workspace_manager_state.as_ref() else {
+            debug!("workspace activate requested but ext-workspace is unavailable");
+            return;
+        };
+
+        let Some(handle) = self.workspace_handle_by_internal_id(id) else {
+            debug!("workspace handle not found for id {id}");
+            return;
+        };
+
+        if self.workspace_is_active(&handle) {
+            return;
+        }
+
+        handle.activate();
+        manager.commit();
+    }
+
+    fn workspace_deactivate(&mut self, id: i64) {
+        let Some(manager) = self.workspace_manager_state.as_ref() else {
+            debug!("workspace deactivate requested but ext-workspace is unavailable");
+            return;
+        };
+
+        let Some(handle) = self.workspace_handle_by_internal_id(id) else {
+            debug!("workspace handle not found for id {id}");
+            return;
+        };
+
+        if !self.workspace_is_active(&handle) {
+            return;
+        }
+
+        handle.deactivate();
+        manager.commit();
+    }
+
+    fn workspace_toggle(&mut self, id: i64) {
+        let Some(handle) = self.workspace_handle_by_internal_id(id) else {
+            debug!("workspace handle not found for id {id}");
+            return;
+        };
+
+        if self.workspace_is_active(&handle) {
+            self.workspace_deactivate(id);
+        } else {
+            self.workspace_activate(id);
+        }
+    }
+
+    fn workspace_activate_exclusive(&mut self, id: i64) {
+        let Some(manager) = self.workspace_manager_state.as_ref() else {
+            debug!("workspace activate exclusive requested but ext-workspace is unavailable");
+            return;
+        };
+
+        let Some(clicked) = self.workspace_handle_by_internal_id(id) else {
+            debug!("workspace handle not found for id {id}");
+            return;
+        };
+
+        let clicked_id = clicked.id();
+        let clicked_group = self
+            .workspace_state
+            .group_for_workspace
+            .get(&clicked_id)
+            .cloned();
+        let clicked_outputs = self.workspace_output_ids_for_workspace(&clicked);
+
+        let mut to_deactivate = Vec::new();
+        for handle in self.workspace_state.workspaces.values() {
+            if handle.id() == clicked_id {
+                continue;
+            }
+
+            let same_output = if !clicked_outputs.is_empty() {
+                !self
+                    .workspace_output_ids_for_workspace(handle)
+                    .is_disjoint(&clicked_outputs)
+            } else if let Some(clicked_group) = clicked_group.as_ref() {
+                self.workspace_state
+                    .group_for_workspace
+                    .get(&handle.id())
+                    .is_some_and(|group| group == clicked_group)
+            } else {
+                false
+            };
+
+            if same_output {
+                to_deactivate.push(handle.clone());
+            }
+        }
+
+        for handle in to_deactivate {
+            handle.deactivate();
+        }
+
+        clicked.activate();
+        manager.commit();
+    }
+
+    fn workspace_handle_by_internal_id(&self, id: i64) -> Option<ExtWorkspaceHandleV1> {
+        self.workspace_state
+            .workspaces
+            .values()
+            .find(|handle| {
+                handle
+                    .data::<WorkspaceHandleData>()
+                    .is_some_and(|data| data.info().internal_id == id)
+            })
+            .cloned()
+    }
+
+    fn workspace_is_active(&self, handle: &ExtWorkspaceHandleV1) -> bool {
+        handle
+            .data::<WorkspaceHandleData>()
+            .is_some_and(|data| data.info().state.bits() & 1 != 0)
+    }
+
+    fn workspace_group_created(&mut self, group: ExtWorkspaceGroupHandleV1) {
+        debug!("workspace group created: {:?}", group.id());
+        self.workspace_state.groups.insert(group.id(), group);
+    }
+
+    fn workspace_group_removed(&mut self, group: ExtWorkspaceGroupHandleV1) {
+        let group_id = group.id();
+        debug!("workspace group removed: {group_id:?}");
+        self.workspace_state.groups.remove(&group_id);
+        self.workspace_state
+            .group_for_workspace
+            .retain(|_, mapped_group| mapped_group != &group_id);
+    }
+
+    fn workspace_created(&mut self, workspace: ExtWorkspaceHandleV1) {
+        trace!("workspace handle created: {:?}", workspace.id());
+        self.workspace_state
+            .workspaces
+            .insert(workspace.id(), workspace);
+    }
+
+    fn workspace_removed(&mut self, workspace: ExtWorkspaceHandleV1) {
+        let workspace_id = workspace.id();
+        debug!("workspace handle removed: {workspace_id:?}");
+        self.workspace_state.workspaces.remove(&workspace_id);
+        self.workspace_state
+            .group_for_workspace
+            .remove(&workspace_id);
+    }
+
+    fn workspace_group_workspace_enter(
+        &mut self,
+        group: ExtWorkspaceGroupHandleV1,
+        workspace: ExtWorkspaceHandleV1,
+    ) {
+        trace!(
+            "workspace entered group: workspace={:?} group={:?}",
+            workspace.id(),
+            group.id()
+        );
+        self.workspace_state
+            .group_for_workspace
+            .insert(workspace.id(), group.id());
+    }
+
+    fn workspace_group_workspace_leave(
+        &mut self,
+        group: ExtWorkspaceGroupHandleV1,
+        workspace: ExtWorkspaceHandleV1,
+    ) {
+        let workspace_id = workspace.id();
+        trace!(
+            "workspace left group: workspace={workspace_id:?} group={:?}",
+            group.id()
+        );
+        if self
+            .workspace_state
+            .group_for_workspace
+            .get(&workspace_id)
+            .is_some_and(|mapped_group| mapped_group == &group.id())
+        {
+            self.workspace_state
+                .group_for_workspace
+                .remove(&workspace_id);
+        }
+    }
+
+    fn workspace_done(&mut self) {
+        if self.workspace_manager_state.is_none() {
+            return;
+        }
+
+        let snapshot = self.build_workspace_snapshot();
+        debug!(
+            "workspace done: groups={} workspaces={} mapped={} snapshot={}",
+            self.workspace_state.groups.len(),
+            self.workspace_state.workspaces.len(),
+            self.workspace_state.group_for_workspace.len(),
+            snapshot.len()
+        );
+        self.apply_workspace_snapshot(snapshot);
+    }
+
+    fn workspace_finished(&mut self) {
+        warn!("ext-workspace manager finished");
+    }
+
+    fn build_workspace_snapshot(&self) -> Vec<WorkspaceSnapshot> {
+        let mut snapshots = Vec::new();
+
+        for (workspace_id, workspace_handle) in &self.workspace_state.workspaces {
+            let Some(data) = workspace_handle.data::<WorkspaceHandleData>() else {
+                continue;
+            };
+            let info = data.info();
+
+            let Some(group_id) = self.workspace_state.group_for_workspace.get(workspace_id) else {
+                continue;
+            };
+
+            let Some(group_handle) = self.workspace_state.groups.get(group_id) else {
+                continue;
+            };
+
+            let monitor = self.output_name_from_group(group_handle);
+            let index = if let Some(index) = info.coordinates.first() {
+                *index as i64
+            } else if let Ok(parsed) = info.name.parse::<i64>() {
+                parsed
+            } else {
+                info.internal_id
+            };
+
+            let bits = info.state.bits();
+            let is_hidden = bits & 4 != 0;
+            let is_active = bits & 1 != 0;
+            let urgent = bits & 2 != 0;
+
+            let visibility = if is_hidden {
+                Visibility::Hidden
+            } else if is_active {
+                Visibility::focused()
+            } else {
+                Visibility::visible()
+            };
+
+            snapshots.push(WorkspaceSnapshot {
+                workspace: Workspace {
+                    id: info.internal_id,
+                    index,
+                    name: info.name,
+                    monitor,
+                    visibility,
+                },
+                urgent,
+            });
+        }
+
+        snapshots.sort_by(|a, b| {
+            (
+                a.workspace.monitor.as_str(),
+                a.workspace.index,
+                a.workspace.name.as_str(),
+            )
+                .cmp(&(
+                    b.workspace.monitor.as_str(),
+                    b.workspace.index,
+                    b.workspace.name.as_str(),
+                ))
+        });
+
+        snapshots
+    }
+
+    fn apply_workspace_snapshot(&mut self, snapshot: Vec<WorkspaceSnapshot>) {
+        if !self.workspace_state.initialized {
+            let workspaces = snapshot
+                .iter()
+                .map(|entry| entry.workspace.clone())
+                .collect::<Vec<_>>();
+
+            self.workspace_state.last_snapshot = snapshot.clone();
+            self.workspace_state.initialized = true;
+            debug!(
+                "workspace init snapshot contains {} workspaces",
+                workspaces.len()
+            );
+            self.event_tx
+                .send_spawn(Event::Workspace(WorkspaceUpdate::Init(workspaces)));
+
+            for entry in snapshot {
+                if entry.urgent {
+                    self.event_tx
+                        .send_spawn(Event::Workspace(WorkspaceUpdate::Urgent {
+                            id: entry.workspace.id,
+                            urgent: true,
+                        }));
+                }
+            }
+
+            return;
+        }
+
+        let old_snapshot = self.workspace_state.last_snapshot.clone();
+        let mut updates = Vec::new();
+
+        let mut old_by_id = HashMap::new();
+        for entry in &old_snapshot {
+            old_by_id.insert(entry.workspace.id, entry);
+        }
+
+        let mut new_by_id = HashMap::new();
+        for entry in &snapshot {
+            new_by_id.insert(entry.workspace.id, entry);
+        }
+
+        for entry in &snapshot {
+            match old_by_id.get(&entry.workspace.id) {
+                None => updates.push(WorkspaceUpdate::Add(entry.workspace.clone())),
+                Some(old_entry) => {
+                    if entry.workspace.name != old_entry.workspace.name {
+                        updates.push(WorkspaceUpdate::Rename {
+                            id: entry.workspace.id,
+                            name: entry.workspace.name.clone(),
+                        });
+                    }
+
+                    if entry.workspace.monitor != old_entry.workspace.monitor
+                        || entry.workspace.index != old_entry.workspace.index
+                    {
+                        updates.push(WorkspaceUpdate::Move(entry.workspace.clone()));
+                    }
+
+                    if entry.urgent != old_entry.urgent {
+                        updates.push(WorkspaceUpdate::Urgent {
+                            id: entry.workspace.id,
+                            urgent: entry.urgent,
+                        });
+                    }
+                }
+            }
+        }
+
+        for entry in &old_snapshot {
+            if !new_by_id.contains_key(&entry.workspace.id) {
+                updates.push(WorkspaceUpdate::Remove(entry.workspace.id));
+            }
+        }
+
+        let mut old_focused = HashMap::new();
+        for entry in &old_snapshot {
+            if entry.workspace.visibility.is_focused() {
+                old_focused.insert(entry.workspace.monitor.clone(), entry.workspace.clone());
+            }
+        }
+
+        let mut new_focused = HashMap::new();
+        for entry in &snapshot {
+            if entry.workspace.visibility.is_focused() {
+                new_focused.insert(entry.workspace.monitor.clone(), entry.workspace.clone());
+            }
+        }
+
+        for (monitor, new_workspace) in &new_focused {
+            let old_workspace = old_focused.get(monitor).cloned();
+            let old_id = old_workspace.as_ref().map(|w| w.id);
+            if old_id != Some(new_workspace.id) {
+                updates.push(WorkspaceUpdate::Focus {
+                    old: old_workspace,
+                    new: new_workspace.clone(),
+                });
+            }
+        }
+
+        self.workspace_state.last_snapshot = snapshot;
+
+        debug!("emitting {} workspace updates", updates.len());
+        for update in updates {
+            self.event_tx.send_spawn(Event::Workspace(update));
+        }
+    }
+
+    fn output_name_from_group(&self, group: &ExtWorkspaceGroupHandleV1) -> String {
+        let Some(data) = group.data::<WorkspaceGroupHandleData>() else {
+            return String::new();
+        };
+
+        for output in data.outputs() {
+            if let Some(info) = self.output_state.info(&output) {
+                if let Some(name) = info.name {
+                    return name;
+                }
+            }
+        }
+
+        String::new()
+    }
+
+    fn workspace_output_ids_for_workspace(
+        &self,
+        workspace: &ExtWorkspaceHandleV1,
+    ) -> HashSet<ObjectId> {
+        let Some(group_id) = self
+            .workspace_state
+            .group_for_workspace
+            .get(&workspace.id())
+        else {
+            return HashSet::new();
+        };
+        let Some(group) = self.workspace_state.groups.get(group_id) else {
+            return HashSet::new();
+        };
+        let Some(data) = group.data::<WorkspaceGroupHandleData>() else {
+            return HashSet::new();
+        };
+
+        data.outputs()
+            .into_iter()
+            .map(|output| output.id())
+            .collect()
     }
 }
 
@@ -438,6 +976,97 @@ impl ProvidesRegistryState for Environment {
         &mut self.registry_state
     }
     registry_handlers![OutputState, SeatState];
+}
+
+#[cfg(feature = "workspaces")]
+impl WorkspaceManagerHandler for Environment {
+    fn workspace_group_created(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        group: ExtWorkspaceGroupHandleV1,
+    ) {
+        self.workspace_group_created(group);
+    }
+
+    fn workspace_created(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        workspace: ExtWorkspaceHandleV1,
+    ) {
+        self.workspace_created(workspace);
+    }
+
+    fn workspace_done(&mut self, _conn: &Connection, _qh: &QueueHandle<Self>) {
+        self.workspace_done();
+    }
+
+    fn workspace_finished(&mut self, _conn: &Connection, _qh: &QueueHandle<Self>) {
+        self.workspace_finished();
+    }
+}
+
+#[cfg(feature = "workspaces")]
+impl WorkspaceGroupHandleHandler for Environment {
+    fn workspace_group_output_enter(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _group: ext_workspace::group_handle::WorkspaceGroupHandle,
+        _output: WlOutput,
+    ) {
+    }
+
+    fn workspace_group_output_leave(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _group: ext_workspace::group_handle::WorkspaceGroupHandle,
+        _output: WlOutput,
+    ) {
+    }
+
+    fn workspace_group_workspace_enter(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        group: ext_workspace::group_handle::WorkspaceGroupHandle,
+        workspace: ExtWorkspaceHandleV1,
+    ) {
+        self.workspace_group_workspace_enter(group.handle, workspace);
+    }
+
+    fn workspace_group_workspace_leave(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        group: ext_workspace::group_handle::WorkspaceGroupHandle,
+        workspace: ExtWorkspaceHandleV1,
+    ) {
+        self.workspace_group_workspace_leave(group.handle, workspace);
+    }
+
+    fn workspace_group_removed(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        group: ext_workspace::group_handle::WorkspaceGroupHandle,
+    ) {
+        self.workspace_group_removed(group.handle);
+    }
+}
+
+#[cfg(feature = "workspaces")]
+impl WorkspaceHandleHandler for Environment {
+    fn workspace_removed(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        handle: ext_workspace::handle::WorkspaceHandle,
+    ) {
+        self.workspace_removed(handle.handle);
+    }
 }
 
 register_client!(Client, wayland);

--- a/src/clients/wayland/mod.rs
+++ b/src/clients/wayland/mod.rs
@@ -900,25 +900,30 @@ impl Environment {
         let mut old_focused = HashMap::new();
         for entry in &old_snapshot {
             if entry.workspace.visibility.is_focused() {
-                old_focused.insert(entry.workspace.monitor.clone(), entry.workspace.clone());
+                old_focused.insert(entry.workspace.id, entry.workspace.clone());
             }
         }
 
         let mut new_focused = HashMap::new();
         for entry in &snapshot {
             if entry.workspace.visibility.is_focused() {
-                new_focused.insert(entry.workspace.monitor.clone(), entry.workspace.clone());
+                new_focused.insert(entry.workspace.id, entry.workspace.clone());
             }
         }
 
-        for (monitor, new_workspace) in &new_focused {
-            let old_workspace = old_focused.get(monitor).cloned();
-            let old_id = old_workspace.as_ref().map(|w| w.id);
-            if old_id != Some(new_workspace.id) {
+        // manually focus without old here and explicitly use unfocus later on. to comply with existing hyprland behavior but allow to go from like 5 Focused to 1 Focused workspace
+        for (id, new_workspace) in &new_focused {
+            if !old_focused.contains_key(id) {
                 updates.push(WorkspaceUpdate::Focus {
-                    old: old_workspace,
+                    old: None,
                     new: new_workspace.clone(),
                 });
+            }
+        }
+
+        for (id, old_workspace) in &old_focused {
+            if !new_focused.contains_key(id) {
+                updates.push(WorkspaceUpdate::Unfocus(old_workspace.clone()));
             }
         }
 

--- a/src/clients/wayland/wlr_foreign_toplevel/manager.rs
+++ b/src/clients/wayland/wlr_foreign_toplevel/manager.rs
@@ -48,7 +48,7 @@ where
         + ToplevelManagerHandler
         + ToplevelHandleHandler
         + 'static,
-    V: ToplevelHandleDataExt + Default + 'static + Send + Sync,
+    V: ToplevelHandleDataExt + Default + Send + Sync + 'static,
 {
     event_created_child!(D, ZwlrForeignToplevelManagerV1, [
         0 => (ZwlrForeignToplevelHandleV1, V::default())

--- a/src/modules/workspaces/button.rs
+++ b/src/modules/workspaces/button.rs
@@ -1,9 +1,10 @@
 use super::open_state::OpenState;
 use crate::channels::AsyncSenderExt;
 use crate::image::IconButton;
-use crate::modules::workspaces::WorkspaceItemContext;
+use crate::modules::workspaces::{WorkspaceClickEvent, WorkspaceItemContext};
 use glib::signal::SignalHandlerId;
 use gtk::Button as GtkButton;
+use gtk::gdk;
 use gtk::prelude::*;
 use tokio::sync::mpsc;
 
@@ -11,8 +12,10 @@ use tokio::sync::mpsc;
 pub struct Button {
     button: IconButton,
     workspace_id: i64,
-    conn_id: Option<SignalHandlerId>,
-    tx: mpsc::Sender<i64>,
+    left_conn_id: Option<SignalHandlerId>,
+    right_click: gtk::GestureClick,
+    right_conn_id: Option<SignalHandlerId>,
+    tx: mpsc::Sender<WorkspaceClickEvent>,
 }
 
 impl Button {
@@ -31,14 +34,26 @@ impl Button {
 
         let tx = context.tx.clone();
 
-        let conn_id = button.connect_clicked(move |_item| {
-            tx.send_spawn(id);
+        let left_conn_id = button.connect_clicked(move |_item| {
+            tx.send_spawn(WorkspaceClickEvent::Left(id));
         });
+
+        let right_click = gtk::GestureClick::new();
+        right_click.set_button(gdk::BUTTON_SECONDARY);
+
+        let tx = context.tx.clone();
+        let right_conn_id = right_click.connect_pressed(move |_gesture, _, _, _| {
+            tx.send_spawn(WorkspaceClickEvent::Right(id));
+        });
+
+        button.add_controller(right_click.clone());
 
         let btn = Self {
             button,
             workspace_id: id,
-            conn_id: Some(conn_id),
+            left_conn_id: Some(left_conn_id),
+            right_click,
+            right_conn_id: Some(right_conn_id),
             tx: context.tx.clone(),
         };
 
@@ -88,13 +103,22 @@ impl Button {
 
     pub fn set_workspace_id(&mut self, id: i64) {
         self.workspace_id = id;
-        if let Some(conn_id) = self.conn_id.take() {
+        if let Some(conn_id) = self.left_conn_id.take() {
             self.button.disconnect(conn_id);
         }
+        if let Some(conn_id) = self.right_conn_id.take() {
+            self.right_click.disconnect(conn_id);
+        }
         let tx = self.tx.clone();
-        let conn_id = self.button.connect_clicked(move |_item| {
-            tx.send_spawn(id);
+        let left_conn_id = self.button.connect_clicked(move |_item| {
+            tx.send_spawn(WorkspaceClickEvent::Left(id));
         });
-        self.conn_id = Some(conn_id);
+        self.left_conn_id = Some(left_conn_id);
+
+        let tx = self.tx.clone();
+        let right_conn_id = self.right_click.connect_pressed(move |_gesture, _, _, _| {
+            tx.send_spawn(WorkspaceClickEvent::Right(id));
+        });
+        self.right_conn_id = Some(right_conn_id);
     }
 }

--- a/src/modules/workspaces/mod.rs
+++ b/src/modules/workspaces/mod.rs
@@ -565,6 +565,16 @@ impl Module<gtk::Box> for WorkspacesModule {
                             button.set_open_state(OpenState::Focused);
                         }
                     }
+                    WorkspaceUpdate::Unfocus(workspace) if has_initialized => {
+                        if let Some(button) = button_map.find_button_mut(&workspace) {
+                            let open_state = if workspace.visibility.is_visible() {
+                                OpenState::Visible
+                            } else {
+                                OpenState::Hidden
+                            };
+                            button.set_open_state(open_state);
+                        }
+                    }
                     WorkspaceUpdate::Rename { id, name } if has_initialized => {
                         let button = if let Some(button) = button_map.get_mut(&Identifier::Id(id)) {
                             Some(button)

--- a/src/modules/workspaces/mod.rs
+++ b/src/modules/workspaces/mod.rs
@@ -64,6 +64,12 @@ pub enum ClickBehavior {
     ActivateExclusive,
 }
 
+#[derive(Debug, Clone, Copy)]
+pub enum WorkspaceClickEvent {
+    Left(i64),
+    Right(i64),
+}
+
 #[derive(Debug, Deserialize, Clone)]
 #[serde(untagged)]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
@@ -158,13 +164,21 @@ pub struct WorkspacesModule {
     /// **Default**: `false`
     all_monitors: bool,
 
-    /// Click behavior for workspace buttons.
+    /// Click behavior for left mouse button.
     ///
     /// Valid options: `activate`, `deactivate`, `toggle`, `activate_exclusive`.
     ///
     /// **Default**: `activate_exclusive`
     #[serde(default)]
-    click_behavior: ClickBehavior,
+    left_click_behavior: ClickBehavior,
+
+    /// Click behavior for right mouse button.
+    ///
+    /// Valid options: `activate`, `deactivate`, `toggle`, `activate_exclusive`.
+    ///
+    /// **Default**: `activate_exclusive`
+    #[serde(default)]
+    right_click_behavior: ClickBehavior,
 
     /// The method used for sorting workspaces.
     ///
@@ -215,7 +229,8 @@ impl Default for WorkspacesModule {
             favorites: Favorites::default(),
             hidden: vec![],
             all_monitors: false,
-            click_behavior: ClickBehavior::default(),
+            left_click_behavior: ClickBehavior::default(),
+            right_click_behavior: ClickBehavior::default(),
             sort: SortOrder::default(),
             icon_size: default::IconSize::Normal as i32,
             format: Format::default(),
@@ -230,7 +245,7 @@ pub struct WorkspaceItemContext {
     name_map: HashMap<String, String>,
     icon_size: i32,
     image_provider: image::Provider,
-    tx: mpsc::Sender<i64>,
+    tx: mpsc::Sender<WorkspaceClickEvent>,
     format_named: String,
     format_unnamed: String,
 }
@@ -304,7 +319,7 @@ fn reorder_workspaces(container: &gtk::Box, sort_order: SortOrder) {
 
 impl Module<gtk::Box> for WorkspacesModule {
     type SendMessage = WorkspaceUpdate;
-    type ReceiveMessage = i64;
+    type ReceiveMessage = WorkspaceClickEvent;
 
     module_impl!("workspaces");
 
@@ -329,13 +344,19 @@ impl Module<gtk::Box> for WorkspacesModule {
         });
 
         let client = context.try_client::<dyn WorkspaceClient>()?;
-        let click_behavior = self.click_behavior;
+        let left_click_behavior = self.left_click_behavior;
+        let right_click_behavior = self.right_click_behavior;
 
         // Change workspace focus
         spawn(async move {
             trace!("Setting up UI event handler");
 
-            while let Some(id) = rx.recv().await {
+            while let Some(click) = rx.recv().await {
+                let (id, click_behavior) = match click {
+                    WorkspaceClickEvent::Left(id) => (id, left_click_behavior),
+                    WorkspaceClickEvent::Right(id) => (id, right_click_behavior),
+                };
+
                 match click_behavior {
                     ClickBehavior::Activate => client.activate(id),
                     ClickBehavior::Deactivate => client.deactivate(id),

--- a/src/modules/workspaces/mod.rs
+++ b/src/modules/workspaces/mod.rs
@@ -49,6 +49,21 @@ pub enum SortOrder {
     Index,
 }
 
+#[derive(Debug, Deserialize, Default, Clone, Copy, Eq, PartialEq)]
+#[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
+pub enum ClickBehavior {
+    /// Activates a workspace on click.
+    Activate,
+    /// Deactivates a workspace on click.
+    Deactivate,
+    /// Toggles workspace activation state on click.
+    Toggle,
+    /// Activates clicked workspace and deactivates others on the output.
+    #[default]
+    ActivateExclusive,
+}
+
 #[derive(Debug, Deserialize, Clone)]
 #[serde(untagged)]
 #[cfg_attr(feature = "extras", derive(schemars::JsonSchema))]
@@ -143,6 +158,14 @@ pub struct WorkspacesModule {
     /// **Default**: `false`
     all_monitors: bool,
 
+    /// Click behavior for workspace buttons.
+    ///
+    /// Valid options: `activate`, `deactivate`, `toggle`, `activate_exclusive`.
+    ///
+    /// **Default**: `activate_exclusive`
+    #[serde(default)]
+    click_behavior: ClickBehavior,
+
     /// The method used for sorting workspaces.
     ///
     /// - `added` always appends to the end.
@@ -192,6 +215,7 @@ impl Default for WorkspacesModule {
             favorites: Favorites::default(),
             hidden: vec![],
             all_monitors: false,
+            click_behavior: ClickBehavior::default(),
             sort: SortOrder::default(),
             icon_size: default::IconSize::Normal as i32,
             format: Format::default(),
@@ -305,13 +329,19 @@ impl Module<gtk::Box> for WorkspacesModule {
         });
 
         let client = context.try_client::<dyn WorkspaceClient>()?;
+        let click_behavior = self.click_behavior;
 
         // Change workspace focus
         spawn(async move {
             trace!("Setting up UI event handler");
 
             while let Some(id) = rx.recv().await {
-                client.focus(id);
+                match click_behavior {
+                    ClickBehavior::Activate => client.activate(id),
+                    ClickBehavior::Deactivate => client.deactivate(id),
+                    ClickBehavior::Toggle => client.toggle(id),
+                    ClickBehavior::ActivateExclusive => client.activate_exclusive(id),
+                }
             }
 
             Ok::<(), Report>(())


### PR DESCRIPTION
Adds a new backend for the `workspaces` module which uses the Wayland `ext-workspace` protocol instead of compositor-specific IPC.

This still needs some work to tidy up the code, but is in a working state and good to be tested.

Resolves #820 