### PR TITLE
clock: align tick to format precision

### DIFF
--- a/src/modules/clock.rs
+++ b/src/modules/clock.rs
@@ -1,6 +1,7 @@
 use std::env;
+use std::time::Duration;
 
-use chrono::{DateTime, Local, Locale};
+use chrono::{DateTime, Local, Locale, Timelike};
 use color_eyre::Result;
 use gtk::prelude::*;
 use gtk::{Align, Button, Calendar, Label, Orientation};
@@ -87,6 +88,20 @@ fn strip_tail(string: String) -> String {
         .unwrap_or(string)
 }
 
+/// Returns true if `format` (a chrono strftime template) contains any
+/// specifier whose rendered value changes within a minute.
+fn format_needs_second_precision(format: &str) -> bool {
+    const MODIFIERS: &[u8] = b"-_0.";
+    const SECOND_SPECIFIERS: &[u8] = b"STXrsc+f";
+
+    let mut bytes = format.bytes();
+    std::iter::from_fn(|| {
+        bytes.find(|&b| b == b'%')?;
+        bytes.find(|b| !b.is_ascii_digit() && !MODIFIERS.contains(b))
+    })
+    .any(|spec| SECOND_SPECIFIERS.contains(&spec))
+}
+
 impl Module<Button> for ClockModule {
     type SendMessage = DateTime<Local>;
     type ReceiveMessage = ();
@@ -100,11 +115,22 @@ impl Module<Button> for ClockModule {
         _rx: mpsc::Receiver<Self::ReceiveMessage>,
     ) -> Result<()> {
         let tx = context.tx.clone();
+        let needs_seconds = format_needs_second_precision(&self.format)
+            || format_needs_second_precision(&self.format_popup);
+
         spawn(async move {
             loop {
                 let date = Local::now();
                 tx.send_update(date).await;
-                sleep(tokio::time::Duration::from_millis(500)).await;
+                // Sleep just past the next second/minute boundary
+                let sub = u64::from(date.timestamp_subsec_millis());
+                let to_next = if needs_seconds {
+                    1000 - sub
+                } else {
+                    60 * 1000 - u64::from(date.second()) * 1000 - sub
+                };
+                // Overshoot boundary by 10ms
+                sleep(Duration::from_millis(to_next + 10)).await;
             }
         });
 
@@ -181,5 +207,60 @@ impl Module<Button> for ClockModule {
         });
 
         Some(container)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::format_needs_second_precision;
+
+    #[test]
+    fn format_needs_second_precision_classification() {
+        let cases = [
+            // Basic second-precision specifiers.
+            ("%S", true),
+            ("%T", true),
+            ("%X", true),
+            ("%r", true),
+            ("%s", true),
+            ("%c", true),
+            ("%+", true),
+            ("%f", true),
+            ("%H:%M:%S", true),
+            ("%Y-%m-%dT%H:%M:%S", true),
+            // Modifier-prefixed forms must also be detected.
+            ("%-S", true),
+            ("%0S", true),
+            ("%.f", true),
+            ("%3f", true),
+            ("%.6f", true),
+            // Known limitation: this format actually make chrono _panic_, this test is simply here
+            // to document the behaviour.
+            ("%------S", true),
+            // Minute-only / no-specifier formats.
+            ("%H:%M", false),
+            ("%R", false),
+            ("%Y-%m-%d", false),
+            ("%H", false),
+            ("", false),
+            ("plain text", false),
+            // `%%` is a literal `%`, not the start of a specifier.
+            ("%%S", false),
+            ("%%-S", false),
+            ("100%% load at %H:%M", false),
+            ("%%S now %S", true),
+            ("%dT%H:%M:%%S", false),
+            // Dangling `%`
+            ("%", false),
+            ("ends with %", false),
+            ("%-", false),
+        ];
+        for (fmt, expected) in cases {
+            assert_eq!(
+                format_needs_second_precision(fmt),
+                expected,
+                "format `{fmt}` expected needs_seconds={expected}"
+            );
+        }
     }
 }


### PR DESCRIPTION
Small optimization that saves quite a few cycles / wakeups.

Impact measured with:

```sh
perf stat -d -e cycles,context-switches
```

Before:
```text
Performance counter stats for 'timeout 60 ./ironbar':

        289968783      cpu_atom/cycles/                                                        (54.48%)
        405203369      cpu_core/cycles/                                                        (59.51%)
              728      context-switches

     60.010151153 seconds time elapsed

      0.223719000 seconds user
      0.094606000 seconds sys
```

After:
```text
Performance counter stats for 'timeout 60 ./ironbar-clock':

        261691886      cpu_atom/cycles/                                                        (56.75%)
        379525472      cpu_core/cycles/                                                        (56.14%)
              359      context-switches

     60.011738976 seconds time elapsed

      0.190068000 seconds user
      0.093777000 seconds sys
```

with config:
```json
{
  "position": "top",
  "height": 24,
  "start": [],
  "center": [],
  "end": [
    {
      "type": "clock",
      "format": "%H:%M",
      "format_popup": "%H:%M"
    }
  ]
}
```