### PR TITLE
feat(volume): add truncate_formats option

### DIFF
--- a/docs/modules/Volume.md
+++ b/docs/modules/Volume.md
@@ -1,7 +1,9 @@
 Displays the current volume level.
 Clicking on the widget opens a volume mixer, which allows you to change the device output level,
 the default playback device, and control application volume levels individually.
-Use `truncate` or `marquee` options to control the display of application titles in the volume mixer.
+Use `truncate_popup` or `marquee` options to control the display of application titles in the volume mixer.
+Use `truncate_popup` option to control the display of sink and sources in the volume mixer.
+Use `truncate` option to control the display of the `format` in the bar.
 
 This requires PulseAudio to function (`pipewire-pulse` is supported).
 
@@ -35,7 +37,8 @@ pulseaudio uses to describe sources of audio:
 | `icons.muted`               | `string`                                             | `󰝟`                   | Yes      | Icon to show for muted outputs.                                                                                                                                                                               |
 | `icons.mic_volume`          | `string`                                             | ``                    | Yes      | Icon to show for high microphone volume levels.                                                                                                                                                               |
 | `icons.mic_muted`           | `string`                                             | ``                    | Yes      | Icon to show for muted microphone inputs.                                                                                                                                                                     |
-| `truncate`                  | `'start'` or `'middle'` or `'end'` or `off` or `Map` | `off`                  | No       | The location of the ellipses and where to truncate text from. Leave null to avoid truncating. Use the long-hand `Map` version if specifying a length. Takes precedence over `marquee` if both are configured. |
+| `truncate_popup`            | `'start'` or `'middle'` or `'end'` or `off` or `Map` | `off`                  | No       | The location of the ellipses and where to truncate text from. Leave null to avoid truncating. Use the long-hand `Map` version if specifying a length. Takes precedence over `marquee` if both are configured. This option applies to sources and sinks in the popup window.  See `truncate` for configuration options.|
+| `truncate`                  | `'start'` or `'middle'` or `'end'` or `off` or `Map` | `off`                  | No       | The location of the ellipses and where to truncate text from. Leave null to avoid truncating. Use the long-hand `Map` version if specifying a length. Takes precedence over `marquee` if both are configured. This option applies to `format` and `mute_format`.|
 | `truncate.mode`             | `'start'` or `'middle'` or `'end'` or `off`          | `off`                  | No       | The location of the ellipses and where to truncate text from. Leave null to avoid truncating.                                                                                                                 |
 | `truncate.length`           | `integer`                                            | `null`                 | No       | The fixed width (in chars) of the widget. Leave blank to let GTK automatically handle.                                                                                                                        |
 | `truncate.max_length`       | `integer`                                            | `null`                 | No       | The maximum number of characters before truncating. Leave blank to let GTK automatically handle.                                                                                                              |
@@ -62,7 +65,8 @@ Information on the profiles system can be found [here](profiles).
       "format": "{icon} {percentage}%",
       "sink_slider_orientation": "vertical",
       "max_volume": 100,
-      "truncate": "middle",
+      "truncate": "end",
+      "truncate_popup": "middle",
       "icons": {
         "volume": "󰕾",
         "muted": "󰝟"
@@ -97,7 +101,11 @@ type = "volume"
 format = "{icon} {percentage}%"
 sink_slider_orientation = "vertical"
 max_volume = 100
-truncate = "end"
+truncate_popup = "end"
+
+[end.truncate]
+mode = "end"
+max_length = 25
 
 [end.icons]
 volume = "󰕾"
@@ -128,6 +136,7 @@ end:
     sink_slider_orientation: vertical
     max_volume: 100
     truncate: end
+    truncate_popup: end
     icons:
       volume: 󰕾
       muted: 󰝟
@@ -156,6 +165,7 @@ end:
       sink_slider_orientation = "vertical"
       max_volume = 100
       truncate = "end"
+      truncate_popup = "end"
       icons.volume = "󰕾"
       icons.muted = "󰝟"
 

--- a/src/modules/volume/config.rs
+++ b/src/modules/volume/config.rs
@@ -87,6 +87,12 @@ pub struct VolumeModule {
     /// **Default**: `null`
     pub(crate) truncate: Option<TruncateMode>,
 
+    // -- Common --
+    /// See [truncate options](module-level-options#truncate-mode).
+    ///
+    /// **Default**: `null`
+    pub(crate) truncate_popup: Option<TruncateMode>,
+
     /// See [marquee options](module-level-options#marquee-mode).
     #[serde(default)]
     pub(crate) marquee: MarqueeMode,
@@ -114,6 +120,7 @@ impl Default for VolumeModule {
             show_monitors: false,
             profiles: Profiles::default(),
             truncate: None,
+            truncate_popup: None,
             marquee: MarqueeMode::default(),
             layout: LayoutConfig::default(),
             common: Some(CommonConfig::default()),

--- a/src/modules/volume/mod.rs
+++ b/src/modules/volume/mod.rs
@@ -100,7 +100,7 @@ impl ObjectSubclass for DropdownItemData {
 
 impl VolumeModule {
     fn overflow_label(&self, name: &str, css_class: &str) -> OverflowLabel {
-        let label = OverflowLabel::new(Label::new(None), self.truncate, self.marquee.clone());
+        let label = OverflowLabel::new(Label::new(None), self.truncate_popup, self.marquee.clone());
         label.label().add_css_class(css_class);
         label.set_label_escaped(name);
         label
@@ -365,6 +365,10 @@ impl Module<Button> for VolumeModule {
                         .replace("{percentage}", &event.state.to_string())
                         .replace("{name}", &desc);
                     button_label.set_label_escaped(&label);
+
+                    if let Some(truncate) = self.truncate {
+                        button_label.truncate(truncate);
+                    }
                 },
             )
         };
@@ -458,7 +462,6 @@ impl Module<Button> for VolumeModule {
                 .set_child(Some(&label));
         });
 
-        let truncate = self.truncate;
         factory.connect_bind(move |_, list_item| {
             let dropdown_item = list_item
                 .downcast_ref::<ListItem>()
@@ -475,7 +478,7 @@ impl Module<Button> for VolumeModule {
                 .expect("should be a `Label`.");
 
             label.set_label(&dropdown_item.value().to_string());
-            if let Some(truncate) = truncate {
+            if let Some(truncate) = self.truncate_popup {
                 label.truncate(truncate);
             }
         });


### PR DESCRIPTION
Closes #1422
Adds `truncate_formats` to the wiki.
Specifies that `truncate` also applies to sink and sources in the volume mixer.