### PR TITLE
fix(volume): volume respects default sink and source

### DIFF
--- a/src/modules/volume/mod.rs
+++ b/src/modules/volume/mod.rs
@@ -610,7 +610,7 @@ impl Module<Button> for VolumeModule {
                                 .append(&DropdownItem::new(&info.name, &info.description));
 
                             if info.active {
-                                let offset = sink_options.find(&no_sink).is_some() as usize;
+                                let offset = source_options.find(&no_source).is_some() as usize;
                                 source_selector.set_selected((sources.len() + offset) as u32);
                                 source_slider.set_value(info.volume.percent());
 

--- a/src/modules/volume/mod.rs
+++ b/src/modules/volume/mod.rs
@@ -126,7 +126,7 @@ impl VolumeModule {
     where
         F: Fn(String) -> Update + 'static,
     {
-        selector.connect_selected_notify(move |selector| {
+        selector.connect_selected_item_notify(move |selector| {
             if let Some(item) = selector.selected_item().and_downcast_ref::<DropdownItem>() {
                 tx.send_spawn(func(item.key()));
             }
@@ -451,8 +451,13 @@ impl Module<Button> for VolumeModule {
         container.append(&device_container);
         container.append(&app_container);
 
+        let no_sink = DropdownItem::new("ironbar_no_sink", "No sink available");
+        let no_source = DropdownItem::new("ironbar_no_source", "No source available");
+
         let sink_options = gio::ListStore::new::<DropdownItem>();
+        sink_options.append(&no_sink);
         let source_options = gio::ListStore::new::<DropdownItem>();
+        source_options.append(&no_source);
         let factory = SignalListItemFactory::new();
         factory.connect_setup(move |_, list_item| {
             let label = Label::new(None);
@@ -589,7 +594,8 @@ impl Module<Button> for VolumeModule {
                         sink_options.append(&DropdownItem::new(&info.name, &info.description));
 
                         if info.active {
-                            sink_selector.set_selected(sinks.len() as u32);
+                            let offset = sink_options.find(&no_sink).is_some() as usize;
+                            sink_selector.set_selected((sinks.len() + offset) as u32);
                             sink_slider.set_value(info.volume.percent());
 
                             sink_manager
@@ -604,7 +610,8 @@ impl Module<Button> for VolumeModule {
                                 .append(&DropdownItem::new(&info.name, &info.description));
 
                             if info.active {
-                                source_selector.set_selected(sources.len() as u32);
+                                let offset = sink_options.find(&no_sink).is_some() as usize;
+                                source_selector.set_selected((sources.len() + offset) as u32);
                                 source_slider.set_value(info.volume.percent());
 
                                 source_manager.update(
@@ -618,11 +625,19 @@ impl Module<Button> for VolumeModule {
                     }
                     Event::UpdateSink(info) => {
                         if info.active
-                            && let Some(pos) = sinks.iter().position(|s| s.name == info.name)
+                            && let Some(pos) =
+                                sink_options.iter::<DropdownItem>().position(|s| match s {
+                                    Ok(s) => s.key() == info.name,
+                                    Err(_) => false,
+                                })
                         {
                             sink_selector.set_selected(pos as u32);
                             if !sink_slider.has_css_class("dragging") {
                                 sink_slider.set_value(info.volume.percent());
+                            }
+
+                            if let Some(pos) = sink_options.find(&no_sink) {
+                                sink_options.remove(pos);
                             }
 
                             sink_manager
@@ -631,12 +646,20 @@ impl Module<Button> for VolumeModule {
                     }
                     Event::UpdateSource(info) => {
                         if info.active
-                            && let Some(pos) = sources.iter().position(|s| s.name == info.name)
+                            && let Some(pos) =
+                                source_options.iter::<DropdownItem>().position(|s| match s {
+                                    Ok(s) => s.key() == info.name,
+                                    Err(_) => false,
+                                })
                             && (!info.monitor || show_monitors)
                         {
                             source_selector.set_selected(pos as u32);
                             if !source_slider.has_css_class("dragging") {
                                 source_slider.set_value(info.volume.percent());
+                            }
+
+                            if let Some(pos) = source_options.find(&no_source) {
+                                source_options.remove(pos);
                             }
 
                             source_manager
@@ -647,12 +670,20 @@ impl Module<Button> for VolumeModule {
                         if let Some(pos) = sinks.iter().position(|s| s.name == name) {
                             sink_options.remove(pos as u32);
                             sinks.remove(pos);
+
+                            if sinks.is_empty() {
+                                sink_options.append(&no_sink);
+                            }
                         }
                     }
                     Event::RemoveSource(name) => {
                         if let Some(pos) = sources.iter().position(|s| s.name == name) {
                             source_options.remove(pos as u32);
                             sources.remove(pos);
+
+                            if sources.is_empty() {
+                                source_options.append(&no_source);
+                            }
                         }
                     }
                     Event::AddInput(info) => {


### PR DESCRIPTION
Should help #1166.
This prevents the drop menu from selecting the first appended item and then trying to set it as the default sink.

Edit: This appends when the list is empty, then one item is appended to the list. This results in the notify event being triggered and then the sink to change to that first sink appended. Same for source.

The drop menu now has a default state where an item No Sink or No Source is preappended to it. This prevents setting the default sink multiple times resulting in inconsistent sink selection (or source).

The following section works for sink and sources.
This now only fires a single notify event to select the default sink sent by PA. If PA sends no default sink, i.e. no`SinkUpdate` then the default no sink available is shown. If this update is send and the sink is valid this option is removed.

I tested this restarting the bar multiple time back to back s this would facilitate the race condition where my sink or source would get changed. This also prevents the bar switching aggressively between two sinks at startup, and may also help with #1411.

It is to be noted that selecting no item in the drop down menu does not work, and this may also be a bug on the gtk side. I though I would offer a solution as I am unsure if this is the default behavior of the drop down menu (the documentation is minimal and I am not very proficient in gtk to say the least).