### PR TITLE
fix(tray): icon updates sometimes breaking icon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3400,9 +3400,9 @@ dependencies = [
 
 [[package]]
 name = "system-tray"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34c949a4724f23683f03ea22043c905a450635e45b21b10c11110c9016c995ce"
+checksum = "959ed14210c918cd8712fc9cfeb86eb9a9c02f82546567ef62191919dfdf8a8b"
 dependencies = [
  "cfg-if",
  "futures-lite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,7 +190,7 @@ mpris = { version = "2.1.0", optional = true }
 sysinfo = { version = "0.38.4", optional = true }
 
 # tray
-system-tray = { version = "0.8.5", optional = true }
+system-tray = { version = "0.8.6", optional = true }
 
 # volume
 libpulse-binding = { version = "2.30.1", optional = true }

--- a/src/modules/tray/interface.rs
+++ b/src/modules/tray/interface.rs
@@ -265,9 +265,6 @@ impl TrayMenu {
     }
 
     pub fn set_icon_name(&mut self, icon_name: Option<String>) {
-        if let Some(icn) = &icon_name {
-            self.widget.set_icon_name(icn);
-        }
         self.icon_name = icon_name;
     }
 

--- a/src/modules/tray/mod.rs
+++ b/src/modules/tray/mod.rs
@@ -337,7 +337,7 @@ impl Module<gtk::Box> for TrayModule {
 /// If loading fails entirely, hides the picture and shows the `fallback_label`
 /// (which was pre-registered synchronously via `set_label`).
 fn load_icon_async(
-    picture: Picture,
+    picture: &Picture,
     fallback_label: gtk::Label,
     icon_name: Option<String>,
     icon_theme_path: Option<PathBuf>,
@@ -347,6 +347,8 @@ fn load_icon_async(
     let size = icon_config.size;
     let prefer_theme = icon_config.prefer_theme;
     let provider = icon_config.provider.clone();
+
+    let picture = picture.clone();
 
     glib::spawn_future_local(async move {
         match icon::get_image(
@@ -424,7 +426,7 @@ fn on_update(
                 .clone();
 
             load_icon_async(
-                picture,
+                &picture,
                 fallback_label,
                 menu_item.icon_name.clone(),
                 menu_item.icon_theme_path.clone(),
@@ -465,6 +467,7 @@ fn on_update(
                         if let Some(picture) = menu_item.image_widget().cloned() {
                             // Reset visibility in case a previous load failed and hid the picture.
                             picture.set_visible(true);
+                            menu_item.set_image(&picture);
 
                             let fallback_label = menu_item
                                 .label_widget()
@@ -473,7 +476,7 @@ fn on_update(
                             fallback_label.set_visible(false);
 
                             load_icon_async(
-                                picture,
+                                &picture,
                                 fallback_label,
                                 icon_name,
                                 menu_item.icon_theme_path.clone(),


### PR DESCRIPTION
Fixes an issue where tray icon updates accidentally passed the icon to GTK, bypassing Ironbar's image rendering and breaking the widget tree. 

Fixes https://github.com/JakeStanger/ironbar/issues/1404