### PR TITLE
fix(volume): default sink/source incorrectly switching

### DIFF
--- a/src/clients/volume/mod.rs
+++ b/src/clients/volume/mod.rs
@@ -31,10 +31,6 @@ trait HasIndex {
 trait PulseObject<'a>: Sized + HasIndex {
     type Inner: 'a + Debug + HasIndex;
 
-    fn name(&self) -> String;
-    fn active(&self) -> bool;
-    fn set_active(&mut self, active: bool);
-
     fn add_event(info: Self) -> Event;
     fn update_event(info: Self) -> Event;
     fn remove_event(info: Self) -> Event;
@@ -58,7 +54,6 @@ trait PulseObject<'a>: Sized + HasIndex {
     fn update(
         result: ListResult<&'a Self::Inner>,
         items: &ArcMutVec<Self>,
-        default: Option<&Arc<Mutex<Option<String>>>>,
         tx: &broadcast::Sender<Event>,
     ) where
         Self: From<&'a Self::Inner>,
@@ -75,25 +70,10 @@ trait PulseObject<'a>: Sized + HasIndex {
                 return;
             };
             items[pos] = info.into();
-
-            // update in local copy
-            if let Some(default) = default.as_ref()
-                && !items[pos].active()
-                && let Some(default_item) = &*lock!(default)
-            {
-                let name = &items[pos].name();
-                items[pos].set_active(name == default_item);
-            }
         }
 
         // update in broadcast copy
-        let mut item: Self = info.into();
-        if let Some(default) = default.as_ref()
-            && !item.active()
-            && let Some(default_item) = &*lock!(default)
-        {
-            item.set_active(&item.name() == default_item);
-        }
+        let item: Self = info.into();
 
         tx.send_expect(Self::update_event(item));
     }
@@ -114,10 +94,12 @@ pub enum Event {
     AddSink(Sink),
     UpdateSink(Sink),
     RemoveSink(String),
+    SetDefaultSink(String),
 
     AddSource(Source),
     UpdateSource(Source),
     RemoveSource(String),
+    SetDefaultSource(String),
 
     AddInput(SinkInput),
     UpdateInput(SinkInput),
@@ -400,10 +382,8 @@ fn on_event(
             &data.default_source_name,
             tx,
         ),
-        Facility::Sink => Sink::on_event(context, &data.sinks, &data.default_sink_name, tx, op, i),
-        Facility::Source => {
-            Source::on_event(context, &data.sources, &data.default_source_name, tx, op, i)
-        }
+        Facility::Sink => Sink::on_event(context, &data.sinks, tx, op, i),
+        Facility::Source => Source::on_event(context, &data.sources, tx, op, i),
         Facility::SinkInput => SinkInput::on_event(context, &data.sink_inputs, tx, op, i),
         Facility::SourceOutput => SourceOutput::on_event(context, &data.source_outputs, tx, op, i),
         _ => error!("Received unhandled facility: {facility:?}"),
@@ -443,12 +423,13 @@ fn set_default_sink(
     if default_sink_name != *lock!(default_sink)
         && let Some(ref default_sink_name) = default_sink_name
     {
+        debug!("Set sink default: {}", default_sink_name);
+        tx.send_expect(Event::SetDefaultSink(default_sink_name.clone()));
+
         if let Some(sink) = lock!(sinks)
             .iter_mut()
             .find(|s| s.name.as_str() == default_sink_name.as_str())
         {
-            sink.active = true;
-            debug!("Set sink active: {}", sink.name);
             tx.send_expect(Event::UpdateSink(sink.clone()));
         } else {
             warn!("Couldn't find sink: {}", default_sink_name);
@@ -469,12 +450,13 @@ fn set_default_source(
     if default_source_name != *lock!(default_source)
         && let Some(ref default_source_name) = default_source_name
     {
+        debug!("Set source active: {}", default_source_name);
+        tx.send_expect(Event::SetDefaultSource(default_source_name.clone()));
+
         if let Some(source) = lock!(sources)
             .iter_mut()
             .find(|s| s.name.as_str() == default_source_name.as_str())
         {
-            source.active = true;
-            debug!("Set source active: {}", source.name);
             tx.send_expect(Event::UpdateSource(source.clone()));
         } else {
             warn!("Couldn't find source: {}", default_source_name);

--- a/src/clients/volume/sink.rs
+++ b/src/clients/volume/sink.rs
@@ -4,7 +4,6 @@ use crate::lock;
 use libpulse_binding::context::Context;
 use libpulse_binding::context::introspect::SinkInfo;
 use libpulse_binding::context::subscribe::Operation;
-use libpulse_binding::def::SinkState;
 use std::sync::{Arc, Mutex};
 use tokio::sync::broadcast;
 use tracing::{debug, instrument};
@@ -16,7 +15,6 @@ pub struct Sink {
     pub description: String,
     pub volume: VolumeLevels,
     pub muted: bool,
-    pub active: bool,
 }
 
 impl From<&SinkInfo<'_>> for Sink {
@@ -35,7 +33,7 @@ impl From<&SinkInfo<'_>> for Sink {
                 .unwrap_or_default(),
             muted: value.mute,
             volume: value.volume.into(),
-            active: value.state == SinkState::Running,
+            // active: value.state == SinkState::Running,
         }
     }
 }
@@ -56,18 +54,6 @@ impl<'a> PulseObject<'a> for Sink {
     type Inner = SinkInfo<'a>;
 
     #[inline]
-    fn name(&self) -> String {
-        self.name.clone()
-    }
-    #[inline]
-    fn active(&self) -> bool {
-        self.active
-    }
-    #[inline]
-    fn set_active(&mut self, active: bool) {
-        self.active = active;
-    }
-    #[inline]
     fn add_event(info: Self) -> Event {
         Event::AddSink(info)
     }
@@ -85,6 +71,11 @@ impl Client {
     #[instrument(level = "trace")]
     pub fn sinks(&self) -> ArcMutVec<Sink> {
         self.data.sinks.clone()
+    }
+
+    #[instrument(level = "trace")]
+    pub fn default_sink(&self) -> Option<String> {
+        lock!(self.data.default_sink_name).clone()
     }
 
     #[instrument(level = "trace")]
@@ -125,7 +116,6 @@ impl Sink {
     pub(super) fn on_event(
         context: &Arc<Mutex<Context>>,
         sinks: &ArcMutVec<Sink>,
-        default_sink: &Arc<Mutex<Option<String>>>,
         tx: &broadcast::Sender<Event>,
         op: Operation,
         i: u32,
@@ -146,11 +136,10 @@ impl Sink {
                 debug!("sink changed");
                 introspect.get_sink_info_by_index(i, {
                     let sinks = sinks.clone();
-                    let default_sink = default_sink.clone();
                     let tx = tx.clone();
 
                     move |info| {
-                        Self::update(info, &sinks, Some(&default_sink), &tx);
+                        Self::update(info, &sinks, &tx);
                     }
                 });
             }

--- a/src/clients/volume/sink_input.rs
+++ b/src/clients/volume/sink_input.rs
@@ -61,17 +61,6 @@ impl<'a> PulseObject<'a> for SinkInput {
     type Inner = SinkInputInfo<'a>;
 
     #[inline]
-    fn name(&self) -> String {
-        self.name.clone()
-    }
-    #[inline]
-    fn active(&self) -> bool {
-        true
-    }
-    #[inline]
-    fn set_active(&mut self, _active: bool) {}
-
-    #[inline]
     fn add_event(info: Self) -> Event {
         Event::AddInput(info)
     }
@@ -145,7 +134,7 @@ impl SinkInput {
                     let inputs = inputs.clone();
                     let tx = tx.clone();
 
-                    move |info| Self::update(info, &inputs, None, &tx)
+                    move |info| Self::update(info, &inputs, &tx)
                 });
             }
             Operation::Removed => {

--- a/src/clients/volume/source.rs
+++ b/src/clients/volume/source.rs
@@ -6,7 +6,6 @@ use crate::lock;
 use libpulse_binding::context::Context;
 use libpulse_binding::context::introspect::SourceInfo;
 use libpulse_binding::context::subscribe::Operation;
-use libpulse_binding::def::SourceState;
 use tokio::sync::broadcast;
 use tracing::{debug, instrument};
 
@@ -17,7 +16,6 @@ pub struct Source {
     pub description: String,
     pub volume: VolumeLevels,
     pub muted: bool,
-    pub active: bool,
     pub monitor: bool,
 }
 
@@ -37,7 +35,6 @@ impl From<&SourceInfo<'_>> for Source {
                 .unwrap_or_default(),
             muted: value.mute,
             volume: value.volume.into(),
-            active: value.state == SourceState::Running,
             monitor: value.monitor_of_sink.is_some(),
         }
     }
@@ -59,18 +56,6 @@ impl<'a> PulseObject<'a> for Source {
     type Inner = SourceInfo<'a>;
 
     #[inline]
-    fn name(&self) -> String {
-        self.name.clone()
-    }
-    #[inline]
-    fn active(&self) -> bool {
-        self.active
-    }
-    #[inline]
-    fn set_active(&mut self, active: bool) {
-        self.active = active;
-    }
-    #[inline]
     fn add_event(info: Self) -> Event {
         Event::AddSource(info)
     }
@@ -88,6 +73,11 @@ impl Client {
     #[instrument(level = "trace")]
     pub fn sources(&self) -> ArcMutVec<Source> {
         self.data.sources.clone()
+    }
+
+    #[instrument(level = "trace")]
+    pub fn default_source(&self) -> Option<String> {
+        lock!(self.data.default_source_name).clone()
     }
 
     #[instrument(level = "trace")]
@@ -128,7 +118,6 @@ impl Source {
     pub(super) fn on_event(
         context: &Arc<Mutex<Context>>,
         sources: &ArcMutVec<Source>,
-        default_source: &Arc<Mutex<Option<String>>>,
         tx: &broadcast::Sender<Event>,
         op: Operation,
         i: u32,
@@ -149,10 +138,9 @@ impl Source {
                 debug!("source changed");
                 introspect.get_source_info_by_index(i, {
                     let source = sources.clone();
-                    let default_source = default_source.clone();
                     let tx = tx.clone();
 
-                    move |info| Self::update(info, &source, Some(&default_source), &tx)
+                    move |info| Self::update(info, &source, &tx)
                 });
             }
             Operation::Removed => {

--- a/src/clients/volume/source_output.rs
+++ b/src/clients/volume/source_output.rs
@@ -50,17 +50,6 @@ impl<'a> PulseObject<'a> for SourceOutput {
     type Inner = SourceOutputInfo<'a>;
 
     #[inline]
-    fn name(&self) -> String {
-        self.name.clone()
-    }
-    #[inline]
-    fn active(&self) -> bool {
-        true
-    }
-    #[inline]
-    fn set_active(&mut self, _active: bool) {}
-
-    #[inline]
     fn add_event(info: Self) -> Event {
         Event::AddOutput(info)
     }
@@ -134,7 +123,7 @@ impl SourceOutput {
                     let outputs = outputs.clone();
                     let tx = tx.clone();
 
-                    move |info| Self::update(info, &outputs, None, &tx)
+                    move |info| Self::update(info, &outputs, &tx)
                 });
             }
             Operation::Removed => {

--- a/src/modules/volume/mod.rs
+++ b/src/modules/volume/mod.rs
@@ -213,6 +213,12 @@ impl Module<Button> for VolumeModule {
             let tx = context.tx.clone();
 
             spawn(async move {
+                let default_sink = client.default_sink();
+                let default_source = client.default_source();
+
+                trace!("default sink: {default_sink:?}");
+                trace!("default source: {default_source:?}");
+
                 // init
                 let sinks = {
                     let sinks = client.sinks();
@@ -245,6 +251,15 @@ impl Module<Button> for VolumeModule {
                 };
 
                 trace!("initial outputs: {outputs:?}");
+
+                if let Some(default_sink) = default_sink {
+                    tx.send_update(Event::SetDefaultSink(default_sink)).await;
+                }
+
+                if let Some(default_source) = default_source {
+                    tx.send_update(Event::SetDefaultSource(default_source))
+                        .await;
+                }
 
                 for sink in sinks {
                     tx.send_update(Event::AddSink(sink)).await;
@@ -374,8 +389,18 @@ impl Module<Button> for VolumeModule {
         };
 
         let show_monitors = self.show_monitors;
+
+        let mut default_sink = None;
+        let mut default_source = None;
+
         rx.recv_glib((), move |(), event| match event {
-            Event::AddSink(sink) | Event::UpdateSink(sink) if sink.active => {
+            Event::SetDefaultSink(name) => default_sink = Some(name),
+            Event::SetDefaultSource(name) => default_source = Some(name),
+            Event::AddSink(sink) | Event::UpdateSink(sink)
+                if default_sink
+                    .as_deref()
+                    .is_some_and(|name| name == sink.name) =>
+            {
                 manager.update(
                     sink.volume.percent(),
                     BarUiUpdate::Sink {
@@ -385,7 +410,8 @@ impl Module<Button> for VolumeModule {
                 );
             }
             Event::AddSource(source) | Event::UpdateSource(source)
-                if source.active && (!source.monitor || show_monitors) =>
+                if Some(source.name.as_str()) == default_source.as_deref()
+                    && (!source.monitor || show_monitors) =>
             {
                 manager.update(
                     source.volume.percent(),
@@ -585,15 +611,24 @@ impl Module<Button> for VolumeModule {
         let mut sources = vec![];
 
         let show_monitors = self.show_monitors;
+
+        let mut default_sink = None;
+        let mut default_source = None;
+
         context
             .subscribe()
             .recv_glib(
                 &sink_input_container,
                 move |input_container, event| match event {
+                    Event::SetDefaultSink(name) => default_sink = Some(name),
+                    Event::SetDefaultSource(name) => default_source = Some(name),
                     Event::AddSink(info) => {
                         sink_options.append(&DropdownItem::new(&info.name, &info.description));
 
-                        if info.active {
+                        if default_sink
+                            .as_deref()
+                            .is_some_and(|name| name == info.name)
+                        {
                             let offset = sink_options.find(&no_sink).is_some() as usize;
                             sink_selector.set_selected((sinks.len() + offset) as u32);
                             sink_slider.set_value(info.volume.percent());
@@ -605,26 +640,30 @@ impl Module<Button> for VolumeModule {
                         sinks.push(info);
                     }
                     Event::AddSource(info) => {
-                        if !info.monitor || show_monitors {
-                            source_options
-                                .append(&DropdownItem::new(&info.name, &info.description));
-
-                            if info.active {
-                                let offset = source_options.find(&no_source).is_some() as usize;
-                                source_selector.set_selected((sources.len() + offset) as u32);
-                                source_slider.set_value(info.volume.percent());
-
-                                source_manager.update(
-                                    info.volume.percent(),
-                                    BtnMuteUiUpdate::muted(info.muted),
-                                );
-                            }
-
-                            sources.push(info);
+                        if !show_monitors && info.monitor {
+                            return;
                         }
+
+                        source_options.append(&DropdownItem::new(&info.name, &info.description));
+
+                        if default_source
+                            .as_deref()
+                            .is_some_and(|name| name == info.name)
+                        {
+                            let offset = source_options.find(&no_source).is_some() as usize;
+                            source_selector.set_selected((sources.len() + offset) as u32);
+                            source_slider.set_value(info.volume.percent());
+
+                            source_manager
+                                .update(info.volume.percent(), BtnMuteUiUpdate::muted(info.muted));
+                        }
+
+                        sources.push(info);
                     }
                     Event::UpdateSink(info) => {
-                        if info.active
+                        if default_sink
+                            .as_deref()
+                            .is_some_and(|name| name == info.name)
                             && let Some(pos) =
                                 sink_options.iter::<DropdownItem>().position(|s| match s {
                                     Ok(s) => s.key() == info.name,
@@ -645,7 +684,9 @@ impl Module<Button> for VolumeModule {
                         }
                     }
                     Event::UpdateSource(info) => {
-                        if info.active
+                        if default_source
+                            .as_deref()
+                            .is_some_and(|name| name == info.name)
                             && let Some(pos) =
                                 source_options.iter::<DropdownItem>().position(|s| match s {
                                     Ok(s) => s.key() == info.name,


### PR DESCRIPTION
The default sink and source were incorrectly tracked before, relying on their status. This did not always line up with the actual default, as there can be more than one running device at a time.

This replaces the old system with one that tracks the default directly from the server, rather than per-object.