### PR TITLE
feat: system-wide /etc/ configuration support

### DIFF
--- a/docs/Configuration guide.md
+++ b/docs/Configuration guide.md
@@ -15,6 +15,8 @@ The examples make use of [Nerd Fonts](https://www.nerdfonts.com/#home) for displ
 
 The config file lives inside the `ironbar` directory in your XDG_CONFIG_DIR, which is usually `~/.config/ironbar`.
 
+Alternatively, you can use a system-level config in `/etc/ironbar/` to set a default config for all users on the machine.
+
 Ironbar supports a range of configuration formats, so you can pick your favourite:
 
 - `config.json`
@@ -23,7 +25,7 @@ Ironbar supports a range of configuration formats, so you can pick your favourit
 - `config.corn` (Includes variable support for re-using blocks.
   See [here](https://github.com/jakestanger/corn) for info)
 
-You can also override the default config path using the `IRONBAR_CONFIG` environment variable.
+You can also override the default config path using the `IRONBAR_CONFIG` environment variable, or the `--config` CLI argument.
 
 A hosted schema is available for the latest Git version ~~and each versioned release~~.
 JSON and YAML both support schema checking by adding the `$schema` key 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -4,6 +4,7 @@ mod r#impl;
 mod layout;
 mod marquee;
 mod profiles;
+mod sources;
 mod truncate;
 
 #[cfg(feature = "battery")]
@@ -55,6 +56,7 @@ pub use self::common::{CommonConfig, ModuleJustification, ModuleOrientation, Tra
 pub use self::layout::LayoutConfig;
 pub use self::marquee::{MarqueeMode, MarqueeOnHover};
 pub use self::profiles::{Profile, ProfileUpdateEvent, Profiles, State};
+pub use self::sources::{Builtin, ConfigSource, CssSource, resolve_sources};
 pub use self::truncate::{EllipsizeMode, TruncateMode};
 
 use gtk::prelude::ObjectExt;
@@ -97,10 +99,7 @@ pub fn get_double_click_time_ms() -> u64 {
 }
 use crate::Ironbar;
 use crate::modules::{AnyModuleFactory, ModuleFactory, ModuleInfo, ModuleRef};
-use crate::style::CssSource;
-use cfg_if::cfg_if;
 use color_eyre::Result;
-use config::FileFormat;
 #[cfg(feature = "extras")]
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -552,26 +551,6 @@ impl FromStr for ConfigLocation {
     }
 }
 
-impl Default for ConfigLocation {
-    fn default() -> Self {
-        Self::Custom(Self::default_path())
-    }
-}
-
-impl ConfigLocation {
-    pub fn default_path() -> PathBuf {
-        dirs::config_dir()
-            .unwrap_or_default()
-            .clone()
-            .join("ironbar/config")
-    }
-
-    #[cfg(not(feature = "cli"))]
-    pub fn from_env(key: &str) -> Option<Self> {
-        std::env::var(key).map(PathBuf::from).ok().map(Self::Custom)
-    }
-}
-
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ErrorLevel {
     None,
@@ -591,65 +570,17 @@ impl ErrorLevel {
 
 impl Config {
     #[cfg(feature = "config")]
-    pub fn load(
-        config_location: ConfigLocation,
-        css_location: Option<ConfigLocation>,
-    ) -> (Config, CssSource, ErrorLevel) {
-        cfg_if! {
-            if #[cfg(feature = "config+corn")] {
-                const CONFIG_MINIMAL: (&str, FileFormat) = (include_str!("../../examples/minimal/config.corn"), FileFormat::Corn);
-                const CONFIG_DESKTOP: (&str, FileFormat) = (include_str!("../../examples/desktop/config.corn"), FileFormat::Corn);
-            } else if #[cfg(feature = "config+json")] {
-                const CONFIG_MINIMAL: (&str, FileFormat) = (include_str!("../../examples/minimal/config.json"), FileFormat::Json);
-                const CONFIG_DESKTOP: (&str, FileFormat) = (include_str!("../../examples/desktop/config.json"), FileFormat::Json);
-            } else if #[cfg(feature = "config+yaml")] {
-                const CONFIG_MINIMAL: (&str, FileFormat) = (include_str!("../../examples/minimal/config.yaml"), FileFormat::Yaml);
-                const CONFIG_DESKTOP: (&str, FileFormat) = (include_str!("../../examples/desktop/config.yaml"), FileFormat::Yaml);
-            } else if #[cfg(feature = "config+toml")] {
-                const CONFIG_MINIMAL: (&str, FileFormat) = (include_str!("../../examples/minimal/config.toml"), FileFormat::Toml);
-                const CONFIG_DESKTOP: (&str, FileFormat) = (include_str!("../../examples/desktop/config.toml"), FileFormat::Toml);
-            }
-        }
-
-        const CSS_MINIMAL: CssSource =
-            CssSource::String(include_str!("../../examples/minimal/style.css"));
-
-        const CSS_DESKTOP: CssSource =
-            CssSource::String(include_str!("../../examples/desktop/style.css"));
-
+    pub fn load(source: &ConfigSource) -> (Config, ErrorLevel) {
         let mut error_level = ErrorLevel::None;
 
-        let config_builder = config::Config::builder();
-
-        let css_source = match css_location.unwrap_or_else(|| config_location.clone()) {
-            ConfigLocation::Minimal => CSS_MINIMAL,
-            ConfigLocation::Desktop => CSS_DESKTOP,
-            ConfigLocation::Custom(mut path) => {
-                if path.is_dir() {
-                    path = path.join("style.css");
-                } else if path.extension().is_none_or(|ext| ext != "css") {
-                    path = path.parent().unwrap_or(&path).join("style.css");
-                }
-
-                if path.exists() {
-                    CssSource::File(path)
-                } else {
-                    error_level = error_level.error();
-                    error!(
-                        "styles at '{}' not found, falling back to minimal theme",
-                        path.display()
-                    );
-                    CSS_MINIMAL
-                }
+        let config_builder = match source {
+            ConfigSource::Builtin(b) => {
+                let (content, format) = b.config();
+                config::Config::builder().add_source(config::File::from_str(content, format))
             }
-        };
-
-        let config_builder = match config_location {
-            ConfigLocation::Minimal => config_builder
-                .add_source(config::File::from_str(CONFIG_MINIMAL.0, CONFIG_MINIMAL.1)),
-            ConfigLocation::Desktop => config_builder
-                .add_source(config::File::from_str(CONFIG_DESKTOP.0, CONFIG_DESKTOP.1)),
-            ConfigLocation::Custom(path) => config_builder.add_source(config::File::from(path)),
+            ConfigSource::File(path) => {
+                config::Config::builder().add_source(config::File::from(path.as_path()))
+            }
         };
 
         let mut config: Config = config_builder
@@ -659,8 +590,9 @@ impl Config {
             .unwrap_or_else(|err| {
                 error_level = error_level.error();
                 error!("Error loading config: {err:?}");
+                let (content, format) = Builtin::Minimal.config();
                 config::Config::builder()
-                    .add_source(config::File::from_str(CONFIG_MINIMAL.0, CONFIG_MINIMAL.1))
+                    .add_source(config::File::from_str(content, format))
                     .build()
                     .expect("should be a valid config")
                     .try_deserialize()
@@ -684,14 +616,11 @@ impl Config {
         // GTK's setting will be set lazily on first use (after GTK is initialized)
         set_double_click_time(config.double_click_time.clone());
 
-        (config, css_source, error_level)
+        (config, error_level)
     }
 
     #[cfg(not(feature = "config"))]
-    pub fn load(
-        config_location: ConfigLocation,
-        css_location: Option<ConfigLocation>,
-    ) -> (Config, CssSource) {
+    pub fn load(config_source: &ConfigSource) -> (Config, ErrorLevel) {
         panic!(
             "Ironbar has been configured without config support. This won't work. Please reconfigure with at least one `config` feature flag enabled."
         )

--- a/src/config/sources.rs
+++ b/src/config/sources.rs
@@ -12,16 +12,7 @@ pub enum Builtin {
 }
 
 impl Builtin {
-    pub fn css(&self) -> &'static str {
-        match self {
-            Self::Minimal => include_str!("../../examples/minimal/style.css"),
-            Self::Desktop => include_str!("../../examples/desktop/style.css"),
-        }
-    }
-}
-
-#[cfg(feature = "config")]
-impl Builtin {
+    #[cfg(feature = "config")]
     pub fn config(&self) -> (&'static str, config::FileFormat) {
         cfg_if! {
             if #[cfg(feature = "config+corn")] {
@@ -45,6 +36,13 @@ impl Builtin {
                     Self::Desktop => (include_str!("../../examples/desktop/config.toml"), FileFormat::Toml)
                 }
             }
+        }
+    }
+
+    pub fn css(&self) -> &'static str {
+        match self {
+            Self::Minimal => include_str!("../../examples/minimal/style.css"),
+            Self::Desktop => include_str!("../../examples/desktop/style.css"),
         }
     }
 }
@@ -74,11 +72,9 @@ pub enum CssSource {
 pub fn resolve_sources(
     cli_config: Option<ConfigLocation>,
     cli_css: Option<ConfigLocation>,
-    env_config: Option<String>,
-    env_css: Option<String>,
 ) -> (ConfigSource, CssSource) {
-    let config = resolve_config(cli_config, env_config);
-    let css = resolve_css(cli_css, env_css, &config);
+    let config = resolve_config(cli_config);
+    let css = resolve_css(cli_css, &config);
     (config, css)
 }
 
@@ -86,21 +82,13 @@ pub fn resolve_sources(
 pub fn resolve_sources(
     cli_config: Option<ConfigLocation>,
     cli_css: Option<ConfigLocation>,
-    env_config: Option<String>,
-    env_css: Option<String>,
 ) -> (ConfigSource, CssSource) {
     panic!(
         "Ironbar has been configured without config support. This won't work. Please reconfigure with at least one `config` feature flag enabled."
     )
 }
 
-fn resolve_config(cli: Option<ConfigLocation>, env: Option<String>) -> ConfigSource {
-    // IRONBAR_CONFIG env var
-    if let Some(path) = env {
-        return ConfigSource::File(PathBuf::from(path));
-    }
-
-    // --config CLI arg
+fn resolve_config(cli: Option<ConfigLocation>) -> ConfigSource {
     if let Some(loc) = cli {
         return match loc {
             ConfigLocation::Minimal => ConfigSource::Builtin(Builtin::Minimal),
@@ -109,7 +97,6 @@ fn resolve_config(cli: Option<ConfigLocation>, env: Option<String>) -> ConfigSou
         };
     }
 
-    // XDG_CONFIG_DIR user config
     let xdg = dirs::config_dir()
         .unwrap_or_default()
         .join("ironbar/config");
@@ -117,27 +104,15 @@ fn resolve_config(cli: Option<ConfigLocation>, env: Option<String>) -> ConfigSou
         return ConfigSource::File(xdg);
     }
 
-    // /etc/ system config
     let etc = Path::new("/etc/ironbar/config");
     if config_source_exists(etc) {
         return ConfigSource::File(etc.to_path_buf());
     }
 
-    // Fallback: minimal config
     ConfigSource::Builtin(Builtin::Minimal)
 }
 
-fn resolve_css(
-    cli: Option<ConfigLocation>,
-    env: Option<String>,
-    config: &ConfigSource,
-) -> CssSource {
-    // IRONBAR_CSS env var
-    if let Some(path) = env {
-        return CssSource::File(css_path(PathBuf::from(path)));
-    }
-
-    // --theme CLI arg
+fn resolve_css(cli: Option<ConfigLocation>, config: &ConfigSource) -> CssSource {
     if let Some(loc) = cli {
         return match loc {
             ConfigLocation::Minimal => CssSource::Builtin(Builtin::Minimal),
@@ -157,7 +132,6 @@ fn resolve_css(
         };
     }
 
-    // CSS from Config dir
     match config {
         ConfigSource::Builtin(b) => CssSource::Builtin(b.clone()),
         ConfigSource::File(path) => {
@@ -176,10 +150,31 @@ fn resolve_css(
 }
 
 fn config_source_exists(base: &Path) -> bool {
-    config::Config::builder()
-        .add_source(config::File::from(base))
-        .build()
-        .is_ok()
+    if base.exists() {
+        return true;
+    }
+
+    #[cfg(feature = "config+corn")]
+    if base.with_extension("corn").exists() {
+        return true;
+    }
+
+    #[cfg(feature = "config+json")]
+    if base.with_extension("json").exists() {
+        return true;
+    }
+
+    #[cfg(feature = "config+yaml")]
+    if base.with_extension("yaml").exists() {
+        return true;
+    }
+
+    #[cfg(feature = "config+toml")]
+    if base.with_extension("toml").exists() {
+        return true;
+    }
+
+    false
 }
 
 fn css_path(path: PathBuf) -> PathBuf {

--- a/src/config/sources.rs
+++ b/src/config/sources.rs
@@ -70,26 +70,26 @@ pub enum CssSource {
 
 #[cfg(feature = "config")]
 pub fn resolve_sources(
-    cli_config: Option<ConfigLocation>,
-    cli_css: Option<ConfigLocation>,
+    config: Option<ConfigLocation>,
+    css: Option<ConfigLocation>,
 ) -> (ConfigSource, CssSource) {
-    let config = resolve_config(cli_config);
-    let css = resolve_css(cli_css, &config);
-    (config, css)
+    let resolved_config = resolve_config(config);
+    let resolved_css = resolve_css(css, &resolved_config);
+    (resolved_config, resolved_css)
 }
 
 #[cfg(not(feature = "config"))]
 pub fn resolve_sources(
-    cli_config: Option<ConfigLocation>,
-    cli_css: Option<ConfigLocation>,
+    config: Option<ConfigLocation>,
+    css: Option<ConfigLocation>,
 ) -> (ConfigSource, CssSource) {
     panic!(
         "Ironbar has been configured without config support. This won't work. Please reconfigure with at least one `config` feature flag enabled."
     )
 }
 
-fn resolve_config(cli: Option<ConfigLocation>) -> ConfigSource {
-    if let Some(loc) = cli {
+fn resolve_config(path_override: Option<ConfigLocation>) -> ConfigSource {
+    if let Some(loc) = path_override {
         return match loc {
             ConfigLocation::Minimal => ConfigSource::Builtin(Builtin::Minimal),
             ConfigLocation::Desktop => ConfigSource::Builtin(Builtin::Desktop),
@@ -112,8 +112,8 @@ fn resolve_config(cli: Option<ConfigLocation>) -> ConfigSource {
     ConfigSource::Builtin(Builtin::Minimal)
 }
 
-fn resolve_css(cli: Option<ConfigLocation>, config: &ConfigSource) -> CssSource {
-    if let Some(loc) = cli {
+fn resolve_css(path_override: Option<ConfigLocation>, config: &ConfigSource) -> CssSource {
+    if let Some(loc) = path_override {
         return match loc {
             ConfigLocation::Minimal => CssSource::Builtin(Builtin::Minimal),
             ConfigLocation::Desktop => CssSource::Builtin(Builtin::Desktop),
@@ -165,7 +165,7 @@ fn config_source_exists(base: &Path) -> bool {
     }
 
     #[cfg(feature = "config+yaml")]
-    if base.with_extension("yaml").exists() {
+    if base.with_extension("yaml").exists() || base.with_extension("yml").exists() {
         return true;
     }
 

--- a/src/config/sources.rs
+++ b/src/config/sources.rs
@@ -1,0 +1,193 @@
+use cfg_if::cfg_if;
+use config::FileFormat;
+use std::path::{Path, PathBuf};
+use tracing::error;
+
+use super::ConfigLocation;
+
+#[derive(Debug, Clone)]
+pub enum Builtin {
+    Minimal,
+    Desktop,
+}
+
+impl Builtin {
+    pub fn css(&self) -> &'static str {
+        match self {
+            Self::Minimal => include_str!("../../examples/minimal/style.css"),
+            Self::Desktop => include_str!("../../examples/desktop/style.css"),
+        }
+    }
+}
+
+#[cfg(feature = "config")]
+impl Builtin {
+    pub fn config(&self) -> (&'static str, config::FileFormat) {
+        cfg_if! {
+            if #[cfg(feature = "config+corn")] {
+                match self {
+                    Self::Minimal => (include_str!("../../examples/minimal/config.corn"), FileFormat::Corn),
+                    Self::Desktop => (include_str!("../../examples/desktop/config.corn"), FileFormat::Corn)
+                }
+            } else if #[cfg(feature = "config+json")] {
+                match self {
+                    Self::Minimal => (include_str!("../../examples/minimal/config.json"), FileFormat::Json),
+                    Self::Desktop => (include_str!("../../examples/desktop/config.json"), FileFormat::Json)
+                }
+            } else if #[cfg(feature = "config+yaml")] {
+                match self {
+                    Self::Minimal => (include_str!("../../examples/minimal/config.yaml"), FileFormat::Yaml),
+                    Self::Desktop => (include_str!("../../examples/desktop/config.yaml"), FileFormat::Yaml)
+                }
+            } else if #[cfg(feature = "config+toml")] {
+                match self {
+                    Self::Minimal => (include_str!("../../examples/minimal/config.toml"), FileFormat::Toml),
+                    Self::Desktop => (include_str!("../../examples/desktop/config.toml"), FileFormat::Toml)
+                }
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum ConfigSource {
+    Builtin(Builtin),
+    File(PathBuf),
+}
+
+impl ConfigSource {
+    pub fn xdg_config_path() -> PathBuf {
+        dirs::config_dir()
+            .unwrap_or_default()
+            .to_path_buf()
+            .join("ironbar/config")
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum CssSource {
+    Builtin(Builtin),
+    File(PathBuf),
+}
+
+#[cfg(feature = "config")]
+pub fn resolve_sources(
+    cli_config: Option<ConfigLocation>,
+    cli_css: Option<ConfigLocation>,
+    env_config: Option<String>,
+    env_css: Option<String>,
+) -> (ConfigSource, CssSource) {
+    let config = resolve_config(cli_config, env_config);
+    let css = resolve_css(cli_css, env_css, &config);
+    (config, css)
+}
+
+#[cfg(not(feature = "config"))]
+pub fn resolve_sources(
+    cli_config: Option<ConfigLocation>,
+    cli_css: Option<ConfigLocation>,
+    env_config: Option<String>,
+    env_css: Option<String>,
+) -> (ConfigSource, CssSource) {
+    panic!(
+        "Ironbar has been configured without config support. This won't work. Please reconfigure with at least one `config` feature flag enabled."
+    )
+}
+
+fn resolve_config(cli: Option<ConfigLocation>, env: Option<String>) -> ConfigSource {
+    // IRONBAR_CONFIG env var
+    if let Some(path) = env {
+        return ConfigSource::File(PathBuf::from(path));
+    }
+
+    // --config CLI arg
+    if let Some(loc) = cli {
+        return match loc {
+            ConfigLocation::Minimal => ConfigSource::Builtin(Builtin::Minimal),
+            ConfigLocation::Desktop => ConfigSource::Builtin(Builtin::Desktop),
+            ConfigLocation::Custom(path) => ConfigSource::File(path),
+        };
+    }
+
+    // XDG_CONFIG_DIR user config
+    let xdg = dirs::config_dir()
+        .unwrap_or_default()
+        .join("ironbar/config");
+    if config_source_exists(&xdg) {
+        return ConfigSource::File(xdg);
+    }
+
+    // /etc/ system config
+    let etc = Path::new("/etc/ironbar/config");
+    if config_source_exists(etc) {
+        return ConfigSource::File(etc.to_path_buf());
+    }
+
+    // Fallback: minimal config
+    ConfigSource::Builtin(Builtin::Minimal)
+}
+
+fn resolve_css(
+    cli: Option<ConfigLocation>,
+    env: Option<String>,
+    config: &ConfigSource,
+) -> CssSource {
+    // IRONBAR_CSS env var
+    if let Some(path) = env {
+        return CssSource::File(css_path(PathBuf::from(path)));
+    }
+
+    // --theme CLI arg
+    if let Some(loc) = cli {
+        return match loc {
+            ConfigLocation::Minimal => CssSource::Builtin(Builtin::Minimal),
+            ConfigLocation::Desktop => CssSource::Builtin(Builtin::Desktop),
+            ConfigLocation::Custom(path) => {
+                let style = css_path(path);
+                if style.exists() {
+                    CssSource::File(style)
+                } else {
+                    error!(
+                        "styles at '{}' not found, falling back to minimal theme",
+                        style.display()
+                    );
+                    CssSource::Builtin(Builtin::Minimal)
+                }
+            }
+        };
+    }
+
+    // CSS from Config dir
+    match config {
+        ConfigSource::Builtin(b) => CssSource::Builtin(b.clone()),
+        ConfigSource::File(path) => {
+            let style = css_path(path.clone());
+            if style.exists() {
+                CssSource::File(style)
+            } else {
+                error!(
+                    "styles at '{}' not found, falling back to minimal theme",
+                    style.display()
+                );
+                CssSource::Builtin(Builtin::Minimal)
+            }
+        }
+    }
+}
+
+fn config_source_exists(base: &Path) -> bool {
+    config::Config::builder()
+        .add_source(config::File::from(base))
+        .build()
+        .is_ok()
+}
+
+fn css_path(path: PathBuf) -> PathBuf {
+    if path.is_dir() {
+        path.join("style.css")
+    } else if path.extension().is_none_or(|ext| ext != "css") {
+        path.parent().unwrap_or(&path).join("style.css")
+    } else {
+        path
+    }
+}

--- a/src/ipc/server/style.rs
+++ b/src/ipc/server/style.rs
@@ -1,8 +1,9 @@
 use crate::Ironbar;
 use crate::bar::Bar;
+use crate::config::CssSource;
 use crate::ipc::{Response, StyleCommand};
 use crate::modules::ModuleRef;
-use crate::style::{CssSource, load_css};
+use crate::style::load_css;
 use gtk::prelude::*;
 
 pub fn handle_command(command: StyleCommand, ironbar: &Ironbar) -> Response {

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,12 +27,12 @@ use crate::bar::{Bar, create_bar};
 use crate::channels::SyncSenderExt;
 use crate::clients::Clients;
 use crate::clients::outputs::MonitorState;
-use crate::config::{Config, ConfigLocation, MonitorConfig};
+use crate::config::{Config, ConfigSource, CssSource, MonitorConfig, resolve_sources};
 use crate::desktop_file::DesktopFiles;
 use crate::error::ExitCode;
 #[cfg(any(feature = "ipc", feature = "cairo"))]
 use crate::ironvar::VariableManager;
-use crate::style::{CssSource, load_css};
+use crate::style::load_css;
 
 mod bar;
 mod channels;
@@ -64,8 +64,13 @@ fn main() {
         if #[cfg(feature = "cli")] {
             run_with_args();
         } else {
-            let config_location = ConfigLocation::from_env("IRONBAR_CONFIG").unwrap_or_default();
-            start_ironbar(false, config_location, ConfigLocation::from_env("IRONBAR_CSS"));
+            let (config_source, css_source) = resolve_sources(
+                None,
+                None,
+                std::env::var("IRONBAR_CONFIG").ok(),
+                std::env::var("IRONBAR_CSS").ok(),
+            );
+            start_ironbar(false, config_source, css_source);
         }
     }
 }
@@ -127,7 +132,13 @@ fn run_with_args() {
         None if args.validate_config > 0 => {
             let _guard = logging::install_logging(args.debug);
 
-            let (_, _, error_level) = Config::load(args.config.unwrap_or_default(), args.theme);
+            let (config_source, _) = resolve_sources(
+                args.config,
+                args.theme,
+                std::env::var("IRONBAR_CONFIG").ok(),
+                std::env::var("IRONBAR_CSS").ok(),
+            );
+            let (_, error_level) = Config::load(&config_source);
 
             let err = match args.validate_config {
                 1 => error_level >= config::ErrorLevel::Error,
@@ -140,7 +151,15 @@ fn run_with_args() {
 
             exit(err as i32);
         }
-        None => start_ironbar(args.debug, args.config.unwrap_or_default(), args.theme),
+        None => {
+            let (config_source, css_source) = resolve_sources(
+                args.config,
+                args.theme,
+                std::env::var("IRONBAR_CONFIG").ok(),
+                std::env::var("IRONBAR_CSS").ok(),
+            );
+            start_ironbar(args.debug, config_source, css_source);
+        }
     }
 }
 
@@ -150,24 +169,15 @@ pub struct Ironbar {
     clients: Rc<RefCell<Clients>>,
     config: Rc<RefCell<Config>>,
     css_source: Rc<CssSource>,
-    config_location: ConfigLocation,
-    css_location: Option<ConfigLocation>,
+    config_source: ConfigSource,
     scripts: Rc<RefCell<HashMap<String, Sender<()>>>>,
     desktop_files: DesktopFiles,
     image_provider: image::Provider,
 }
 
 impl Ironbar {
-    fn new(config_location: ConfigLocation, css_location: Option<ConfigLocation>) -> Self {
-        cfg_if!(
-            if #[cfg(feature = "config")] {
-                let (mut config, css_source, _) =
-                    Config::load(config_location.clone(), css_location.clone());
-            } else {
-                let (mut config, css_source) =
-                    Config::load(config_location.clone(), css_location.clone());
-            }
-        );
+    fn new(config_source: ConfigSource, css_source: CssSource) -> Self {
+        let (mut config, _) = Config::load(&config_source);
 
         let desktop_files = DesktopFiles::new();
         let image_provider =
@@ -178,8 +188,7 @@ impl Ironbar {
             clients: rc_mut!(Clients::new()),
             config: rc_mut!(config),
             css_source: Rc::new(css_source),
-            config_location,
-            css_location,
+            config_source,
             scripts: rc_mut!(HashMap::new()),
             desktop_files,
             image_provider,
@@ -375,19 +384,14 @@ impl Ironbar {
     /// Note this does *not* reload bars, which must be performed separately.
     #[cfg(feature = "ipc")]
     fn reload_config(&self) {
-        self.config
-            .replace(Config::load(self.config_location.clone(), self.css_location.clone()).0);
+        self.config.replace(Config::load(&self.config_source).0);
     }
 }
 
-fn start_ironbar(
-    debug: bool,
-    config_location: ConfigLocation,
-    css_location: Option<ConfigLocation>,
-) {
+fn start_ironbar(debug: bool, config_source: ConfigSource, css_source: CssSource) {
     let _guard = logging::install_logging(debug);
 
-    let ironbar = Ironbar::new(config_location, css_location);
+    let ironbar = Ironbar::new(config_source, css_source);
     ironbar.start();
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,8 +67,6 @@ fn main() {
             let (config_source, css_source) = resolve_sources(
                 None,
                 None,
-                std::env::var("IRONBAR_CONFIG").ok(),
-                std::env::var("IRONBAR_CSS").ok(),
             );
             start_ironbar(false, config_source, css_source);
         }
@@ -132,12 +130,7 @@ fn run_with_args() {
         None if args.validate_config > 0 => {
             let _guard = logging::install_logging(args.debug);
 
-            let (config_source, _) = resolve_sources(
-                args.config,
-                args.theme,
-                std::env::var("IRONBAR_CONFIG").ok(),
-                std::env::var("IRONBAR_CSS").ok(),
-            );
+            let (config_source, _) = resolve_sources(args.config, args.theme);
             let (_, error_level) = Config::load(&config_source);
 
             let err = match args.validate_config {
@@ -152,12 +145,7 @@ fn run_with_args() {
             exit(err as i32);
         }
         None => {
-            let (config_source, css_source) = resolve_sources(
-                args.config,
-                args.theme,
-                std::env::var("IRONBAR_CONFIG").ok(),
-                std::env::var("IRONBAR_CSS").ok(),
-            );
+            let (config_source, css_source) = resolve_sources(args.config, args.theme);
             start_ironbar(args.debug, config_source, css_source);
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,8 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::env;
 use std::future::Future;
+#[cfg(not(feature = "cli"))]
+use std::path::PathBuf;
 use std::process::exit;
 use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
@@ -27,6 +29,8 @@ use crate::bar::{Bar, create_bar};
 use crate::channels::SyncSenderExt;
 use crate::clients::Clients;
 use crate::clients::outputs::MonitorState;
+#[cfg(not(feature = "cli"))]
+use crate::config::ConfigLocation;
 use crate::config::{Config, ConfigSource, CssSource, MonitorConfig, resolve_sources};
 use crate::desktop_file::DesktopFiles;
 use crate::error::ExitCode;
@@ -65,8 +69,8 @@ fn main() {
             run_with_args();
         } else {
             let (config_source, css_source) = resolve_sources(
-                None,
-                None,
+                env::var("IRONBAR_CONFIG").map(PathBuf::from).ok().map(ConfigLocation::Custom),
+                env::var("IRONBAR_CSS").map(PathBuf::from).ok().map(ConfigLocation::Custom),
             );
             start_ironbar(false, config_source, css_source);
         }

--- a/src/modules/cairo.rs
+++ b/src/modules/cairo.rs
@@ -1,6 +1,7 @@
 use crate::channels::{AsyncSenderExt, BroadcastReceiverExt};
 use crate::clients::lua::LuaEngine;
-use crate::config::{CommonConfig, ConfigLocation};
+use crate::config::CommonConfig;
+use crate::config::ConfigSource;
 use crate::modules::{Module, ModuleInfo, ModuleParts, WidgetContext};
 use crate::{module_impl, rc_mut, spawn};
 use glib::translate::ToGlibPtr;
@@ -180,12 +181,12 @@ impl Module<gtk::Box> for CairoModule {
 
         let area = DrawingArea::new();
 
-        let config_dir = match &context.ironbar.config_location {
-            ConfigLocation::Minimal | ConfigLocation::Desktop => {
-                let path = ConfigLocation::default_path();
-                path.parent().unwrap_or(&path).to_path_buf()
+        let config_dir = match &context.ironbar.config_source {
+            ConfigSource::Builtin(_) => {
+                let xdg_path = ConfigSource::xdg_config_path();
+                xdg_path.parent().unwrap_or(&xdg_path).to_path_buf()
             }
-            ConfigLocation::Custom(path) => path.parent().unwrap_or(path).to_path_buf(),
+            ConfigSource::File(path) => path.parent().unwrap_or(path).to_path_buf(),
         };
 
         let lua = context.ironbar.clients.borrow_mut().lua(&config_dir);

--- a/src/style.rs
+++ b/src/style.rs
@@ -1,21 +1,15 @@
 use crate::channels::{AsyncSenderExt, MpscReceiverExt};
+use crate::config::CssSource;
 use crate::spawn;
 use gtk::ffi::GTK_STYLE_PROVIDER_PRIORITY_USER;
 use gtk::{CssProvider, gio};
 use notify::event::ModifyKind;
 use notify::{Event, EventKind, RecursiveMode, Result, Watcher, recommended_watcher};
 use std::env;
-use std::path::PathBuf;
 use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio::time::sleep;
 use tracing::{debug, error, info};
-
-#[derive(Debug)]
-pub enum CssSource {
-    String(&'static str),
-    File(PathBuf),
-}
 
 /// Attempts to load CSS file at the given path
 /// and attach if to the current GTK application.
@@ -26,8 +20,8 @@ pub fn load_css(source: &CssSource) {
     let provider = CssProvider::new();
 
     let path = match source {
-        CssSource::String(str) => {
-            provider.load_from_string(str);
+        CssSource::Builtin(b) => {
+            provider.load_from_string(b.css());
             debug!("loaded built-in css");
             None
         }


### PR DESCRIPTION
Refactors Config and CSS Source resolution out of config loader and into a separate `sources.rs` file, and adds `/etc/` as a system-wide configuration source.

Config Resolution order:
1. `IRONBAR_CONFIG` / `IRONBAR_CSS` env vars
2. `--config` / `--theme` CLI args
3. `$XDG_CONFIG_HOME/ironbar/` user level config
4. `/etc/ironbar/` system level config
5. Builtin Minimal config fallback