### PR TITLE
fix(workspaces): clear stale `.visible` class on cross-monitor focus

### DIFF
--- a/src/modules/workspaces/button.rs
+++ b/src/modules/workspaces/button.rs
@@ -11,6 +11,8 @@ use tokio::sync::mpsc;
 pub struct Button {
     button: IconButton,
     workspace_id: i64,
+    monitor: String,
+    open_state: OpenState,
     conn_id: Option<SignalHandlerId>,
     tx: mpsc::Sender<i64>,
 }
@@ -20,6 +22,7 @@ impl Button {
         id: i64,
         index: i64,
         name: &str,
+        monitor: &str,
         open_state: OpenState,
         context: &WorkspaceItemContext,
     ) -> Self {
@@ -35,9 +38,11 @@ impl Button {
             tx.send_spawn(id);
         });
 
-        let btn = Self {
+        let mut btn = Self {
             button,
             workspace_id: id,
+            monitor: monitor.to_string(),
+            open_state,
             conn_id: Some(conn_id),
             tx: context.tx.clone(),
         };
@@ -54,7 +59,13 @@ impl Button {
         self.button.set_label(label);
     }
 
-    pub fn set_open_state(&self, open_state: OpenState) {
+    pub fn open_state(&self) -> OpenState {
+        self.open_state
+    }
+
+    pub fn set_open_state(&mut self, open_state: OpenState) {
+        self.open_state = open_state;
+
         if open_state.is_visible() {
             self.button.add_css_class("visible");
         } else {
@@ -96,5 +107,13 @@ impl Button {
             tx.send_spawn(id);
         });
         self.conn_id = Some(conn_id);
+    }
+
+    pub fn monitor(&self) -> &str {
+        &self.monitor
+    }
+
+    pub fn set_monitor(&mut self, monitor: &str) {
+        self.monitor = monitor.to_string();
     }
 }

--- a/src/modules/workspaces/button.rs
+++ b/src/modules/workspaces/button.rs
@@ -64,6 +64,9 @@ impl Button {
     }
 
     pub fn set_open_state(&mut self, open_state: OpenState) {
+        if self.open_state == open_state {
+            return;
+        }
         self.open_state = open_state;
 
         if open_state.is_visible() {

--- a/src/modules/workspaces/mod.rs
+++ b/src/modules/workspaces/mod.rs
@@ -354,7 +354,14 @@ impl Module<gtk::Box> for WorkspacesModule {
                     (-1, 0)
                 }
             };
-            let btn = Button::new(id, index, favorite, OpenState::Closed, &item_context);
+            let btn = Button::new(
+                id,
+                index,
+                favorite,
+                info.output_name,
+                OpenState::Closed,
+                &item_context,
+            );
 
             btn.button().set_tag("workspace_index", index);
             container.append(btn.button());
@@ -381,6 +388,7 @@ impl Module<gtk::Box> for WorkspacesModule {
 
                         // set an ID to track the open workspace for the favourite
                         btn.set_workspace_id(workspace.id);
+                        btn.set_monitor(&workspace.monitor);
                         btn.set_open_state(workspace.visibility.into());
                         let label = item_context.format_label(&workspace.name, workspace.index);
                         btn.set_label(&label);
@@ -389,12 +397,14 @@ impl Module<gtk::Box> for WorkspacesModule {
                     } else if let Some(btn) = button_map.find_button_mut(&workspace) {
                         let label = item_context.format_label(&workspace.name, workspace.index);
                         btn.set_label(&label);
+                        btn.set_monitor(&workspace.monitor);
                         btn.button().set_tag("workspace_index", workspace.index);
                     } else {
                         let btn = Button::new(
                             workspace.id,
                             workspace.index,
                             &workspace.name,
+                            &workspace.monitor,
                             workspace.visibility.into(),
                             &item_context,
                         );
@@ -507,8 +517,19 @@ impl Module<gtk::Box> for WorkspacesModule {
                             button.set_open_state(open_state);
                         }
 
-                        if let Some(button) = button_map.find_button_mut(&new) {
-                            button.set_open_state(OpenState::Focused);
+                        // Exactly one monitor should be focused. Update old buttons in the same monitor.
+                        for button in button_map.values_mut() {
+                            if button.open_state() == OpenState::Closed {
+                                continue;
+                            }
+                            if button.monitor() == new.monitor {
+                                let open_state = if button.workspace_id() == new.id {
+                                    OpenState::Focused
+                                } else {
+                                    OpenState::Hidden
+                                };
+                                button.set_open_state(open_state);
+                            }
                         }
                     }
                     WorkspaceUpdate::Rename { id, name } if has_initialized => {

--- a/src/modules/workspaces/mod.rs
+++ b/src/modules/workspaces/mod.rs
@@ -505,29 +505,11 @@ impl Module<gtk::Box> for WorkspacesModule {
                         // as that seems to come back wrong, at least on Hyprland.
                         // Likely a deeper issue that needs exploring.
 
-                        if let Some(old) = old
-                            && let Some(button) = button_map.find_button_mut(&old)
-                        {
-                            let open_state = if new.monitor == old.monitor {
-                                OpenState::Hidden
-                            } else {
-                                OpenState::Visible
-                            };
-
-                            button.set_open_state(open_state);
-                        }
-
                         // Exactly one monitor should be focused. Update old buttons in the same monitor.
                         for button in button_map.values_mut() {
-                            if button.open_state() == OpenState::Closed {
-                                continue;
-                            }
-                            if button.monitor() == new.monitor {
-                                let open_state = if button.workspace_id() == new.id {
-                                    OpenState::Focused
-                                } else {
-                                    OpenState::Hidden
-                                };
+                            if let Some(open_state) =
+                                new_state_for_button(button, &new, old.as_ref())
+                            {
                                 button.set_open_state(open_state);
                             }
                         }
@@ -575,6 +557,32 @@ impl Module<gtk::Box> for WorkspacesModule {
             widget: container,
             popup: None,
         })
+    }
+}
+
+fn new_state_for_button(
+    button: &Button,
+    new: &Workspace,
+    old: Option<&Workspace>,
+) -> Option<OpenState> {
+    if button.open_state() == OpenState::Closed {
+        None
+    } else if button.monitor() == new.monitor {
+        if button.workspace_id() == new.id {
+            Some(OpenState::Focused)
+        } else {
+            Some(OpenState::Hidden)
+        }
+    } else if let Some(old) = old
+        && old.id == button.workspace_id()
+    {
+        if new.monitor == old.monitor {
+            Some(OpenState::Hidden)
+        } else {
+            Some(OpenState::Visible)
+        }
+    } else {
+        None
     }
 }
 


### PR DESCRIPTION
Compositors only emit a `Focus` event for the (old, new) workspace pair, so a third workspace which was visible on the newly-focused output would keep its `.visible` CSS class indefinitely.

No known issue. 

See video with before/after:
https://github.com/user-attachments/assets/f5aa39df-9422-401a-a119-f930ffddc98d

My ironbar style.css differentiates button colors between visible, focused and hidden. You can see the colors change as I focus the other monitor (not visible in recording).

Before: As I switch to the second monitor, the buttons of the first switch to the visible state color. However, when I switch back to the main monitor to a different workspace, they never lose their "visible" status.
After: Switching to a different workspace in the first monitor updates the other buttons.