### PR TITLE
fix(workspaces): apply visibility hint classes on startup

### DIFF
--- a/src/modules/brightness.rs
+++ b/src/modules/brightness.rs
@@ -334,7 +334,7 @@ impl Module<Button> for BrightnessModule {
                                     default_resource_name.as_deref(),
                                     new_brightness,
                                 )
-                                    .await
+                                .await
                                 {
                                     tracing::error!(?err, "Could not change brightness");
                                 }

--- a/src/modules/workspaces/button.rs
+++ b/src/modules/workspaces/button.rs
@@ -38,7 +38,7 @@ impl Button {
             tx.send_spawn(id);
         });
 
-        let mut btn = Self {
+        let btn = Self {
             button,
             workspace_id: id,
             monitor: monitor.to_string(),
@@ -47,7 +47,7 @@ impl Button {
             tx: context.tx.clone(),
         };
 
-        btn.set_open_state(open_state);
+        btn.apply_open_state();
         btn
     }
 
@@ -68,6 +68,11 @@ impl Button {
             return;
         }
         self.open_state = open_state;
+        self.apply_open_state();
+    }
+
+    fn apply_open_state(&self) {
+        let open_state = self.open_state;
 
         if open_state.is_visible() {
             self.button.add_css_class("visible");


### PR DESCRIPTION
The early-return guard in `set_open_state` short-circuited at button construction time, making the call a no-op.