### PR TITLE
fix(volume): refactor popup

### DIFF
--- a/src/modules/volume/mod.rs
+++ b/src/modules/volume/mod.rs
@@ -11,11 +11,11 @@ use gtk::{
     Button, DropDown, Expression, Label, ListItem, Orientation, Scale, SignalListItemFactory,
     ToggleButton, gio,
 };
-use tokio::sync::mpsc::{self, Sender};
+use tokio::sync::mpsc::{self};
 use tracing::trace;
 
 use crate::channels::{AsyncSenderExt, BroadcastReceiverExt};
-use crate::clients::volume::{self, Event};
+use crate::clients::volume::{self, Event, Sink, SinkInput, Source, SourceOutput, VolumeLevels};
 use crate::config::{ModuleOrientation, ProfileUpdateEvent};
 use crate::gtk_helpers::{IronbarLabelExt, OverflowLabel};
 use crate::modules::{
@@ -58,22 +58,6 @@ enum BarUiUpdate {
 
 struct BtnMuteUiUpdate {
     muted: bool,
-    button: Option<ToggleButton>,
-}
-
-impl BtnMuteUiUpdate {
-    fn muted(muted: bool) -> Self {
-        Self {
-            muted,
-            button: None,
-        }
-    }
-    fn muted_with(muted: bool, button: ToggleButton) -> Self {
-        Self {
-            muted,
-            button: Some(button),
-        }
-    }
 }
 
 glib::wrapper! {
@@ -107,16 +91,148 @@ impl ObjectSubclass for DropdownItemData {
     type Type = DropdownItem;
 }
 
-impl VolumeModule {
-    fn overflow_label(&self, name: &str, css_class: &str) -> OverflowLabel {
-        let label = OverflowLabel::new(Label::new(None), self.truncate_popup, &self.marquee);
-        label.label().add_css_class(css_class);
-        label.set_label_escaped(name);
-        label
-    }
+#[derive(Debug, Clone)]
+struct Device {
+    name: String,
+    description: String,
+    volume: VolumeLevels,
+    muted: bool,
+}
 
-    fn new_slider(&self) -> Scale {
-        let slider = match self.source_slider_orientation {
+impl From<Source> for Device {
+    fn from(source: Source) -> Device {
+        Device {
+            name: source.name,
+            description: source.description,
+            volume: source.volume,
+            muted: source.muted,
+        }
+    }
+}
+
+impl From<Sink> for Device {
+    fn from(sink: Sink) -> Device {
+        Device {
+            name: sink.name,
+            description: sink.description,
+            volume: sink.volume,
+            muted: sink.muted,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct Stream {
+    index: u32,
+    name: String,
+    volume: VolumeLevels,
+    muted: bool,
+    can_set_volume: bool,
+}
+
+impl From<SourceOutput> for Stream {
+    fn from(source_output: SourceOutput) -> Stream {
+        Stream {
+            index: source_output.index,
+            name: source_output.name,
+            volume: source_output.volume,
+            muted: source_output.muted,
+            can_set_volume: source_output.can_set_volume,
+        }
+    }
+}
+
+impl From<SinkInput> for Stream {
+    fn from(sink_input: SinkInput) -> Stream {
+        Stream {
+            index: sink_input.index,
+            name: sink_input.name,
+            volume: sink_input.volume,
+            muted: sink_input.muted,
+            can_set_volume: sink_input.can_set_volume,
+        }
+    }
+}
+
+struct DeviceUi {
+    config: VolumeModule,
+    default_device_name: Option<String>,
+    container: gtk::Box,
+    selector: DropDown,
+    slider: Scale,
+    options: gio::ListStore,
+    no_device: DropdownItem,
+    btn_mute: ToggleButton,
+    profile_update: Box<dyn FnMut(f64, BtnMuteUiUpdate)>,
+}
+
+// This struct avoids the too many arguments clippy warning in DeviceUi::new
+struct DeviceUiCallbacks {
+    select_notify_fn: fn(String) -> Update,
+    slider_notify_fn: fn(String, f64) -> Update,
+    button_notify_fn: fn(String, bool) -> Update,
+    profile_update_fn: fn(&ToggleButton, ProfileUpdateEvent<f64, VolumeProfile, BtnMuteUiUpdate>),
+}
+
+impl DeviceUi {
+    fn new(
+        config: VolumeModule,
+        context: &WidgetContext<Event, Update>,
+        ignore_selected: &Rc<Cell<bool>>,
+        no_device: DropdownItem,
+        callbacks: DeviceUiCallbacks,
+    ) -> Self {
+        let container = gtk::Box::new(Orientation::Vertical, 5);
+
+        let options = gio::ListStore::new::<DropdownItem>();
+        options.append(&no_device);
+
+        let factory = SignalListItemFactory::new();
+        factory.connect_setup(move |_, list_item| {
+            let label = Label::new(None);
+            list_item
+                .downcast_ref::<ListItem>()
+                .expect("Needs to be ListItem")
+                .set_child(Some(&label));
+        });
+        factory.connect_bind(move |_, list_item| {
+            let dropdown_item = list_item
+                .downcast_ref::<ListItem>()
+                .expect("should be ListItem")
+                .item()
+                .and_downcast::<DropdownItem>()
+                .expect("should be `DropdownItem`.");
+
+            let label = list_item
+                .downcast_ref::<ListItem>()
+                .expect("should be ListItem")
+                .child()
+                .and_downcast::<Label>()
+                .expect("should be a `Label`.");
+
+            label.set_label(&dropdown_item.value().clone());
+            if let Some(truncate) = config.truncate_popup {
+                label.truncate(truncate);
+            }
+        });
+
+        let selector = DropDown::new(Some(options.clone()), None::<Expression>);
+        selector.set_factory(Some(&factory));
+        selector.add_css_class("device-selector");
+        {
+            let tx = context.controller_tx.clone();
+            let ignore_selected = ignore_selected.clone();
+            selector.connect_selected_item_notify(move |selector| {
+                if !ignore_selected.get()
+                    && let Some(item) = selector.selected_item().and_downcast_ref::<DropdownItem>()
+                {
+                    tx.send_spawn((callbacks.select_notify_fn)(item.key()));
+                }
+            });
+        }
+        container.append(&selector);
+
+        let slider = match config.source_slider_orientation {
             ModuleOrientation::Horizontal => Scale::builder()
                 .orientation(Orientation::Horizontal)
                 .build(),
@@ -126,76 +242,390 @@ impl VolumeModule {
                 .inverted(true)
                 .build(),
         };
-        slider.set_range(0.0, self.max_volume);
-        slider.set_value(50.0);
-        slider
+        slider.set_range(0.0, config.max_volume);
+        slider.add_css_class("slider");
+        container.append(&slider);
+        {
+            let tx = context.controller_tx.clone();
+            let max_volume = config.max_volume;
+            let selector = selector.clone();
+            slider.connect_value_changed(move |slider| {
+                if slider.has_css_class("dragging")
+                    && let Some(item) = selector.selected_item().and_downcast_ref::<DropdownItem>()
+                {
+                    // GTK will send values outside min/max range
+                    let val = slider.value().clamp(0.0, max_volume);
+                    tx.send_spawn((callbacks.slider_notify_fn)(item.key(), val));
+                }
+            });
+        }
+
+        let btn_mute = ToggleButton::new();
+        btn_mute.add_css_class("btn-mute");
+        container.append(&btn_mute);
+        {
+            let tx = context.controller_tx.clone();
+            let selector = selector.clone();
+            btn_mute.connect_toggled(move |btn_mute| {
+                if let Some(item) = selector.selected_item().and_downcast_ref::<DropdownItem>() {
+                    let muted = btn_mute.is_active();
+                    tx.send_spawn((callbacks.button_notify_fn)(item.key(), muted));
+                };
+            });
+        }
+
+        let mut manager = config
+            .profiles
+            .attach(&btn_mute, callbacks.profile_update_fn);
+        let ui = Self {
+            config,
+            default_device_name: None,
+            container,
+            selector,
+            slider,
+            options,
+            no_device,
+            btn_mute,
+            profile_update: Box::new(move |v, d| manager.update(v, d)),
+        };
+        ui.set_no_device();
+        ui
     }
 
-    fn select_notify<F>(selector: &DropDown, tx: Sender<Update>, ignore: &Rc<Cell<bool>>, func: F)
-    where
-        F: Fn(String) -> Update + 'static,
-    {
-        let ignore = ignore.clone();
-        selector.connect_selected_item_notify(move |selector| {
-            if !ignore.get()
-                && let Some(item) = selector.selected_item().and_downcast_ref::<DropdownItem>()
-            {
-                tx.send_spawn(func(item.key()));
+    fn set_default_device_name(&mut self, default_device_name: String) {
+        self.default_device_name = Some(default_device_name);
+    }
+
+    fn add_device(&mut self, device: Device, show: bool) {
+        if show {
+            self.options
+                .append(&DropdownItem::new(&device.name, &device.description));
+        }
+
+        if !self.is_default(&device.name) {
+            return;
+        }
+
+        if show {
+            self.set_device(device, self.options.n_items() - 1);
+        } else {
+            self.set_no_device();
+        }
+    }
+
+    fn update_device(&mut self, device: Device) {
+        if !self.is_default(&device.name) {
+            return;
+        }
+
+        if let Some(pos) = self.get_device_position(&device.name) {
+            self.set_device(device, pos);
+        } else {
+            self.set_no_device();
+        }
+    }
+
+    fn remove_device(&mut self, device_name: &str) {
+        if let Some(pos) = self.get_device_position(device_name) {
+            self.options.remove(pos);
+
+            if self.options.n_items() == 0 {
+                self.set_no_device();
             }
-        });
+        }
     }
 
-    fn slider_notify<F>(&self, scale: &Scale, selector: DropDown, tx: Sender<Update>, func: F)
-    where
-        F: Fn(String, f64) -> Update + 'static,
-    {
-        let max_volume = self.max_volume;
-        scale.connect_value_changed(move |scale| {
-            if scale.has_css_class("dragging")
-                && let Some(item) = selector.selected_item().and_downcast_ref::<DropdownItem>()
-            {
+    fn set_device(&mut self, device: Device, pos: u32) {
+        self.selector.set_selected(pos);
+        self.slider.set_visible(true);
+        if !self.slider.has_css_class("dragging") {
+            self.slider.set_value(device.volume.percent());
+        }
+        self.btn_mute.set_visible(true);
+        (self.profile_update)(
+            device.volume.percent(),
+            BtnMuteUiUpdate {
+                muted: device.muted,
+            },
+        );
+
+        if let Some(no_device_pos) = self.options.find(&self.no_device) {
+            self.options.remove(no_device_pos);
+        }
+    }
+
+    fn set_no_device(&self) {
+        let no_device_pos = if let Some(pos) = self.options.find(&self.no_device) {
+            pos
+        } else {
+            self.options.insert(0, &self.no_device);
+            0
+        };
+        self.selector.set_selected(no_device_pos);
+        self.slider.set_visible(false);
+        self.btn_mute.set_visible(false);
+    }
+
+    fn is_default(&self, device_name: &str) -> bool {
+        self.default_device_name.as_deref() == Some(device_name)
+    }
+
+    fn get_device_position(&self, device_name: &str) -> Option<u32> {
+        self.options
+            .iter::<DropdownItem>()
+            .position(|s| s.is_ok_and(|s| s.key() == *device_name))
+            .map(|pos| pos as u32)
+    }
+}
+
+struct SinkUi {
+    inner: DeviceUi,
+}
+
+impl SinkUi {
+    fn new(
+        config: &VolumeModule,
+        context: &WidgetContext<Event, Update>,
+        ignore_selected: &Rc<Cell<bool>>,
+    ) -> Self {
+        let inner = DeviceUi::new(
+            config.clone(),
+            context,
+            ignore_selected,
+            DropdownItem::new("ironbar_no_sink", "No sink available"),
+            DeviceUiCallbacks {
+                select_notify_fn: Update::SinkChange,
+                slider_notify_fn: Update::SinkVolume,
+                button_notify_fn: Update::SinkMute,
+                profile_update_fn: update_sink_mute,
+            },
+        );
+        inner.container.add_css_class("sink-box");
+        inner.selector.add_css_class("sink-selector");
+        inner.slider.add_css_class("sink-slider");
+        inner.btn_mute.add_css_class("sink-mute");
+        Self { inner }
+    }
+
+    fn add_sink(&mut self, sink: Sink) {
+        self.inner.add_device(sink.into(), true);
+    }
+
+    fn update_sink(&mut self, sink: Sink) {
+        self.inner.update_device(sink.into());
+    }
+}
+
+struct SourceUi {
+    inner: DeviceUi,
+}
+
+impl SourceUi {
+    fn new(
+        config: &VolumeModule,
+        context: &WidgetContext<Event, Update>,
+        ignore_selected: &Rc<Cell<bool>>,
+    ) -> Self {
+        let inner = DeviceUi::new(
+            config.clone(),
+            context,
+            ignore_selected,
+            DropdownItem::new("ironbar_no_source", "No source available"),
+            DeviceUiCallbacks {
+                select_notify_fn: Update::SourceChange,
+                slider_notify_fn: Update::SourceVolume,
+                button_notify_fn: Update::SourceMute,
+                profile_update_fn: update_source_mute,
+            },
+        );
+        inner.container.add_css_class("source-box");
+        inner.selector.add_css_class("source-selector");
+        inner.slider.add_css_class("source-slider");
+        inner.btn_mute.add_css_class("source-mute");
+        Self { inner }
+    }
+
+    fn add_source(&mut self, source: Source) {
+        let show = !source.monitor || self.inner.config.show_monitors;
+        self.inner.add_device(source.into(), show);
+    }
+
+    fn update_source(&mut self, source: Source) {
+        self.inner.update_device(source.into());
+    }
+}
+
+struct StreamUi {
+    container: gtk::Box,
+    title_label: OverflowLabel,
+    slider: Scale,
+    btn_mute: ToggleButton,
+    // Store original (unformatted) title to detect change when marquee is enabled
+    label_raw: String,
+    profile_update: Box<dyn FnMut(f64, BtnMuteUiUpdate)>,
+}
+
+impl StreamUi {
+    fn new(
+        stream: Stream,
+        config: &VolumeModule,
+        context: &WidgetContext<Event, Update>,
+        slider_notify_fn: fn(u32, f64) -> Update,
+        button_notify_fn: fn(u32, bool) -> Update,
+        profile_update_fn: fn(
+            &ToggleButton,
+            ProfileUpdateEvent<f64, VolumeProfile, BtnMuteUiUpdate>,
+        ),
+    ) -> Self {
+        let index = stream.index;
+
+        let container = gtk::Box::new(Orientation::Vertical, 0);
+        container.add_css_class("app-box");
+
+        let title_label =
+            OverflowLabel::new(Label::new(None), config.truncate_popup, &config.marquee);
+        title_label.label().add_css_class("title");
+        container.append(title_label.widget());
+
+        let tx = context.controller_tx.clone();
+        let slider = Scale::builder().sensitive(stream.can_set_volume).build();
+        let max_volume = config.max_volume;
+        slider.set_range(0.0, max_volume);
+        slider.add_css_class("slider");
+        slider.connect_value_changed(move |slider| {
+            if slider.has_css_class("dragging") {
                 // GTK will send values outside min/max range
-                let val = scale.value().clamp(0.0, max_volume);
-                tx.send_spawn(func(item.key(), val));
+                let val = slider.value().clamp(0.0, max_volume);
+                tx.send_spawn(slider_notify_fn(index, val));
             }
         });
-    }
 
-    fn button_notify<F>(btn: &ToggleButton, selector: DropDown, tx: Sender<Update>, func: F)
-    where
-        F: Fn(String, bool) -> Update + 'static,
-    {
-        btn.connect_toggled(move |btn| {
-            if let Some(item) = selector.selected_item().and_downcast_ref::<DropdownItem>() {
-                let muted = btn.is_active();
-                tx.send_spawn(func(item.key(), muted));
-            }
-        });
-    }
-
-    fn simple_slider_notify<F>(&self, scale: &Scale, tx: Sender<Update>, i: u32, func: F)
-    where
-        F: Fn(u32, f64) -> Update + 'static,
-    {
-        let max_volume = self.max_volume;
-        scale.connect_value_changed(move |scale| {
-            if scale.has_css_class("dragging") {
-                // GTK will send values outside min/max range
-                let val = scale.value().clamp(0.0, max_volume);
-                tx.send_spawn(func(i, val));
-            }
-        });
-    }
-
-    fn simple_button_notify<F>(btn: &ToggleButton, tx: Sender<Update>, i: u32, func: F)
-    where
-        F: Fn(u32, bool) -> Update + 'static,
-    {
-        btn.connect_toggled(move |btn| {
+        let tx = context.controller_tx.clone();
+        let btn_mute = ToggleButton::new();
+        btn_mute.add_css_class("btn-mute");
+        btn_mute.connect_toggled(move |btn| {
             let muted = btn.is_active();
-            tx.send_spawn(func(i, muted));
+            tx.send_spawn(button_notify_fn(index, muted));
         });
+
+        container.append(&slider);
+        container.append(&btn_mute);
+
+        let mut manager = config.profiles.attach(&btn_mute, profile_update_fn);
+        let mut ui = Self {
+            container,
+            title_label,
+            slider,
+            btn_mute,
+            label_raw: String::default(),
+            profile_update: Box::new(move |v, d| manager.update(v, d)),
+        };
+        ui.update_stream(stream);
+        ui
     }
+
+    fn update_stream(&mut self, stream: Stream) {
+        if self.label_raw != stream.name {
+            self.title_label.set_label_escaped(&stream.name);
+            self.label_raw = stream.name;
+        }
+
+        if !self.slider.has_css_class("dragging") {
+            self.slider.set_value(stream.volume.percent());
+        }
+
+        self.slider.set_sensitive(stream.can_set_volume);
+        (self.profile_update)(
+            stream.volume.percent(),
+            BtnMuteUiUpdate {
+                muted: stream.muted,
+            },
+        );
+    }
+}
+
+struct SinkInputUi {
+    inner: StreamUi,
+}
+
+impl SinkInputUi {
+    fn new(
+        sink_input: SinkInput,
+        config: &VolumeModule,
+        context: &WidgetContext<Event, Update>,
+    ) -> Self {
+        let inner = StreamUi::new(
+            sink_input.into(),
+            config,
+            context,
+            Update::InputVolume,
+            Update::InputMute,
+            update_sink_mute,
+        );
+        inner.container.add_css_class("input-box");
+        inner.btn_mute.add_css_class("sink-mute");
+        Self { inner }
+    }
+
+    fn update_sink_input(&mut self, sink_input: SinkInput) {
+        self.inner.update_stream(sink_input.into());
+    }
+}
+
+struct SourceOutputUi {
+    inner: StreamUi,
+}
+
+impl SourceOutputUi {
+    fn new(
+        source_output: SourceOutput,
+        config: &VolumeModule,
+        context: &WidgetContext<Event, Update>,
+    ) -> Self {
+        let inner = StreamUi::new(
+            source_output.into(),
+            config,
+            context,
+            Update::OutputVolume,
+            Update::OutputMute,
+            update_source_mute,
+        );
+        inner.container.add_css_class("output-box");
+        inner.btn_mute.add_css_class("source-mute");
+        Self { inner }
+    }
+
+    fn update_source_output(&mut self, source_output: SourceOutput) {
+        self.inner.update_stream(source_output.into());
+    }
+}
+
+fn update_sink_mute(
+    btn_mute: &ToggleButton,
+    event: ProfileUpdateEvent<f64, VolumeProfile, BtnMuteUiUpdate>,
+) {
+    btn_mute.set_active(event.data.muted);
+
+    let icons = &event.profile.icons;
+    btn_mute.set_label(if event.data.muted {
+        &icons.muted
+    } else {
+        &icons.volume
+    });
+}
+
+fn update_source_mute(
+    btn_mute: &ToggleButton,
+    event: ProfileUpdateEvent<f64, VolumeProfile, BtnMuteUiUpdate>,
+) {
+    btn_mute.set_active(event.data.muted);
+
+    let icons = &event.profile.icons;
+    btn_mute.set_label(if event.data.muted {
+        &icons.mic_muted
+    } else {
+        &icons.mic_volume
+    });
 }
 
 impl Module<Button> for VolumeModule {
@@ -467,21 +897,8 @@ impl Module<Button> for VolumeModule {
     {
         let container = gtk::Box::new(self.popup_orientation.into(), 10);
 
-        let sink_container = gtk::Box::new(Orientation::Vertical, 5);
-        sink_container.add_css_class("sink-box");
-
-        let source_container = gtk::Box::new(Orientation::Vertical, 5);
-        source_container.add_css_class("source-box");
-
         let device_container = gtk::Box::new(Orientation::Vertical, 5);
         device_container.add_css_class("device-box");
-
-        if self.show_sinks {
-            device_container.append(&sink_container);
-        }
-        if self.show_sources {
-            device_container.append(&source_container);
-        }
 
         let sink_input_container = gtk::Box::new(Orientation::Vertical, 5);
         sink_input_container.add_css_class("sink-input-box");
@@ -503,145 +920,20 @@ impl Module<Button> for VolumeModule {
         container.append(&device_container);
         container.append(&app_container);
 
-        let no_sink = DropdownItem::new("ironbar_no_sink", "No sink available");
-        let no_source = DropdownItem::new("ironbar_no_source", "No source available");
-
-        let sink_options = gio::ListStore::new::<DropdownItem>();
-        sink_options.append(&no_sink);
-        let source_options = gio::ListStore::new::<DropdownItem>();
-        source_options.append(&no_source);
-        let factory = SignalListItemFactory::new();
-        factory.connect_setup(move |_, list_item| {
-            let label = Label::new(None);
-            list_item
-                .downcast_ref::<ListItem>()
-                .expect("Needs to be ListItem")
-                .set_child(Some(&label));
-        });
-
-        factory.connect_bind(move |_, list_item| {
-            let dropdown_item = list_item
-                .downcast_ref::<ListItem>()
-                .expect("should be ListItem")
-                .item()
-                .and_downcast::<DropdownItem>()
-                .expect("should be `DropdownItem`.");
-
-            let label = list_item
-                .downcast_ref::<ListItem>()
-                .expect("should be ListItem")
-                .child()
-                .and_downcast::<Label>()
-                .expect("should be a `Label`.");
-
-            label.set_label(&dropdown_item.value().clone());
-            if let Some(truncate) = self.truncate_popup {
-                label.truncate(truncate);
-            }
-        });
-
-        let ignore_selected = Rc::new(Cell::new(false));
-
-        let sink_selector = DropDown::new(Some(sink_options.clone()), None::<Expression>);
-        sink_selector.set_factory(Some(&factory));
-        sink_selector.add_css_class("device-selector");
-        sink_selector.add_css_class("sink-selector");
-        {
-            let tx = context.controller_tx.clone();
-            Self::select_notify(&sink_selector, tx, &ignore_selected, Update::SinkChange);
-        }
-        sink_container.append(&sink_selector);
-
-        let source_selector = DropDown::new(Some(source_options.clone()), None::<Expression>);
-        source_selector.set_factory(Some(&factory));
-        source_selector.add_css_class("device-selector");
-        source_selector.add_css_class("source-selector");
-        {
-            let tx = context.controller_tx.clone();
-            Self::select_notify(&source_selector, tx, &ignore_selected, Update::SourceChange);
-        }
-        source_container.append(&source_selector);
-
-        let sink_slider = self.new_slider();
-        sink_slider.add_css_class("slider");
-        sink_slider.add_css_class("sink-slider");
-        sink_container.append(&sink_slider);
-        {
-            let tx = context.controller_tx.clone();
-            let select = sink_selector.clone();
-            let scale = sink_slider.clone();
-            self.slider_notify(&scale, select, tx, Update::SinkVolume);
-        }
-
-        let source_slider = self.new_slider();
-        source_slider.add_css_class("slider");
-        source_slider.add_css_class("source-slider");
-        source_container.append(&source_slider);
-        {
-            let tx = context.controller_tx.clone();
-            let select = source_selector.clone();
-            let scale = source_slider.clone();
-            self.slider_notify(&scale, select, tx, Update::SourceVolume);
-        }
-
-        let sink_mute = ToggleButton::new();
-        sink_mute.add_css_class("btn-mute");
-        sink_mute.add_css_class("sink-mute");
-        sink_container.append(&sink_mute);
-        {
-            let tx = context.controller_tx.clone();
-            let select = sink_selector.clone();
-            Self::button_notify(&sink_mute, select, tx, Update::SinkMute);
-        }
-
-        let source_mute = ToggleButton::new();
-        source_mute.add_css_class("btn-mute");
-        source_mute.add_css_class("source-mute");
-        source_container.append(&source_mute);
-        {
-            let tx = context.controller_tx.clone();
-            let selector = source_selector.clone();
-            Self::button_notify(&source_mute, selector, tx, Update::SourceMute);
-        }
-
-        let mut sink_manager = self.profiles.attach(
-            &sink_mute,
-            move |btn_mute, event: ProfileUpdateEvent<f64, VolumeProfile, BtnMuteUiUpdate>| {
-                let btn = event.data.button.as_ref().unwrap_or(btn_mute);
-                btn.set_active(event.data.muted);
-
-                let icons = &event.profile.icons;
-                btn.set_label(if event.data.muted {
-                    &icons.muted
-                } else {
-                    &icons.volume
-                });
-            },
-        );
-        let mut source_manager = self.profiles.attach(
-            &source_mute,
-            move |btn_mute, event: ProfileUpdateEvent<f64, VolumeProfile, BtnMuteUiUpdate>| {
-                let btn = event.data.button.as_ref().unwrap_or(btn_mute);
-                btn.set_active(event.data.muted);
-
-                let icons = &event.profile.icons;
-                btn.set_label(if event.data.muted {
-                    &icons.mic_muted
-                } else {
-                    &icons.mic_volume
-                });
-            },
-        );
-
         let mut inputs = HashMap::new();
         let mut outputs = HashMap::new();
-        let mut sinks = vec![];
-        let mut sources = vec![];
 
-        let show_monitors = self.show_monitors;
+        let ignore_selected = Rc::new(Cell::new(false));
+        let mut sink_ui = SinkUi::new(&self, &context, &ignore_selected);
+        let mut source_ui = SourceUi::new(&self, &context, &ignore_selected);
 
-        let mut default_sink = None;
-        let mut default_source = None;
+        if self.show_sinks {
+            device_container.append(&sink_ui.inner.container);
+        }
+
+        if self.show_sources {
+            device_container.append(&source_ui.inner.container);
+        }
 
         context
             .subscribe()
@@ -649,243 +941,44 @@ impl Module<Button> for VolumeModule {
                 // Ignore selected sink and source notifications caused by programmatic changes
                 let _ignore_guard = IgnoreGuard::new(&ignore_selected);
                 match event {
-                    Event::SetDefaultSink(name) => default_sink = Some(name),
-                    Event::SetDefaultSource(name) => default_source = Some(name),
-                    Event::AddSink(info) => {
-                        sink_options.append(&DropdownItem::new(&info.name, &info.description));
-
-                        if default_sink
-                            .as_deref()
-                            .is_some_and(|name| name == info.name)
-                        {
-                            let offset = sink_options.find(&no_sink).is_some() as usize;
-                            sink_selector.set_selected((sinks.len() + offset) as u32);
-                            sink_slider.set_value(info.volume.percent());
-
-                            sink_manager
-                                .update(info.volume.percent(), BtnMuteUiUpdate::muted(info.muted));
-                        }
-
-                        sinks.push(info);
-                    }
-                    Event::AddSource(info) => {
-                        if !show_monitors && info.monitor {
-                            return;
-                        }
-
-                        source_options.append(&DropdownItem::new(&info.name, &info.description));
-
-                        if default_source
-                            .as_deref()
-                            .is_some_and(|name| name == info.name)
-                        {
-                            let offset = source_options.find(&no_source).is_some() as usize;
-                            source_selector.set_selected((sources.len() + offset) as u32);
-                            source_slider.set_value(info.volume.percent());
-
-                            source_manager
-                                .update(info.volume.percent(), BtnMuteUiUpdate::muted(info.muted));
-                        }
-
-                        sources.push(info);
-                    }
-                    Event::UpdateSink(info) => {
-                        if default_sink
-                            .as_deref()
-                            .is_some_and(|name| name == info.name)
-                            && let Some(pos) =
-                                sink_options.iter::<DropdownItem>().position(|s| match s {
-                                    Ok(s) => s.key() == info.name,
-                                    Err(_) => false,
-                                })
-                        {
-                            sink_selector.set_selected(pos as u32);
-                            if !sink_slider.has_css_class("dragging") {
-                                sink_slider.set_value(info.volume.percent());
-                            }
-
-                            if let Some(pos) = sink_options.find(&no_sink) {
-                                sink_options.remove(pos);
-                            }
-
-                            sink_manager
-                                .update(info.volume.percent(), BtnMuteUiUpdate::muted(info.muted));
-                        }
-                    }
-                    Event::UpdateSource(info) => {
-                        if default_source
-                            .as_deref()
-                            .is_some_and(|name| name == info.name)
-                            && let Some(pos) =
-                                source_options.iter::<DropdownItem>().position(|s| match s {
-                                    Ok(s) => s.key() == info.name,
-                                    Err(_) => false,
-                                })
-                            && (!info.monitor || show_monitors)
-                        {
-                            source_selector.set_selected(pos as u32);
-                            if !source_slider.has_css_class("dragging") {
-                                source_slider.set_value(info.volume.percent());
-                            }
-
-                            if let Some(pos) = source_options.find(&no_source) {
-                                source_options.remove(pos);
-                            }
-
-                            source_manager
-                                .update(info.volume.percent(), BtnMuteUiUpdate::muted(info.muted));
-                        }
-                    }
-                    Event::RemoveSink(name) => {
-                        if let Some(pos) = sinks.iter().position(|s| s.name == name) {
-                            sink_options.remove(pos as u32);
-                            sinks.remove(pos);
-
-                            if sinks.is_empty() {
-                                sink_options.append(&no_sink);
-                            }
-                        }
-                    }
-                    Event::RemoveSource(name) => {
-                        if let Some(pos) = sources.iter().position(|s| s.name == name) {
-                            source_options.remove(pos as u32);
-                            sources.remove(pos);
-
-                            if sources.is_empty() {
-                                source_options.append(&no_source);
-                            }
-                        }
-                    }
+                    Event::SetDefaultSink(name) => sink_ui.inner.set_default_device_name(name),
+                    Event::SetDefaultSource(name) => source_ui.inner.set_default_device_name(name),
+                    Event::AddSink(info) => sink_ui.add_sink(info),
+                    Event::AddSource(info) => source_ui.add_source(info),
+                    Event::UpdateSink(info) => sink_ui.update_sink(info),
+                    Event::UpdateSource(info) => source_ui.update_source(info),
+                    Event::RemoveSink(name) => sink_ui.inner.remove_device(&name),
+                    Event::RemoveSource(name) => source_ui.inner.remove_device(&name),
                     Event::AddInput(info) => {
                         let index = info.index;
-
-                        let item_container = gtk::Box::new(Orientation::Vertical, 0);
-                        item_container.add_css_class("app-box");
-                        item_container.add_css_class("input-box");
-
-                        let title_label = self.overflow_label(&info.name, "title");
-                        item_container.append(title_label.widget());
-
-                        let tx = context.controller_tx.clone();
-                        let slider = Scale::builder().sensitive(info.can_set_volume).build();
-                        slider.set_range(0.0, self.max_volume);
-                        slider.set_value(info.volume.percent());
-                        slider.add_css_class("slider");
-                        self.simple_slider_notify(&slider, tx, index, Update::InputVolume);
-
-                        let tx = context.controller_tx.clone();
-                        let btn_mute = ToggleButton::new();
-                        btn_mute.add_css_class("btn-mute");
-                        btn_mute.add_css_class("sink-mute");
-                        Self::simple_button_notify(&btn_mute, tx, index, Update::InputMute);
-
-                        item_container.append(&slider);
-                        item_container.append(&btn_mute);
-                        input_container.append(&item_container);
-
-                        sink_manager.update(
-                            info.volume.percent(),
-                            BtnMuteUiUpdate::muted_with(info.muted, btn_mute.clone()),
-                        );
-
-                        inputs.insert(
-                            info.index,
-                            VolumeUi {
-                                container: item_container,
-                                button: btn_mute,
-                                title_label,
-                                slider,
-                                label_raw: info.name.clone(),
-                            },
-                        );
+                        let input_ui = SinkInputUi::new(info, &self, &context);
+                        input_container.append(&input_ui.inner.container);
+                        inputs.insert(index, input_ui);
                     }
                     Event::AddOutput(info) => {
                         let index = info.index;
-
-                        let item_container = gtk::Box::new(Orientation::Vertical, 0);
-                        item_container.add_css_class("app-box");
-                        item_container.add_css_class("output-box");
-
-                        let title_label = self.overflow_label(&info.name, "title");
-                        item_container.append(title_label.widget());
-
-                        let tx = context.controller_tx.clone();
-                        let slider = Scale::builder().sensitive(info.can_set_volume).build();
-                        slider.set_range(0.0, self.max_volume);
-                        slider.set_value(info.volume.percent());
-                        slider.add_css_class("slider");
-                        self.simple_slider_notify(&slider, tx, index, Update::OutputVolume);
-
-                        let tx = context.controller_tx.clone();
-                        let btn_mute = ToggleButton::new();
-                        btn_mute.add_css_class("btn-mute");
-                        btn_mute.add_css_class("source-mute");
-                        Self::simple_button_notify(&btn_mute, tx, index, Update::OutputMute);
-
-                        item_container.append(&slider);
-                        item_container.append(&btn_mute);
-                        source_output_container.append(&item_container);
-
-                        source_manager.update(
-                            info.volume.percent(),
-                            BtnMuteUiUpdate::muted_with(info.muted, btn_mute.clone()),
-                        );
-
-                        outputs.insert(
-                            info.index,
-                            VolumeUi {
-                                container: item_container,
-                                button: btn_mute,
-                                title_label,
-                                slider,
-                                label_raw: info.name.clone(),
-                            },
-                        );
+                        let output_ui = SourceOutputUi::new(info, &self, &context);
+                        source_output_container.append(&output_ui.inner.container);
+                        outputs.insert(index, output_ui);
                     }
                     Event::UpdateInput(info) => {
                         if let Some(ui) = inputs.get_mut(&info.index) {
-                            if ui.label_raw != info.name {
-                                ui.title_label.set_label_escaped(&info.name);
-                                ui.label_raw.clone_from(&info.name);
-                            }
-
-                            if !ui.slider.has_css_class("dragging") {
-                                ui.slider.set_value(info.volume.percent());
-                            }
-
-                            ui.slider.set_sensitive(info.can_set_volume);
-                            sink_manager.update(
-                                info.volume.percent(),
-                                BtnMuteUiUpdate::muted_with(info.muted, ui.button.clone()),
-                            );
+                            ui.update_sink_input(info);
                         }
                     }
                     Event::UpdateOutput(info) => {
                         if let Some(ui) = outputs.get_mut(&info.index) {
-                            if ui.label_raw != info.name {
-                                ui.title_label.set_label_escaped(&info.name);
-                                ui.label_raw.clone_from(&info.name);
-                            }
-
-                            if !ui.slider.has_css_class("dragging") {
-                                ui.slider.set_value(info.volume.percent());
-                            }
-
-                            ui.slider.set_sensitive(info.can_set_volume);
-                            source_manager.update(
-                                info.volume.percent(),
-                                BtnMuteUiUpdate::muted_with(info.muted, ui.button.clone()),
-                            );
+                            ui.update_source_output(info);
                         }
                     }
                     Event::RemoveInput(index) => {
                         if let Some(ui) = inputs.remove(&index) {
-                            input_container.remove(&ui.container);
+                            input_container.remove(&ui.inner.container);
                         }
                     }
                     Event::RemoveOutput(index) => {
                         if let Some(ui) = outputs.remove(&index) {
-                            source_output_container.remove(&ui.container);
+                            source_output_container.remove(&ui.inner.container);
                         }
                     }
                 };
@@ -893,15 +986,6 @@ impl Module<Button> for VolumeModule {
 
         Some(container)
     }
-}
-
-struct VolumeUi {
-    container: gtk::Box,
-    title_label: OverflowLabel,
-    slider: Scale,
-    button: ToggleButton,
-    // Store original (unformatted) title to detect change when marquee is enabled
-    label_raw: String,
 }
 
 struct IgnoreGuard<'a> {


### PR DESCRIPTION
I have found some issues with the volume popup, like the mute button and volume slider appearing when there is no sink or source, the source selector not going back to "No source available" after removing my mic, and the same profiles manager being shared between devices and streams.

After fixing these problems, there was a lot of duplicate code, so I refactored the shared logic into new `DeviceUi` and `StreamUi` structs, and moved the type-specific code into `SinkUi`, `SourceUi`, `SinkInputUi`, and `SourceOutputUi`.

I have tried to keep the existing logic, so aside from these fixes, the behavior should be the same as before.