### PR TITLE
feat(inhibit): toggle css classes .on/.off depending on state

### DIFF
--- a/docs/modules/Inhibit.md
+++ b/docs/modules/Inhibit.md
@@ -109,8 +109,10 @@ end:
 
 ## Styling
 
-| Selector   | Description           |
-| ---------- | --------------------- |
-| `.inhibit` | Inhibit widget button |
+| Selector       | Description                                  |
+| -------------- | -------------------------------------------- |
+| `.inhibit`     | Inhibit widget button                        |
+| `.inhibit.off` | Inhibit widget button when inhibition is off |
+| `.inhibit.on`  | Inhibit widget button when inhibition is on  |
 
 For more information on styling, please see the [styling guide](styling-guide).

--- a/src/modules/inhibit/mod.rs
+++ b/src/modules/inhibit/mod.rs
@@ -119,6 +119,7 @@ impl Module<Button> for InhibitModule {
         let (fmt_on, fmt_off) = (self.format_on, self.format_off);
         let controller_tx = ctx.controller_tx.clone();
 
+        let btn = button.clone();
         // gtk based inhibit() requires glib context / main thread
         ctx.subscribe().recv_glib(&label, move |label, state| {
             if state.active != was_active.replace(state.active) {
@@ -136,6 +137,14 @@ impl Module<Button> for InhibitModule {
 
             let fmt = if state.active { &fmt_on } else { &fmt_off };
             label.set_label_escaped(&fmt.replace("{duration}", &format_duration(state.duration)));
+
+            if state.active {
+                btn.add_css_class("on");
+                btn.remove_css_class("off");
+            } else {
+                btn.remove_css_class("on");
+                btn.add_css_class("off");
+            };
         });
         Ok(ModuleParts::new(button, None))
     }


### PR DESCRIPTION
Tiny change to get CSS classes depending on the inhibitor's state. I opted for `.on/.off` to match the configuration fields `format_*`.

Fixes #1515