### PR TITLE
fix[style]: Use dark backgrounds for more UI

### DIFF
--- a/examples/minimal/style.css
+++ b/examples/minimal/style.css
@@ -44,7 +44,7 @@ switch:not(:checked) {
   background-color: var(--color-dark-secondary);
 }
 
-#bar, popover, popover contents, calendar {
+#bar, popover, popover contents, calendar, popover .view {
     background-color: var(--color-dark-primary);
 }
 
@@ -58,7 +58,7 @@ button {
     padding-right: var(--margin-sm);
 }
 
-button:hover, button:active {
+button:hover, button:active, *:selected {
     background-color: var(--color-dark-secondary);
 }
 


### PR DESCRIPTION
This fixes a couple of places, where the UI was falling back to the default GTK styles, which was unreadable with a light gtk theme combined with the dark colors of the "minimal" style.

In particular:

-  Use primary background for "popover .view" so that the background of dropdown menus (for example the device dropdown in the volume module)  uses a dark background, and the light colord text is visible.
- Use secondary dark color for "*:selected"  so that the "selected" item in the dropdown uses a dark background, and is more readable. Also impacts action items in tray drop downs.