### PR TITLE
fix(networkmanager): set icon visible after device update

### DIFF
--- a/src/modules/networkmanager.rs
+++ b/src/modules/networkmanager.rs
@@ -154,6 +154,7 @@ impl Module<GtkBox> for NetworkManagerModule {
             }
 
             icon.set_label(Some(&icon_name));
+            icon.set_visible(true);
         });
 
         let container_clone = container.clone();


### PR DESCRIPTION
The NetworkManager module can reuse icons for different devices. For instance, if an update removes a device and adds another, the icon of the old device will be reused for the new one. But the current implementation doesn't make the icon visible after the update, so the icon will always remain hidden if the old device was blacklisted.

I've added a call to `icon.set_visible(true)` at the end of the profile update to ensure that the icon is shown when the device is allowed.