### PR TITLE
refactor(inhibit): migrate inhibit logic to client

### DIFF
--- a/src/channels.rs
+++ b/src/channels.rs
@@ -34,6 +34,13 @@ impl<T: Debug> SyncSenderExt<T> for broadcast::Sender<T> {
     }
 }
 
+impl<T: Debug> SyncSenderExt<T> for mpsc::UnboundedSender<T> {
+    #[inline]
+    fn send_expect(&self, message: T) {
+        self.send(message).expect(crate::error::ERR_CHANNEL_SEND);
+    }
+}
+
 pub trait AsyncSenderExt<T>: Sync + Send + Sized + Clone {
     /// Asynchronously sends a message on the channel,
     /// panicking if it cannot be sent.

--- a/src/clients/inhibit.rs
+++ b/src/clients/inhibit.rs
@@ -1,7 +1,10 @@
-use crate::{lock, register_client};
+use crate::channels::SyncSenderExt;
+use crate::register_client;
 use gtk::ApplicationInhibitFlags;
+use gtk::glib;
 use gtk::prelude::*;
-use std::sync::{Arc, Mutex, Weak};
+use std::time::Duration;
+use tokio::sync::{mpsc, watch};
 use tracing::{error, trace};
 
 fn get_app() -> gtk::Application {
@@ -10,58 +13,119 @@ fn get_app() -> gtk::Application {
         .expect("GTK application not initialized")
 }
 
-/// Cookie holder that uninhibits on drop
-pub struct InhibitCookie(pub u32);
+/// Uninhibits on drop.
+struct InhibitCookie(u32);
 
 impl Drop for InhibitCookie {
     fn drop(&mut self) {
+        trace!("dropped inhibit cookie: {}", self.0);
         get_app().uninhibit(self.0);
     }
 }
 
-/// Client for managing GTK application inhibit state.
-///
-/// Uses Weak reference to delegate ownership to modules - when all modules
-/// drop their `InhibitCookie`, the system uninhibit is called automatically.
-#[derive(Debug)]
-pub struct Client {
-    cookie: Mutex<Option<Weak<InhibitCookie>>>,
+fn gtk_inhibit() -> Option<InhibitCookie> {
+    let id = get_app().inhibit(
+        None::<&gtk::Window>,
+        ApplicationInhibitFlags::IDLE,
+        Some("Ironbar inhibit"),
+    );
+    if id == 0 {
+        error!("GTK inhibit failed - platform may not support it");
+        None
+    } else {
+        trace!("created inhibit cookie: {id}");
+        Some(InhibitCookie(id))
+    }
 }
 
-impl Client {
-    pub(crate) fn new() -> Self {
-        trace!("Initializing inhibit client");
-        Self {
-            cookie: Mutex::new(None),
+/// The held GTK cookie and its remaining duration: both exist, or neither.
+#[derive(Default)]
+struct Inhibitor {
+    current: Option<(InhibitCookie, Duration)>,
+}
+
+impl Inhibitor {
+    fn remaining(&self) -> Option<Duration> {
+        self.current.as_ref().map(|(_, duration)| *duration)
+    }
+
+    fn is_counting_down(&self) -> bool {
+        self.remaining()
+            .is_some_and(|duration| duration != Duration::MAX)
+    }
+
+    /// `Some` starts the inhibit or updates its duration; `None` stops it.
+    fn set_remaining(&mut self, target: Option<Duration>) {
+        match target {
+            None => self.current = None,
+            Some(duration) => {
+                if let Some((_, existing)) = &mut self.current {
+                    *existing = duration;
+                } else {
+                    self.current = gtk_inhibit().map(|cookie| (cookie, duration));
+                }
+            }
         }
     }
 
-    /// Acquires an inhibit cookie.
-    ///
-    /// Uses global inhibition (no window-specific behavior).
-    /// Reuses existing cookie when multiple modules request inhibit.
-    /// Returns None if platform doesn't support inhibit.
-    pub fn acquire(&self) -> Option<Arc<InhibitCookie>> {
-        let mut cookie_opt = lock!(self.cookie);
+    /// Decrements the countdown, dropping the cookie at zero.
+    fn tick(&mut self) {
+        if let Some((_, duration)) = &mut self.current {
+            *duration = duration.saturating_sub(Duration::from_secs(1));
+        }
+        if self.remaining() == Some(Duration::ZERO) {
+            self.current = None;
+        }
+    }
+}
 
-        // Upgrade weak cookie ref if it exists else create a new one
-        cookie_opt.as_ref().and_then(Weak::upgrade).or_else(|| {
-            let cookie = get_app().inhibit(
-                None::<&gtk::Window>,
-                ApplicationInhibitFlags::IDLE,
-                Some("Ironbar inhibit"),
-            );
+/// Process-global inhibit: owns the GTK cookie and the live countdown in a single
+/// `glib` task. Each widget updates its label to the same remaining duration.
+/// When the timer stops, each widget reverts to its currently-selected preset (`durations[idx]`).
+#[derive(Debug)]
+pub struct Client {
+    req_tx: mpsc::UnboundedSender<Option<Duration>>,
+    remaining_tx: watch::Sender<Option<Duration>>,
+}
 
-            if cookie == 0 {
-                error!("GTK inhibit failed - platform may not support it");
-                return None;
+impl Client {
+    /// Must be called on the GTK main thread - spawns the cookie/countdown task.
+    pub(crate) fn new() -> Self {
+        let (req_tx, mut rx) = mpsc::unbounded_channel::<Option<Duration>>();
+        let (remaining_tx, _) = watch::channel(None::<Duration>);
+
+        glib::spawn_future_local({
+            let remaining_tx = remaining_tx.clone();
+            async move {
+                let mut inhibitor = Inhibitor::default();
+
+                loop {
+                    tokio::select! {
+                        Some(request) = rx.recv() => inhibitor.set_remaining(request),
+                        // Timer armed only while a finite countdown runs.
+                        () = glib::timeout_future_seconds(1),
+                            if inhibitor.is_counting_down() => inhibitor.tick(),
+                    }
+
+                    remaining_tx.send_replace(inhibitor.remaining());
+                }
             }
+        });
 
-            trace!("Created inhibit cookie: {}", cookie);
-            let rc = Arc::new(InhibitCookie(cookie));
-            *cookie_opt = Some(Arc::downgrade(&rc));
-            Some(rc)
-        })
+        Self {
+            req_tx,
+            remaining_tx,
+        }
+    }
+
+    pub fn subscribe(&self) -> watch::Receiver<Option<Duration>> {
+        self.remaining_tx.subscribe()
+    }
+
+    /// Set the inhibit duration: `Some` starts it (or updates the duration if
+    /// already inhibiting), `None` stops it. `Duration::MAX` = infinite.
+    pub fn set_duration(&self, duration: Option<Duration>) {
+        self.req_tx.send_expect(duration);
     }
 }
 

--- a/src/modules/inhibit/mod.rs
+++ b/src/modules/inhibit/mod.rs
@@ -1,10 +1,8 @@
 use color_eyre::Result;
 use gtk::prelude::*;
 use gtk::{Button, Label};
-use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::mpsc::Receiver;
-use tracing::{debug, trace};
 
 use crate::channels::{AsyncSenderExt, BroadcastReceiverExt};
 use crate::clients::inhibit;
@@ -17,15 +15,11 @@ mod config;
 use config::InhibitCommand;
 pub use config::InhibitModule;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub struct State {
-    active: bool,
-    duration: Duration,
-}
+const INFINITE_DURATION_LABEL: &str = "";
 
 fn format_duration(d: Duration) -> String {
     if d == Duration::MAX {
-        return "".to_string();
+        return INFINITE_DURATION_LABEL.to_string();
     }
     let s = d.as_secs();
     let (h, m, s) = (s / 3600, s % 3600 / 60, s % 60);
@@ -33,6 +27,13 @@ fn format_duration(d: Duration) -> String {
         (h, m) if h > 0 => format!("{h:02}:{m:02}:{s:02}"),
         (_, m) => format!("{m:02}:{s:02}"),
     }
+}
+
+/// What a bar renders: the shared countdown when active, else this bar's preset.
+#[derive(Debug, Clone, Copy)]
+pub struct State {
+    active: bool,
+    duration: Duration,
 }
 
 impl Module<Button> for InhibitModule {
@@ -47,41 +48,42 @@ impl Module<Button> for InhibitModule {
         ctx: &WidgetContext<Self::SendMessage, Self::ReceiveMessage>,
         mut rx: Receiver<Self::ReceiveMessage>,
     ) -> Result<()> {
+        let client = ctx.client::<inhibit::Client>();
+        let mut remaining_rx = client.subscribe();
         let tx = ctx.tx.clone();
         let durations = self.duration_spec.durations.clone();
         let default = self.duration_spec.default_duration;
 
         spawn(async move {
-            debug!("Inhibit controller started");
             let mut idx = durations.iter().position(|d| *d == default).unwrap_or(0);
-            let mut state = State {
-                active: false,
-                duration: durations[idx],
-            };
-            tx.send_update(state).await;
 
             loop {
+                let remaining = *remaining_rx.borrow();
+                let state = State {
+                    active: remaining.is_some(),
+                    duration: remaining.unwrap_or(durations[idx]),
+                };
+                tx.send_update(state).await;
+
                 tokio::select! {
-                    Some(cmd) = rx.recv() => {
+                    changed = remaining_rx.changed() => if changed.is_err() { break },
+                    cmd = rx.recv() => {
+                        let Some(cmd) = cmd else { break }; // widget gone
                         match cmd {
-                            InhibitCommand::Cycle => idx = (idx + 1) % durations.len(),
-                            InhibitCommand::Toggle => state.active = !state.active,
+                            InhibitCommand::Toggle if remaining.is_some() => client.set_duration(None),
+                            InhibitCommand::Toggle => client.set_duration(Some(durations[idx])),
+                            InhibitCommand::Cycle => {
+                                idx = (idx + 1) % durations.len();
+                                if remaining.is_some() {
+                                    client.set_duration(Some(durations[idx]));
+                                }
+                            }
                         }
-                        state.duration = durations[idx];
-                        trace!("Inhibit state update: active={}, duration={}", state.active, format_duration(state.duration));
-                        tx.send_update(state).await;
-                    }
-                    () = tokio::time::sleep(Duration::from_secs(1)), if state.active && state.duration != Duration::MAX => {
-                        state.duration = state.duration.saturating_sub(Duration::from_secs(1));
-                        if state.duration == Duration::ZERO {
-                            state.active = false;
-                            state.duration = durations[idx];
-                        }
-                        tx.send_update(state).await;
                     }
                 }
             }
         });
+
         Ok(())
     }
 
@@ -97,8 +99,8 @@ impl Module<Button> for InhibitModule {
             .justify(self.layout.justify.into())
             .build();
         button.set_child(Some(&label));
-        let tx = ctx.controller_tx.clone();
 
+        let tx = ctx.controller_tx.clone();
         [
             (MouseButton::Primary, self.on_click_left),
             (MouseButton::Secondary, self.on_click_right),
@@ -106,37 +108,17 @@ impl Module<Button> for InhibitModule {
         ]
         .into_iter()
         .filter_map(|(btn, cmd)| cmd.map(|c| (btn, c)))
-        .for_each(|(btn, action)| {
+        .for_each(|(btn, cmd)| {
             let tx = tx.clone();
-            button.connect_pressed(btn, move || {
-                tx.send_spawn(action);
-            });
+            button.connect_pressed(btn, move || tx.send_spawn(cmd));
         });
 
-        let client = ctx.client::<inhibit::Client>();
-        let inhibit_handle = std::cell::RefCell::new(None::<Arc<inhibit::InhibitCookie>>);
-        let was_active = std::cell::Cell::new(false);
         let (fmt_on, fmt_off) = (self.format_on, self.format_off);
-        let controller_tx = ctx.controller_tx.clone();
-
-        // gtk based inhibit() requires glib context / main thread
         ctx.subscribe().recv_glib(&label, move |label, state| {
-            if state.active != was_active.replace(state.active) {
-                if state.active {
-                    if let Some(cookie) = client.acquire() {
-                        *inhibit_handle.borrow_mut() = Some(cookie)
-                    } else {
-                        controller_tx.send_spawn(InhibitCommand::Toggle);
-                        return;
-                    }
-                } else {
-                    *inhibit_handle.borrow_mut() = None;
-                }
-            }
-
             let fmt = if state.active { &fmt_on } else { &fmt_off };
             label.set_label_escaped(&fmt.replace("{duration}", &format_duration(state.duration)));
         });
+
         Ok(ModuleParts::new(button, None))
     }
 }


### PR DESCRIPTION
Mirror the volume/bluetooth stateful-client pattern so inhibit state and the GTK cookie survive `ironbar reload` / monitor hotplug.

Also makes inhibit state global across bars (Closes #1518).

One alternative I considered is skipping tokio entirely (currently its gtk -> tokio -> tokio (from client) -> gtk inhibit) but this is more decoupled and more in line with rest of codebase.