### PR TITLE
fix(autohide): configurable hotspot size and reveal on motion event

### DIFF
--- a/src/bar.rs
+++ b/src/bar.rs
@@ -141,6 +141,7 @@ impl Bar {
         );
 
         let autohide = config.autohide;
+        let autohide_hotspot_height = config.autohide_hotspot_height;
         let anchor_to_edges = config.anchor_to_edges;
         let margin = config.margin;
 
@@ -149,7 +150,12 @@ impl Bar {
 
         let autohide_state = if let Some(autohide) = autohide {
             let hotspot_window = Window::new();
-            self.setup_autohide(&hotspot_window, load_result.popup.clone(), autohide);
+            self.setup_autohide(
+                &hotspot_window,
+                load_result.popup.clone(),
+                autohide,
+                autohide_hotspot_height,
+            );
             self.setup_layer_shell(
                 &hotspot_window,
                 false,
@@ -240,15 +246,21 @@ impl Bar {
         );
     }
 
-    fn setup_autohide(&self, hotspot_window: &Window, popup: Rc<Popup>, timeout: u64) {
+    fn setup_autohide(
+        &self,
+        hotspot_window: &Window,
+        popup: Rc<Popup>,
+        timeout: u64,
+        hotspot_height: i32,
+    ) {
         hotspot_window.set_visible(false);
 
         hotspot_window.set_opacity(0.01);
         hotspot_window.set_decorated(false);
 
         let (w, h) = match self.position {
-            BarPosition::Top | BarPosition::Bottom => (0, 5),
-            BarPosition::Left | BarPosition::Right => (5, 0),
+            BarPosition::Top | BarPosition::Bottom => (0, hotspot_height),
+            BarPosition::Left | BarPosition::Right => (hotspot_height, 0),
         };
         hotspot_window.set_default_size(w, h);
 
@@ -349,6 +361,14 @@ impl Bar {
 
             let hotspot_win = hotspot_window.clone();
             event_controller.connect_enter(move |_, _, _| {
+                hotspot_win.set_visible(false);
+                win.set_visible(true);
+            });
+
+            let hotspot_win = hotspot_window.clone();
+            let win = self.window.clone();
+
+            event_controller.connect_motion(move |_, _, _| {
                 hotspot_win.set_visible(false);
                 win.set_visible(true);
             });

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -409,6 +409,11 @@ pub struct BarConfig {
     /// **Default**: `null`
     pub autohide: Option<u64>,
 
+    /// The height in pixels of the hotspot that reveals the bar
+    ///
+    /// **Default**: `5`
+    pub autohide_hotspot_height: i32,
+
     /// An array of modules to append to the start of the bar.
     /// Depending on the orientation, this is either the top of the left edge.
     ///
@@ -438,6 +443,7 @@ impl Default for BarConfig {
             height: 42,
             start_hidden: None,
             autohide: None,
+            autohide_hotspot_height: 5,
             start: None,
             center: None,
             end: None,


### PR DESCRIPTION
Fixes #1497

It seems to be related to relying only on GTK's `enter` event. The hotspot becomes visible before the cursor is moved away from the hotspot so the `enter` event is never triggered.

This change adds a listener to the motion inside the hotspot window which reliably reveals the bar.
```rust
let hotspot_win = hotspot_window.clone();
let win = self.window.clone();

event_controller.connect_motion(move |_, _, _| {
    hotspot_win.set_visible(false);
    win.set_visible(true);
});
```

The original `enter` event listener can probably be removed as it does not trigger with the `motion` listener in place, at least from my testing.

I also made the height of the hotspot configurable with `autohide_hotspot_height`  because I found it too small for my bar's height and it sounds like it's something that should be configurable :sweat_smile: 5px is the default as it was originally. This is not required for the fix.