### PR TITLE
🐛 fix(hyprland): switch workspaces on Lua config providers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,7 +117,7 @@ volume = ["libpulse-binding"]
 workspaces = ["futures-lite"]
 "workspaces+all" = ["workspaces", "workspaces+sway", "workspaces+hyprland", "workspaces+niri"]
 "workspaces+sway" = ["workspaces", "sway"]
-"workspaces+hyprland" = ["workspaces", "hyprland"]
+"workspaces+hyprland" = ["workspaces", "hyprland", "dep:serde_json"]
 "workspaces+niri" = ["workspaces", "niri"]
 
 sway = ["swayipc-async", "futures-lite"]

--- a/src/clients/compositor/hyprland.rs
+++ b/src/clients/compositor/hyprland.rs
@@ -35,6 +35,9 @@ pub struct Client {
     #[cfg(feature = "workspaces+hyprland")]
     workspace: TxRx<WorkspaceUpdate>,
 
+    #[cfg(feature = "workspaces+hyprland")]
+    use_lua_dispatch: bool,
+
     #[cfg(feature = "keyboard+hyprland")]
     keyboard_layout: TxRx<KeyboardLayoutUpdate>,
 
@@ -47,6 +50,8 @@ impl Client {
         let instance = Self {
             #[cfg(feature = "workspaces+hyprland")]
             workspace: TxRx::new(),
+            #[cfg(feature = "workspaces+hyprland")]
+            use_lua_dispatch: detect_lua_config(),
             #[cfg(feature = "keyboard+hyprland")]
             keyboard_layout: TxRx::new(),
             #[cfg(feature = "bindmode+hyprland")]
@@ -406,9 +411,15 @@ impl Client {
 #[cfg(feature = "workspaces+hyprland")]
 impl super::WorkspaceClient for Client {
     fn focus(&self, id: i64) {
-        let identifier = WorkspaceIdentifierWithSpecial::Id(id as i32);
+        let res = if self.use_lua_dispatch {
+            let arg = format!("{{workspace=\"{id}\"}}");
+            Dispatch::call(DispatchType::Custom("hl.dsp.focus", &arg))
+        } else {
+            let identifier = WorkspaceIdentifierWithSpecial::Id(id as i32);
+            Dispatch::call(DispatchType::Workspace(identifier))
+        };
 
-        if let Err(e) = Dispatch::call(DispatchType::Workspace(identifier)) {
+        if let Err(e) = res {
             error!("Couldn't focus workspace '{id}': {e:#}");
         }
     }
@@ -494,6 +505,23 @@ impl KeyboardLayoutClient for Client {
 impl BindModeClient for Client {
     fn subscribe(&self) -> super::Result<Receiver<BindModeUpdate>> {
         Ok(self.bindmode.tx.subscribe())
+    }
+}
+
+#[cfg(feature = "workspaces+hyprland")]
+fn detect_lua_config() -> bool {
+    match std::process::Command::new("hyprctl")
+        .arg("systeminfo")
+        .output()
+    {
+        Ok(output) => String::from_utf8_lossy(&output.stdout).lines().any(|line| {
+            let line = line.trim();
+            line.starts_with("configProvider:") && line.contains("lua")
+        }),
+        Err(err) => {
+            warn!("Failed to detect Hyprland config provider, assuming legacy: {err}");
+            false
+        }
     }
 }
 

--- a/src/clients/compositor/hyprland.rs
+++ b/src/clients/compositor/hyprland.rs
@@ -12,6 +12,12 @@ use hyprland::dispatch::{Dispatch, DispatchType, WorkspaceIdentifierWithSpecial}
 use hyprland::event_listener::EventListener;
 use hyprland::prelude::*;
 use hyprland::shared::{HyprDataVec, WorkspaceType};
+#[cfg(feature = "workspaces+hyprland")]
+use serde::Deserialize;
+#[cfg(feature = "workspaces+hyprland")]
+use std::io::{Read, Write};
+#[cfg(feature = "workspaces+hyprland")]
+use std::os::unix::net::UnixStream;
 use tokio::sync::broadcast::{Receiver, Sender, channel};
 use tracing::{debug, error, info, warn};
 
@@ -510,19 +516,36 @@ impl BindModeClient for Client {
 
 #[cfg(feature = "workspaces+hyprland")]
 fn detect_lua_config() -> bool {
-    match std::process::Command::new("hyprctl")
-        .arg("systeminfo")
-        .output()
-    {
-        Ok(output) => String::from_utf8_lossy(&output.stdout).lines().any(|line| {
-            let line = line.trim();
-            line.starts_with("configProvider:") && line.contains("lua")
-        }),
+    match get_hyprland_config_provider() {
+        Ok(provider) => provider == "lua",
         Err(err) => {
             warn!("Failed to detect Hyprland config provider, assuming legacy: {err}");
             false
         }
     }
+}
+
+#[cfg(feature = "workspaces+hyprland")]
+#[derive(Deserialize)]
+struct HyprlandStatus {
+    #[serde(rename = "configProvider")]
+    config_provider: String,
+}
+
+#[cfg(feature = "workspaces+hyprland")]
+fn get_hyprland_config_provider() -> std::result::Result<String, Box<dyn std::error::Error>> {
+    let runtime_dir = std::env::var("XDG_RUNTIME_DIR")
+        .or_else(|_| std::env::var("UID").map(|uid| format!("/run/user/{uid}")))?;
+    let instance = std::env::var("HYPRLAND_INSTANCE_SIGNATURE")?;
+    let socket_path = format!("{runtime_dir}/hypr/{instance}/.socket.sock");
+
+    let mut stream = UnixStream::connect(socket_path)?;
+    stream.write_all(b"j/status")?;
+
+    let mut response = String::new();
+    stream.read_to_string(&mut response)?;
+
+    Ok(serde_json::from_str::<HyprlandStatus>(&response)?.config_provider)
 }
 
 fn get_workspace_name(name: WorkspaceType) -> String {


### PR DESCRIPTION
Clicking a workspace button did nothing on Hyprland 0.55+ when running with a Lua config provider.

`hyprland-rs` serializes the focus dispatch to the socket as the legacy `dispatch workspace <id>`. Under a Lua config provider, Hyprland evaluates every dispatch payload as a Lua expression (`return hl.dispatch(<payload>)`), so `workspace <id>` is invalid Lua and fails with `"')' expected near '<id>'"`, and thus the switch never happens and no visual feedback occurs.

Detect the config provider once at client construction via `hyprctl systeminfo` (the `configProvider: lua` line; hyprland-rs does not expose `systeminfo`), cache it, and on a Lua provider dispatch `hl.dsp.focus {workspace="<id>"}` instead. The legacy path is left untouched, and detection failures fall back to legacy so nothing changes for existing setups. Only `dispatch` payloads are Lua-wrapped, so other commands (e.g. keyboard-layout switching) are unaffected.

Tested this branch on my live system, and clicking now works on Hyprland using a Lua config.

Closes #1548