### PR TITLE
fix(inhibit): pass a window to gtk_application_inhibit for wayland idle-inhibit

### DIFF
--- a/src/clients/inhibit.rs
+++ b/src/clients/inhibit.rs
@@ -24,8 +24,10 @@ impl Drop for InhibitCookie {
 }
 
 fn gtk_inhibit() -> Option<InhibitCookie> {
-    let id = get_app().inhibit(
-        None::<&gtk::Window>,
+    let app = get_app();
+    let window = app.windows().into_iter().next();
+    let id = app.inhibit(
+        window.as_ref(),
         ApplicationInhibitFlags::IDLE,
         Some("Ironbar inhibit"),
     );


### PR DESCRIPTION
The module called `gtk_application_inhibit` with a null window, so GTK skipped its Wayland idle-inhibit path (which requires a window) and fell back to the DBus session inhibit - a no-op on wlroots compositors (sway, Hyprland), where the module silently did nothing.

Pass one of the application's windows; GTK then creates a zwp_idle_inhibitor on its surface, which wlroots idle daemons (swayidle, hypridle) honour.

Fixes #1551.