### PR TITLE
feat: better support for 'cargo deb'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,16 @@ keywords = ["gtk", "bar", "wayland", "wlroots", "gtk-layer-shell"]
 [package.metadata.binstall]
 pkg-url = "{ repo }/releases/download/v{ version }/{ name }-v{ version }-{ target-arch }{ archive-suffix }"
 
+[package.metadata.deb]
+maintainer = "Jake Stanger"
+copyright = "© copyright 2022 Jake Stanger"
+extended-description = "A customisable Wayland GTK4 bar."
+depends = "$auto"
+assets = [
+    ["target/release/ironbar", "usr/bin/", "755"],
+    ["ironbar.service", "usr/lib/systemd/user/ironbar.service", "644"],
+]
+
 [features]
 default = [
     "battery",
@@ -210,13 +220,3 @@ clap_complete = {  version = "4.6.5", optional = true }
 
 [build-dependencies]
 vergen-git2 = "9.1.0"
-
-[package.metadata.deb]
-maintainer = "Jake Stanger"
-copyright = "© copyright 2022 Jake Stanger"
-extended-description = "A customisable Wayland GTK4 bar."
-depends = "$auto"
-assets = [
-    ["target/release/ironbar", "usr/bin/", "755"],
-    ["ironbar.service", "usr/lib/systemd/user/ironbar.service", "644"],
-]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -210,3 +210,13 @@ clap_complete = {  version = "4.6.5", optional = true }
 
 [build-dependencies]
 vergen-git2 = "9.1.0"
+
+[package.metadata.deb]
+maintainer = "Jake Stanger"
+copyright = "© copyright 2022 Jake Stanger"
+extended-description = "A customisable Wayland GTK4 bar."
+depends = "$auto"
+assets = [
+    ["target/release/ironbar", "usr/bin/", "755"],
+    ["ironbar.service", "usr/lib/systemd/user/ironbar.service", "644"],
+]


### PR DESCRIPTION
https://github.com/kornelski/cargo-deb is an alternative to `cargo install` that creates deb packages for Debian's apt.

`cargo deb` works without this patch, sans service file, but complains in a few places once installed. This cleans up those complaints.