### PR TITLE
build(nix): replace nix-systems with `lib.systems.flakeExposed`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -30,21 +30,6 @@
         "type": "github"
       }
     },
-    "nix-systems": {
-      "locked": {
-        "lastModified": 1689347949,
-        "narHash": "sha256-12tWmuL2zgBgZkdoB6qXZsgJEH9LR3oUgpaQq2RbI80=",
-        "owner": "nix-systems",
-        "repo": "default-linux",
-        "rev": "31732fcf5e8fea42e59c2488ad31a0e651500f68",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default-linux",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1785454630,
@@ -65,7 +50,6 @@
       "inputs": {
         "crane": "crane",
         "flake-compat": "flake-compat",
-        "nix-systems": "nix-systems",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,6 @@
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     flake-compat.url = "github:edolstra/flake-compat";
     crane.url = "github:ipetkov/crane";
-    nix-systems.url = "github:nix-systems/default-linux";
   };
 
   outputs =
@@ -13,13 +12,14 @@
       self,
       nixpkgs,
       crane,
-      nix-systems,
       ...
     }:
     let
       forAllSystems =
         function:
-        nixpkgs.lib.genAttrs (import nix-systems) (system: function nixpkgs.legacyPackages.${system});
+        nixpkgs.lib.genAttrs nixpkgs.lib.systems.flakeExposed (
+          system: function nixpkgs.legacyPackages.${system}
+        );
     in
     {
       # Devshell


### PR DESCRIPTION
this removes an unneeded input and makes sure anyone who can use flakes has access to this one's outputs

another alternative is `lib.platforms.all` (don't ask my why one is under systems and the other platforms) which is all the systems nix has (but probably unnecessary and clutters `nix flake show` and similar)