### PR TITLE
fix(tray): apply menu property updates and activate the correct radio item

### DIFF
--- a/src/modules/tray/diff.rs
+++ b/src/modules/tray/diff.rs
@@ -1,0 +1,153 @@
+//! Incremental application of dbusmenu property updates (`MenuDiff`) to a
+//! retained menu model.
+//!
+//! The `system-tray` crate delivers post-interaction changes — a radio
+//! selection moving to another entry, a submenu label changing — as
+//! [`MenuDiff`]s keyed by the *global* dbusmenu item id, which can sit at any
+//! depth in the menu tree. The crate's own `apply_menu_diffs` only walks the
+//! top-level items, so nested items (e.g. a radio group inside a submenu) never
+//! receive their updates. We therefore walk the whole tree and patch the item
+//! whose id matches, recursing into every submenu.
+
+use system_tray::menu::{MenuDiff, MenuItem, MenuItemUpdate};
+
+/// Applies every diff to the matching item anywhere in `items`, recursing into
+/// nested submenus. A diff whose id matches no item is ignored.
+///
+/// The `remove` field of a diff (properties reset to their default) is not
+/// applied — this matches the property set the `system-tray` crate itself
+/// understands, and the reported failures are all `update`s (toggle-state,
+/// label).
+pub(crate) fn apply_menu_diffs(items: &mut [MenuItem], diffs: &[MenuDiff]) {
+    for item in items {
+        if let Some(diff) = diffs.iter().find(|d| d.id == item.id) {
+            apply_menu_item_update(item, &diff.update);
+        }
+        apply_menu_diffs(&mut item.submenu, diffs);
+    }
+}
+
+/// Overwrites exactly the fields the update carries, leaving the rest intact.
+fn apply_menu_item_update(item: &mut MenuItem, update: &MenuItemUpdate) {
+    if let Some(label) = &update.label {
+        item.label.clone_from(label);
+    }
+    if let Some(enabled) = update.enabled {
+        item.enabled = enabled;
+    }
+    if let Some(visible) = update.visible {
+        item.visible = visible;
+    }
+    if let Some(icon_name) = &update.icon_name {
+        item.icon_name.clone_from(icon_name);
+    }
+    if let Some(icon_data) = &update.icon_data {
+        item.icon_data.clone_from(icon_data);
+    }
+    if let Some(toggle_state) = update.toggle_state {
+        item.toggle_state = toggle_state;
+    }
+    if let Some(disposition) = update.disposition {
+        item.disposition = disposition;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use system_tray::menu::{MenuDiff, MenuItem, MenuItemUpdate, ToggleState, ToggleType};
+
+    fn radio(id: i32, label: &str, state: ToggleState) -> MenuItem {
+        MenuItem {
+            id,
+            label: Some(label.to_string()),
+            enabled: true,
+            visible: true,
+            toggle_type: ToggleType::Radio,
+            toggle_state: state,
+            ..Default::default()
+        }
+    }
+
+    fn toggle_state_diff(id: i32, state: ToggleState) -> MenuDiff {
+        MenuDiff {
+            id,
+            update: MenuItemUpdate {
+                toggle_state: Some(state),
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    /// The reported bug: a radio group nested inside a submenu. Clicking an
+    /// entry moves the `toggle-state` from one item to another; dbusmenu
+    /// delivers this as `MenuDiff`s keyed by the (nested) item ids, so the menu
+    /// model must reflect the moved selection.
+    #[test]
+    fn applies_toggle_state_move_to_nested_radio_group() {
+        // given: a submenu containing a radio group, "A" selected, "B" not
+        let mut items = vec![MenuItem {
+            id: 1,
+            label: Some("parent".to_string()),
+            enabled: true,
+            visible: true,
+            children_display: Some("submenu".to_string()),
+            submenu: vec![
+                radio(10, "A", ToggleState::On),
+                radio(11, "B", ToggleState::Off),
+            ],
+            ..Default::default()
+        }];
+
+        // when: the user clicks "B" — A turns off, B turns on
+        let diffs = vec![
+            toggle_state_diff(10, ToggleState::Off),
+            toggle_state_diff(11, ToggleState::On),
+        ];
+        apply_menu_diffs(&mut items, &diffs);
+
+        // then: the nested radio group reflects the new selection
+        let submenu = &items[0].submenu;
+        assert_eq!(
+            submenu[0].toggle_state,
+            ToggleState::Off,
+            "clicked-away entry A should be deselected"
+        );
+        assert_eq!(
+            submenu[1].toggle_state,
+            ToggleState::On,
+            "clicked entry B should be selected"
+        );
+    }
+
+    /// A label change (e.g. a submenu summary reflecting the new selection)
+    /// must be applied.
+    #[test]
+    fn applies_label_update() {
+        let mut items = vec![radio(5, "old", ToggleState::Off)];
+        let diffs = vec![MenuDiff {
+            id: 5,
+            update: MenuItemUpdate {
+                label: Some(Some("new".to_string())),
+                ..Default::default()
+            },
+            ..Default::default()
+        }];
+
+        apply_menu_diffs(&mut items, &diffs);
+
+        assert_eq!(items[0].label.as_deref(), Some("new"));
+    }
+
+    /// A diff whose id matches no item is a harmless no-op.
+    #[test]
+    fn ignores_unknown_id() {
+        let mut items = vec![radio(1, "A", ToggleState::On)];
+        let diffs = vec![toggle_state_diff(999, ToggleState::Off)];
+
+        apply_menu_diffs(&mut items, &diffs);
+
+        assert_eq!(items[0].toggle_state, ToggleState::On);
+    }
+}

--- a/src/modules/tray/interface.rs
+++ b/src/modules/tray/interface.rs
@@ -14,7 +14,7 @@ use gtk::{Button, Label, PopoverMenu};
 use std::path::PathBuf;
 use system_tray::client::ActivateRequest;
 use system_tray::item::{IconPixmap, Status, StatusNotifierItem, Tooltip};
-use system_tray::menu::ToggleState;
+use system_tray::menu::{MenuDiff, ToggleState};
 use tokio::sync::mpsc;
 use tracing::{debug, error, trace};
 
@@ -29,6 +29,10 @@ pub(crate) struct TrayMenu {
     tx: mpsc::Sender<UiEvent>,
     path: Option<String>,
     address: String,
+
+    /// The last full menu model received, retained so incremental
+    /// [`MenuDiff`]s (post-click property changes) have something to patch.
+    menu: Option<system_tray::menu::TrayMenu>,
 
     pub title: Option<String>,
     pub icon_name: Option<String>,
@@ -217,6 +221,7 @@ impl TrayMenu {
             icon_pixmap: item.icon_pixmap,
             path: None,
             address: address.to_owned(),
+            menu: None,
         }
     }
 
@@ -298,7 +303,35 @@ impl TrayMenu {
         self.path = Some(menu.to_owned());
     }
 
-    pub fn set_menu_widget(&self, tray_menu: &system_tray::menu::TrayMenu) {
+    /// Replaces the menu with a freshly received full model and repaints.
+    pub fn set_menu_widget(&mut self, tray_menu: &system_tray::menu::TrayMenu) {
+        self.menu = Some(tray_menu.clone());
+        self.build_menu_widget();
+    }
+
+    /// Applies incremental dbusmenu property updates to the retained model and
+    /// repaints, so post-click changes (a moved radio selection, a new label)
+    /// become visible without the caller re-sending the whole menu.
+    pub fn apply_menu_diff(&mut self, diffs: &[MenuDiff]) {
+        match self.menu.as_mut() {
+            Some(menu) => super::diff::apply_menu_diffs(&mut menu.submenus, diffs),
+            None => {
+                // A diff arrived before any full menu — nothing to patch.
+                trace!("received menu diff with no menu to apply it to");
+                return;
+            }
+        }
+
+        self.build_menu_widget();
+    }
+
+    /// Rebuilds the popover's menu model, action group, and shortcuts from the
+    /// retained menu model.
+    fn build_menu_widget(&self) {
+        let Some(tray_menu) = self.menu.as_ref() else {
+            return;
+        };
+
         debug!("set menu");
 
         let action_group = SimpleActionGroup::new();

--- a/src/modules/tray/interface.rs
+++ b/src/modules/tray/interface.rs
@@ -398,33 +398,48 @@ impl TrayMenu {
         format!("menu.{action_name}")
     }
 
-    pub fn connect_radio_item(
+    /// Registers the single stateful action shared by every item of one radio
+    /// group, returning it alongside its `menu.`-qualified name.
+    ///
+    /// The caller points each item at `"{name}::{item target}"` and parks the
+    /// state on the selected item; the action itself cannot tell the options
+    /// apart, so the target is the only thing identifying which one was
+    /// clicked.
+    fn connect_radio_group(
         &self,
-        sub: &system_tray::menu::MenuItem,
         action_group: &SimpleActionGroup,
-        radio_group: &str,
-        value: &str,
-        selected: bool,
-    ) -> String {
-        let action_name = format!("action_radio_{radio_group}");
+        group_id: i32,
+        initial_target: &str,
+    ) -> (SimpleAction, String) {
+        let action_name = radio_action_name(group_id);
         let tx = self.tx.clone();
-        let id = sub.id;
-
-        let action =
-            SimpleAction::new_stateful(&action_name, Some(VariantTy::STRING), &value.to_variant());
-
-        if selected {
-            action.set_state(&value.to_variant());
-        }
-
         let address = self.address.clone();
 
+        let action = SimpleAction::new_stateful(
+            &action_name,
+            Some(VariantTy::STRING),
+            &initial_target.to_variant(),
+        );
+
         if let Some(path) = self.path.clone() {
-            action.connect_change_state(move |_, _| activate(&tx, &address, &path, id));
+            action.connect_change_state(move |action, state| {
+                let Some(state) = state else { return };
+
+                let Some(id) = radio_target_id(state) else {
+                    error!("radio action state is not a menu item id: {state:?}");
+                    return;
+                };
+
+                // GTK does not advance a stateful action's state for us on
+                // change-state, so without this the mark never moves.
+                action.set_state(state);
+
+                activate(&tx, &address, &path, id);
+            });
         }
 
         action_group.add_action(&action);
-        format!("menu.{action_name}")
+        (action, format!("menu.{action_name}"))
     }
 
     pub fn connect_shortcut(
@@ -459,12 +474,11 @@ impl TrayMenu {
         use system_tray::menu::{MenuType, ToggleType};
         let mut section_container: Option<Menu> = None;
 
-        // As current implementation it identifies radio groups based on the
-        // item of type radio coming one after the other,
-        // if there is a gap than a new radio group is started,
-        // for handling multiple radio groups it use a sequential one of each group used as key for the action
-        let mut radio_group_sequential = 0;
-        let mut radio_group = None;
+        // dbusmenu has no explicit radio grouping, so a group is a run of
+        // consecutive radio items; anything else — another toggle type, or a
+        // submenu — ends the run. The run's shared action is created on its
+        // first item and reused by the rest.
+        let mut radio_group: Option<(SimpleAction, String)> = None;
         let mut model = Menu::new();
 
         for sub in items {
@@ -490,32 +504,24 @@ impl TrayMenu {
                         let action = if sub.enabled {
                             match sub.toggle_type {
                                 ToggleType::Radio => {
-                                    let value = match sub.toggle_state {
-                                        ToggleState::On => true,
-                                        ToggleState::Off | ToggleState::Indeterminate => false,
-                                    };
-
                                     let target = format!("{}", sub.id);
 
-                                    let rg = if let Some(rg) = radio_group {
-                                        rg
-                                    } else {
-                                        radio_group_sequential += 1;
+                                    let (group_action, action_name) = radio_group
+                                        .get_or_insert_with(|| {
+                                            self.connect_radio_group(action_group, sub.id, &target)
+                                        });
 
-                                        let id = radio_group_sequential.to_string();
+                                    // Park the group's state on the item the
+                                    // application reports as selected, so the
+                                    // mark lands there rather than on whichever
+                                    // item happened to create the action.
+                                    if matches!(sub.toggle_state, ToggleState::On) {
+                                        group_action.set_state(&target.to_variant());
+                                    }
 
-                                        self.connect_radio_item(
-                                            sub,
-                                            action_group,
-                                            &id,
-                                            &target,
-                                            value,
-                                        )
-                                    };
                                     debug!("radio item {label:?}");
 
-                                    radio_group = Some(rg.clone());
-                                    format!("{rg}::{target}")
+                                    format!("{action_name}::{target}")
                                 }
                                 ToggleType::Checkmark => {
                                     radio_group = None;
@@ -596,6 +602,26 @@ impl TrayMenu {
     }
 }
 
+/// Names the GTK action shared by one radio group.
+///
+/// Every radio group in a tray menu — including groups nested in different
+/// submenus — is registered into the *same* `SimpleActionGroup`, and
+/// `add_action` silently replaces an existing action of the same name. Deriving
+/// the name from the group's first dbusmenu id, which is unique across the whole
+/// menu, makes that collision impossible by construction.
+fn radio_action_name(group_id: i32) -> String {
+    format!("action_radio_{group_id}")
+}
+
+/// Reads the clicked item's dbusmenu id out of a radio action's new state.
+///
+/// One action backs a whole radio group, so this target is the only thing
+/// distinguishing the options; dropping it would send every click to whichever
+/// item created the action.
+fn radio_target_id(state: &glib::Variant) -> Option<i32> {
+    state.str()?.parse().ok()
+}
+
 fn activate(tx: &mpsc::Sender<UiEvent>, address: &str, path: &str, id: i32) {
     trace!("activated {},{}, {}", address, path, id);
     let tx = tx.clone();
@@ -607,4 +633,36 @@ fn activate(tx: &mpsc::Sender<UiEvent>, address: &str, path: &str, id: i32) {
         menu_path: path,
         submenu_id: id,
     }));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Radio groups from different submenus all land in one
+    /// `SimpleActionGroup`, where `add_action` replaces on a duplicate name —
+    /// so two groups sharing a name means only one survives and every radio
+    /// item in the menu drives it. Distinct first-item ids are what prevent
+    /// that.
+    #[test]
+    fn groups_with_different_first_items_get_different_action_names() {
+        assert_ne!(radio_action_name(5), radio_action_name(19));
+    }
+
+    /// `as_menu` targets each radio item with `format!("{}", sub.id)`; this is
+    /// the other half of that contract. If the two formats ever drift apart,
+    /// clicks stop resolving and the menu silently does nothing.
+    #[test]
+    fn target_round_trips_the_menu_item_id() {
+        for id in [0, 1, 19, i32::MAX] {
+            let target = format!("{id}");
+            assert_eq!(radio_target_id(&target.to_variant()), Some(id));
+        }
+    }
+
+    #[test]
+    fn returns_none_when_state_is_not_a_menu_item_id() {
+        assert_eq!(radio_target_id(&"not-an-id".to_variant()), None);
+        assert_eq!(radio_target_id(&true.to_variant()), None);
+    }
 }

--- a/src/modules/tray/interface.rs
+++ b/src/modules/tray/interface.rs
@@ -34,6 +34,11 @@ pub(crate) struct TrayMenu {
     /// [`MenuDiff`]s (post-click property changes) have something to patch.
     menu: Option<system_tray::menu::TrayMenu>,
 
+    /// The shortcut controller currently attached to the widget, retained so
+    /// the next rebuild can detach it — `add_controller` appends, and nothing
+    /// else ever removes.
+    shortcut_controller: Option<ShortcutController>,
+
     pub title: Option<String>,
     pub icon_name: Option<String>,
     pub icon_theme_path: Option<PathBuf>,
@@ -222,6 +227,7 @@ impl TrayMenu {
             path: None,
             address: address.to_owned(),
             menu: None,
+            shortcut_controller: None,
         }
     }
 
@@ -327,7 +333,7 @@ impl TrayMenu {
 
     /// Rebuilds the popover's menu model, action group, and shortcuts from the
     /// retained menu model.
-    fn build_menu_widget(&self) {
+    fn build_menu_widget(&mut self) {
         let Some(tray_menu) = self.menu.as_ref() else {
             return;
         };
@@ -343,6 +349,16 @@ impl TrayMenu {
 
         self.popover.set_menu_model(Some(&model));
         self.widget.insert_action_group("menu", Some(&action_group));
+
+        // `insert_action_group` replaces the previous group by name, but
+        // `add_controller` only appends — detach the previous controller or
+        // they accumulate on the widget for the lifetime of the tray item.
+        if let Some(old) = self
+            .shortcut_controller
+            .replace(shortcut_controller.clone())
+        {
+            self.widget.remove_controller(&old);
+        }
         self.widget.add_controller(shortcut_controller);
     }
 

--- a/src/modules/tray/mod.rs
+++ b/src/modules/tray/mod.rs
@@ -1,3 +1,4 @@
+mod diff;
 mod icon;
 mod interface;
 
@@ -498,6 +499,7 @@ fn on_update(
                 }
                 UpdateEvent::MenuDiff(diff) => {
                     trace!("received menu diff {diff:?}");
+                    menu_item.apply_menu_diff(&diff);
                 }
             }
         }


### PR DESCRIPTION
Two related tray menu fixes which together make menus with radio groups work
end-to-end. The first implements the menu update bug you diagnosed in #1538;
the second fixes a wrong-id activation bug in the radio path that the first
fix made observable.

## 1. Apply `MenuDiff` updates so menus repaint after a click

The tray interface handled `UpdateEvent::Menu` (full replace) and
`MenuConnect`, but only `trace!`'d `UpdateEvent::MenuDiff` and dropped it.
`MenuDiff` is how the standard `com.canonical.dbusmenu`
`ItemsPropertiesUpdated` signal reaches the module, so every post-click
property change — a moved radio toggle-state, a refreshed label, an
enabled/disabled entry — was discarded and the widget kept rendering the
previous state. This is the case you described in #1538:

> this is the first tray app I've seen that actually sends menu property
> update events rather than replacing the whole thing, and I just skipped
> implementing it previously as I had nothing to test against.

It affects any conforming tray implementation, not one toolkit: Qt,
libdbusmenu and ksni all report property-only changes this way and only
escalate to `LayoutUpdated` when the structure changes.

**Why apply the diffs in ironbar rather than in `system-tray`:** the crate's
own `apply_menu_diffs` walks only the top-level submenus and consumes diffs
positionally (`next_if(|d| d.id == item.id)`), so nested groups are never
patched — but fixing that alone wouldn't be enough, because ironbar dropped
the event before the widget could repaint. The widget side needs a retained
menu model and a rebuild regardless, so `TrayMenu` now keeps the last full
menu model and applies diffs itself, matching by global item id at any depth
(`src/modules/tray/diff.rs`, unit-tested including the nested-radio case).
Happy to send a recursion fix for the crate's `apply_menu_diffs` as a
follow-up if you'd take it.

## 2. Activate the clicked radio item, not the group's first

Clicking any radio item sent one fixed dbusmenu id, so the application either
did nothing or silently re-applied a setting it already had. Two defects
combined:

1. **Colliding action names.** `as_menu` numbered radio groups with a counter
   local to the function, but recursed into each submenu carrying the same
   `SimpleActionGroup`. The counter restarted per submenu while the namespace
   did not, so every submenu's first group was named `action_radio_1` —
   and `ActionMap::add_action` replaces on a duplicate name, leaving one
   surviving action driven by every radio item in the menu.
2. **The change-state handler discarded its parameter.** One action backs a
   whole group, so the clicked option is identified only by the target string
   in the new state. The handler was `move |_, _| activate(.., id)`, using an
   id captured at build time — the group's first item. On its own this breaks
   every group of more than one option, even without collisions.

The fix names the action from the group's first dbusmenu id (unique
menu-wide, so collision-free by construction) and reads the clicked id back
out of the change-state payload. The group's state is also parked on the item
the application reports as selected, so the radio mark renders on the actually
active option instead of always the first.

Standard and checkmark items were never affected — they use the globally
unique `action_{id}` path — which is why tray menus looked mostly functional
and only radio groups misbehaved.

## Testing

- Unit tests for the diff application (nested radio toggle-state move, label
  update, unknown-id no-op) and for the radio action contract (action-name
  uniqueness across groups, target string round-tripping the item id).
- Verified live against a ksni app whose menu has five radio groups in five
  submenus. Before: every click in every group sent id 19 (confirmed via
  `busctl … GetLayout` against the app's real menu ids plus trace logging of
  the outgoing `ActivateRequest`). After: the sent id varies per click,
  selections apply across different groups and both options within a group,
  and the menu repaints to show the moved selection without reopening.
- `cargo fmt --check`, `cargo clippy --all-targets` (0 warnings), builds with
  `--no-default-features`, `cargo test` all pass.

Refs #1538 — this implements the menu update part; the scroll-event and
libappindicator points from that issue are out of scope here.
