### PR TITLE
Added mangowm compositor handling and workspaces supporting and Updated.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1933,7 +1933,7 @@ dependencies = [
 
 [[package]]
 name = "ironbar"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "bluer",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ironbar"
-version = "0.19.0"
+version = "0.20.0"
 edition = "2024"
 license = "MIT"
 description = "Customisable GTK Layer Shell wlroots/sway bar"
@@ -125,14 +125,17 @@ tray = ["system-tray"]
 volume = ["libpulse-binding"]
 
 workspaces = ["futures-lite"]
-"workspaces+all" = ["workspaces", "workspaces+sway", "workspaces+hyprland", "workspaces+niri"]
+"workspaces+all" = ["workspaces", "workspaces+sway", "workspaces+hyprland", "workspaces+niri", "workspaces+mangowm"]
 "workspaces+sway" = ["workspaces", "sway"]
 "workspaces+hyprland" = ["workspaces", "hyprland", "dep:serde_json"]
 "workspaces+niri" = ["workspaces", "niri"]
+"workspaces+mangowm" = ["workspaces", "mangowm"]
 
 sway = ["swayipc-async", "futures-lite"]
 
 niri = ["dep:serde_json"]
+
+mangowm = []
 
 extras = ["dep:schemars", "dep:clap_complete"]
 

--- a/src/clients/compositor/mangowm.rs
+++ b/src/clients/compositor/mangowm.rs
@@ -1,0 +1,230 @@
+use super::{Visibility, Workspace, WorkspaceClient, WorkspaceUpdate};
+use crate::channels::SyncSenderExt;
+use crate::spawn;
+use serde::Deserialize;
+use std::process::Stdio;
+use std::sync::{Arc, RwLock};
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::process::Command;
+use tokio::sync::broadcast::{Receiver, Sender, channel};
+use tracing::{debug, error};
+
+#[derive(Debug, Deserialize)]
+struct Tag {
+    index: i64,
+    is_active: bool,
+    #[serde(default)]
+    client_count: i64,
+}
+
+#[derive(Debug, Deserialize)]
+struct MonitorTags {
+    monitor: String,
+    tags: Vec<Tag>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AllTags {
+    all_tags: Vec<MonitorTags>,
+}
+
+fn make_id(monitor_index: i64, tag_index: i64) -> i64 {
+    monitor_index * 100 + tag_index
+}
+
+fn to_workspaces(all_tags: AllTags) -> Vec<Workspace> {
+    let mut out = Vec::new();
+
+    for (mon_idx, mon) in all_tags.all_tags.into_iter().enumerate() {
+        for tag in mon.tags {
+            if !tag.is_active && tag.client_count == 0 {
+                continue;
+            }
+
+            out.push(Workspace {
+                id: make_id(mon_idx as i64, tag.index),
+                index: tag.index,
+                name: tag.index.to_string(),
+                monitor: mon.monitor.clone(),
+                visibility: if tag.is_active {
+                    Visibility::focused()
+                } else {
+                    Visibility::visible()
+                },
+            });
+        }
+    }
+
+    out
+}
+
+#[derive(Debug)]
+pub struct Client {
+    tx: Sender<WorkspaceUpdate>,
+    _rx: Receiver<WorkspaceUpdate>,
+    workspaces: Arc<RwLock<Vec<Workspace>>>,
+}
+
+impl Client {
+    pub fn new() -> Self {
+        let (tx, rx) = channel(16);
+        let tx2 = tx.clone();
+
+        let workspaces = Arc::new(RwLock::new(Vec::new()));
+        let workspaces2 = workspaces.clone();
+
+        spawn(async move {
+            loop {
+                if let Err(err) = watch_loop(&tx, &workspaces).await {
+                    error!("mangowm: `mmsg watch all-tags` error: {err:#}, retrying in 2s");
+                    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+                }
+            }
+        });
+
+        Self {
+            tx: tx2,
+            _rx: rx,
+            workspaces: workspaces2,
+        }
+    }
+}
+
+impl Default for Client {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+async fn watch_loop(
+    tx: &Sender<WorkspaceUpdate>,
+    workspaces: &Arc<RwLock<Vec<Workspace>>>,
+) -> color_eyre::Result<()> {
+    let mut child = Command::new("mmsg")
+        .args(["watch", "all-tags"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .kill_on_drop(true)
+        .spawn()?;
+
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| color_eyre::Report::msg("mmsg watch all-tags: no stdout"))?;
+
+    let mut lines = BufReader::new(stdout).lines();
+    let mut first = true;
+
+    while let Some(line) = lines.next_line().await? {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+
+        let all_tags: AllTags = match serde_json::from_str(line) {
+            Ok(v) => v,
+            Err(err) => {
+                error!("mangowm: failed to parse `mmsg watch all-tags` line: {err} ({line})");
+                continue;
+            }
+        };
+
+        let new_workspaces = to_workspaces(all_tags);
+        debug!("mangowm: all-tags update: {new_workspaces:?}");
+
+        if first {
+            first = false;
+            tx.send_expect(WorkspaceUpdate::Init(new_workspaces.clone()));
+        } else {
+            let old_workspaces = workspaces.read().expect("lock poisoned").clone();
+            for update in diff(&old_workspaces, &new_workspaces) {
+                tx.send_expect(update);
+            }
+        }
+
+        *workspaces.write().expect("lock poisoned") = new_workspaces;
+    }
+
+    let status = child.wait().await.ok();
+    Err(color_eyre::Report::msg(format!(
+        "mmsg watch all-tags exited: {status:?}"
+    )))
+}
+
+fn diff(old: &[Workspace], new: &[Workspace]) -> Vec<WorkspaceUpdate> {
+    let mut updates = Vec::new();
+
+    for workspace in new {
+        match old.iter().find(|w| w.id == workspace.id) {
+            None => updates.push(WorkspaceUpdate::Add(workspace.clone())),
+            Some(old_workspace) if old_workspace.monitor != workspace.monitor => {
+                updates.push(WorkspaceUpdate::Move(workspace.clone()));
+            }
+            _ => {}
+        }
+    }
+
+    for workspace in old {
+        if !new.iter().any(|w| w.id == workspace.id) {
+            updates.push(WorkspaceUpdate::Remove(workspace.id));
+        }
+    }
+
+    let old_focused = old.iter().find(|w| w.visibility.is_focused());
+    let new_focused = new.iter().find(|w| w.visibility.is_focused());
+
+    if let Some(new_focused) = new_focused
+        && old_focused.map(|w| w.id) != Some(new_focused.id)
+    {
+        updates.push(WorkspaceUpdate::Focus {
+            old: old_focused.cloned(),
+            new: new_focused.clone(),
+        });
+    }
+
+    updates
+}
+
+#[cfg(feature = "workspaces+mangowm")]
+impl WorkspaceClient for Client {
+    fn focus(&self, id: i64) {
+        let tag_index = id % 100;
+
+        spawn(async move {
+            let arg = format!("view,{tag_index},0");
+            match Command::new("mmsg")
+                .args(["dispatch", &arg])
+                .stdin(Stdio::null())
+                .output()
+                .await
+            {
+                Ok(output) if !output.status.success() => {
+                    error!(
+                        "mangowm: `mmsg dispatch {arg}` failed: {}",
+                        String::from_utf8_lossy(&output.stderr)
+                    );
+                }
+                Ok(output) => {
+                    let stdout = String::from_utf8_lossy(&output.stdout);
+                    if stdout.contains("\"error\"") {
+                        error!("mangowm: `mmsg dispatch {arg}` returned: {stdout}");
+                    }
+                }
+                Err(err) => error!("mangowm: failed to run `mmsg dispatch {arg}`: {err}"),
+            }
+        });
+    }
+
+    fn subscribe(&self) -> Receiver<WorkspaceUpdate> {
+        let rx = self.tx.subscribe();
+
+        let workspaces = self.workspaces.read().expect("lock poisoned");
+        if !workspaces.is_empty() {
+            self.tx
+                .send_expect(WorkspaceUpdate::Init(workspaces.clone()));
+        }
+
+        rx
+    }
+}

--- a/src/clients/compositor/mangowm.rs
+++ b/src/clients/compositor/mangowm.rs
@@ -171,16 +171,17 @@ fn diff(old: &[Workspace], new: &[Workspace]) -> Vec<WorkspaceUpdate> {
         }
     }
 
-    let old_focused = old.iter().find(|w| w.visibility.is_focused());
-    let new_focused = new.iter().find(|w| w.visibility.is_focused());
+    for new_focused in new.iter().filter(|w| w.visibility.is_focused()) {
+        let old_focused = old
+            .iter()
+            .find(|w| w.monitor == new_focused.monitor && w.visibility.is_focused());
 
-    if let Some(new_focused) = new_focused
-        && old_focused.map(|w| w.id) != Some(new_focused.id)
-    {
-        updates.push(WorkspaceUpdate::Focus {
-            old: old_focused.cloned(),
-            new: new_focused.clone(),
-        });
+        if old_focused.map(|w| w.id) != Some(new_focused.id) {
+            updates.push(WorkspaceUpdate::Focus {
+                old: old_focused.cloned(),
+                new: new_focused.clone(),
+            });
+        }
     }
 
     updates

--- a/src/clients/compositor/mod.rs
+++ b/src/clients/compositor/mod.rs
@@ -8,6 +8,8 @@ use tracing::debug;
 
 #[cfg(feature = "hyprland")]
 pub mod hyprland;
+#[cfg(feature = "mangowm")]
+pub mod mangowm;
 #[cfg(feature = "niri")]
 pub mod niri;
 #[cfg(feature = "sway")]
@@ -32,6 +34,8 @@ pub enum Compositor {
     Hyprland,
     #[cfg(feature = "niri")]
     Niri,
+    #[cfg(feature = "mangowm")]
+    MangoWm,
     Unsupported,
 }
 
@@ -47,6 +51,8 @@ impl Display for Compositor {
                 Self::Hyprland => "Hyprland",
                 #[cfg(feature = "workspaces+niri")]
                 Self::Niri => "Niri",
+                #[cfg(feature = "workspaces+mangowm")]
+                Self::MangoWm => "MangoWm",
                 Self::Unsupported => "Unsupported",
             }
         )
@@ -54,8 +60,6 @@ impl Display for Compositor {
 }
 
 impl Compositor {
-    /// Attempts to get the current compositor.
-    /// This is done by checking system env vars.
     fn get_current() -> Self {
         if std::env::var("SWAYSOCK").is_ok() {
             cfg_if! {
@@ -71,6 +75,11 @@ impl Compositor {
             cfg_if! {
                 if #[cfg(feature = "niri")] { Self::Niri }
                 else {tracing::error!("Not compiled with Niri support"); Self::Unsupported }
+            }
+        } else if std::env::var("MANGO_INSTANCE_SIGNATURE").is_ok() {
+            cfg_if! {
+                if #[cfg(feature = "mangowm")] { Self::MangoWm }
+                else { tracing::error!("Not compiled with MangoWm support"); Self::Unsupported }
             }
         } else {
             Self::Unsupported
@@ -115,8 +124,6 @@ impl Compositor {
         }
     }
 
-    /// Creates a new instance of
-    /// the workspace client for the current compositor.
     #[cfg(feature = "workspaces")]
     pub fn create_workspace_client(
         clients: &mut super::Clients,
@@ -130,9 +137,11 @@ impl Compositor {
             Self::Hyprland => Ok(clients.hyprland()),
             #[cfg(feature = "workspaces+niri")]
             Self::Niri => Ok(Arc::new(niri::Client::new())),
+            #[cfg(feature = "workspaces+mangowm")]
+            Self::MangoWm => Ok(Arc::new(mangowm::Client::new())),
             Self::Unsupported => Err(Error::Unsupported(
                 "workspaces",
-                &["sway", "hyprland", "niri"],
+                &["sway", "hyprland", "niri", "mangowm"],
             )),
             #[allow(unreachable_patterns)]
             _ => Err(Error::Disabled("workspaces")),
@@ -142,20 +151,13 @@ impl Compositor {
 
 #[derive(Debug, Clone)]
 pub struct Workspace {
-    /// Unique identifier
     pub id: i64,
-    /// The workspace index (e.g. for sorting)
     pub index: i64,
-    /// Workspace friendly name
     pub name: String,
-    /// Name of the monitor (output) the workspace is located on
     pub monitor: String,
-    /// How visible the workspace is
     pub visibility: Visibility,
 }
 
-/// Indicates workspace visibility.
-/// Visible workspaces have a boolean flag to indicate if they are also focused.
 #[derive(Debug, Copy, Clone)]
 pub enum Visibility {
     Visible { focused: bool },
@@ -191,13 +193,10 @@ pub struct KeyboardLayoutUpdate(pub String);
 #[derive(Debug, Clone)]
 #[cfg(feature = "workspaces")]
 pub enum WorkspaceUpdate {
-    /// Provides an initial list of workspaces.
-    /// This is re-sent to all subscribers when a new subscription is created.
     Init(Vec<Workspace>),
     Add(Workspace),
     Remove(i64),
     Move(Workspace),
-    /// Declares focus moved from the old workspace to the new.
     Focus {
         old: Option<Workspace>,
         new: Workspace,
@@ -208,34 +207,25 @@ pub enum WorkspaceUpdate {
         name: String,
     },
 
-    /// The urgent state of a node changed.
     Urgent {
         id: i64,
         urgent: bool,
     },
 
-    /// An update was triggered by the compositor but this was not mapped by Ironbar.
-    ///
-    /// This is purely used for ergonomics within the compositor clients
-    /// and should be ignored by consumers.
     Unknown,
 }
 
 #[derive(Clone, Debug)]
 #[cfg(feature = "bindmode")]
 pub struct BindModeUpdate {
-    /// The binding mode that became active.
     pub name: String,
-    /// Whether the mode should be parsed as pango markup.
     pub pango_markup: bool,
 }
 
 #[cfg(feature = "workspaces")]
 pub trait WorkspaceClient: Debug + Send + Sync {
-    /// Requests the workspace with this id is focused.
     fn focus(&self, id: i64);
 
-    /// Creates a new to workspace event receiver.
     fn subscribe(&self) -> broadcast::Receiver<WorkspaceUpdate>;
 }
 
@@ -244,10 +234,8 @@ register_fallible_client!(dyn WorkspaceClient, workspaces);
 
 #[cfg(feature = "keyboard")]
 pub trait KeyboardLayoutClient: Debug + Send + Sync {
-    /// Switches to the next layout.
     fn set_next_active(&self);
 
-    /// Creates a new to keyboard layout event receiver.
     fn subscribe(&self) -> broadcast::Receiver<KeyboardLayoutUpdate>;
 }
 
@@ -256,7 +244,6 @@ register_fallible_client!(dyn KeyboardLayoutClient, keyboard_layout);
 
 #[cfg(feature = "bindmode")]
 pub trait BindModeClient: Debug + Send + Sync {
-    /// Add a callback for bindmode updates.
     fn subscribe(&self) -> Result<broadcast::Receiver<BindModeUpdate>>;
 }
 


### PR DESCRIPTION
As I said, I added compositor handling and workspace support with a simple implementation for Mangowm, but I did it in mmsg-based format. An entry point is required. Since there will be the possibility of breaking changes in future versions regarding dwl-ipc.h stabilization, I supported it in mmsg-based format because mmsg can remain more stable in this regard.