### PR TITLE
Add keyboard layout support for niri

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,9 +97,10 @@ focused = []
 inhibit = ["chrono"]
 
 keyboard = ["dep:colpetto", "dep:evdev-rs", "dep:rustix", "futures-lite"]
-"keyboard+all" = ["keyboard", "keyboard+sway", "keyboard+hyprland"]
+"keyboard+all" = ["keyboard", "keyboard+sway", "keyboard+hyprland", "keyboard+niri"]
 "keyboard+sway" = ["keyboard", "sway"]
 "keyboard+hyprland" = ["keyboard", "hyprland"]
+"keyboard+niri" = ["keyboard", "niri"]
 
 label = []
 

--- a/src/clients/compositor/mod.rs
+++ b/src/clients/compositor/mod.rs
@@ -107,9 +107,12 @@ impl Compositor {
             Self::Sway => Ok(clients.sway().map_err(|err| Error::Other(err.into()))?),
             #[cfg(feature = "keyboard+hyprland")]
             Self::Hyprland => Ok(clients.hyprland()),
-            #[cfg(feature = "niri")]
-            Self::Niri => Err(Error::Unsupported("keyboard", &["sway", "hyprland"])),
-            Self::Unsupported => Err(Error::Unsupported("keyboard", &["sway", "hyprland"])),
+            #[cfg(feature = "keyboard+niri")]
+            Self::Niri => Ok(clients.niri()),
+            Self::Unsupported => Err(Error::Unsupported(
+                "keyboard",
+                &["sway", "hyprland", "niri"],
+            )),
             #[allow(unreachable_patterns)]
             _ => Err(Error::Disabled("keyboard")),
         }
@@ -129,7 +132,7 @@ impl Compositor {
             #[cfg(feature = "workspaces+hyprland")]
             Self::Hyprland => Ok(clients.hyprland()),
             #[cfg(feature = "workspaces+niri")]
-            Self::Niri => Ok(Arc::new(niri::Client::new())),
+            Self::Niri => Ok(clients.niri()),
             Self::Unsupported => Err(Error::Unsupported(
                 "workspaces",
                 &["sway", "hyprland", "niri"],

--- a/src/clients/compositor/mod.rs
+++ b/src/clients/compositor/mod.rs
@@ -45,7 +45,7 @@ impl Display for Compositor {
                 Self::Sway => "Sway",
                 #[cfg(any(feature = "hyprland"))]
                 Self::Hyprland => "Hyprland",
-                #[cfg(feature = "workspaces+niri")]
+                #[cfg(feature = "niri")]
                 Self::Niri => "Niri",
                 Self::Unsupported => "Unsupported",
             }

--- a/src/clients/compositor/niri/connection.rs
+++ b/src/clients/compositor/niri/connection.rs
@@ -1,8 +1,7 @@
 /// Taken from the `niri_ipc` crate.
 /// Only a relevant snippet has been extracted
 /// to reduce compile times.
-use crate::clients::compositor::Workspace as IronWorkspace;
-use crate::{await_sync, clients::compositor::Visibility};
+use crate::await_sync;
 use core::str;
 use serde::{Deserialize, Serialize};
 use std::io::Result;
@@ -23,103 +22,114 @@ pub type Reply = std::result::Result<Response, String>;
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub enum Response {
     Handled,
-    Workspaces(Vec<Workspace>),
+    #[cfg(feature = "workspaces")]
+    Workspaces(Vec<ws::Workspace>),
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub enum Action {
+    #[cfg(feature = "workspaces")]
     FocusWorkspace {
-        reference: WorkspaceReferenceArg,
+        reference: ws::WorkspaceReferenceArg,
     },
-    #[cfg(feature = "keyboard+niri")]
-    SwitchLayout {
-        layout: LayoutSwitchTarget,
-    },
-}
-
-#[cfg(feature = "keyboard+niri")]
-#[derive(Serialize, Deserialize, Debug, Clone, Copy)]
-pub enum LayoutSwitchTarget {
-    Next,
-    Prev,
-    Index(u8),
-}
-
-#[cfg(feature = "keyboard+niri")]
-#[derive(Serialize, Deserialize, Debug, Clone, Default)]
-pub struct KeyboardLayouts {
-    pub names: Vec<String>,
-    pub current_idx: u8,
-}
-
-#[cfg(feature = "keyboard+niri")]
-impl KeyboardLayouts {
-    pub fn current(&self) -> Option<&str> {
-        self.names
-            .get(self.current_idx as usize)
-            .map(|x| x.as_str())
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
-pub enum WorkspaceReferenceArg {
-    Name(String),
-    Id(u64),
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct Workspace {
-    pub id: u64,
-    pub idx: u8,
-    pub name: Option<String>,
-    pub output: Option<String>,
-    pub is_active: bool,
-    pub is_focused: bool,
-}
-
-impl From<&Workspace> for IronWorkspace {
-    fn from(workspace: &Workspace) -> IronWorkspace {
-        // Workspaces in niri don't neccessarily have names.
-        // If the niri workspace has a name then it is assigned as is,
-        // but if it does not have a name, the monitor index is used.
-        Self {
-            id: workspace.id as i64,
-            index: workspace.idx as i64,
-            name: workspace.name.clone().unwrap_or(workspace.idx.to_string()),
-            monitor: workspace.output.clone().unwrap_or_default(),
-            visibility: if workspace.is_active {
-                Visibility::Visible {
-                    focused: workspace.is_focused,
-                }
-            } else {
-                Visibility::Hidden
-            },
-        }
-    }
+    #[cfg(feature = "keyboard")]
+    SwitchLayout { layout: kb::LayoutSwitchTarget },
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum Event {
+    #[cfg(feature = "workspaces")]
     WorkspacesChanged {
-        workspaces: Vec<Workspace>,
+        workspaces: Vec<ws::Workspace>,
     },
+    #[cfg(feature = "workspaces")]
     WorkspaceActivated {
         id: u64,
         focused: bool,
     },
+    #[cfg(feature = "workspaces")]
     WorkspaceUrgencyChanged {
         id: u64,
         urgent: bool,
     },
-    #[cfg(feature = "keyboard+niri")]
+    #[cfg(feature = "keyboard")]
     KeyboardLayoutsChanged {
-        keyboard_layouts: KeyboardLayouts,
+        keyboard_layouts: kb::KeyboardLayouts,
     },
-    #[cfg(feature = "keyboard+niri")]
+    #[cfg(feature = "keyboard")]
     KeyboardLayoutSwitched {
         idx: u8,
     },
     Other,
+}
+
+#[cfg(feature = "keyboard")]
+pub mod kb {
+    use super::{Deserialize, Serialize};
+
+    #[derive(Serialize, Deserialize, Debug, Clone, Copy)]
+    pub enum LayoutSwitchTarget {
+        Next,
+        Prev,
+        Index(u8),
+    }
+
+    #[derive(Serialize, Deserialize, Debug, Clone, Default)]
+    pub struct KeyboardLayouts {
+        pub names: Vec<String>,
+        pub current_idx: u8,
+    }
+
+    impl KeyboardLayouts {
+        pub fn current(&self) -> Option<&str> {
+            self.names
+                .get(self.current_idx as usize)
+                .map(|x| x.as_str())
+        }
+    }
+}
+
+#[cfg(feature = "workspaces")]
+pub mod ws {
+    use super::{Deserialize, Serialize};
+    use crate::clients::compositor::{Visibility, Workspace as IronWorkspace};
+
+    #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+    pub enum WorkspaceReferenceArg {
+        Name(String),
+        Id(u64),
+    }
+
+    #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+    pub struct Workspace {
+        pub id: u64,
+        pub idx: u8,
+        pub name: Option<String>,
+        pub output: Option<String>,
+        pub is_active: bool,
+        pub is_focused: bool,
+    }
+
+    impl From<&Workspace> for IronWorkspace {
+        fn from(workspace: &Workspace) -> IronWorkspace {
+            // Workspaces in niri don't neccessarily have names.
+            // If the niri workspace has a name then it is assigned as is,
+            // but if it does not have a name, the monitor index is used.
+            Self {
+                id: workspace.id as i64,
+                index: workspace.idx as i64,
+                name: workspace.name.clone().unwrap_or(workspace.idx.to_string()),
+                monitor: workspace.output.clone().unwrap_or_default(),
+                visibility: if workspace.is_active {
+                    Visibility::Visible {
+                        focused: workspace.is_focused,
+                    }
+                } else {
+                    Visibility::Hidden
+                },
+            }
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/src/clients/compositor/niri/connection.rs
+++ b/src/clients/compositor/niri/connection.rs
@@ -28,7 +28,37 @@ pub enum Response {
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub enum Action {
-    FocusWorkspace { reference: WorkspaceReferenceArg },
+    FocusWorkspace {
+        reference: WorkspaceReferenceArg,
+    },
+    #[cfg(feature = "keyboard+niri")]
+    SwitchLayout {
+        layout: LayoutSwitchTarget,
+    },
+}
+
+#[cfg(feature = "keyboard+niri")]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy)]
+pub enum LayoutSwitchTarget {
+    Next,
+    Prev,
+    Index(u8),
+}
+
+#[cfg(feature = "keyboard+niri")]
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+pub struct KeyboardLayouts {
+    pub names: Vec<String>,
+    pub current_idx: u8,
+}
+
+#[cfg(feature = "keyboard+niri")]
+impl KeyboardLayouts {
+    pub fn current(&self) -> Option<&str> {
+        self.names
+            .get(self.current_idx as usize)
+            .map(|x| x.as_str())
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
@@ -70,9 +100,25 @@ impl From<&Workspace> for IronWorkspace {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum Event {
-    WorkspacesChanged { workspaces: Vec<Workspace> },
-    WorkspaceActivated { id: u64, focused: bool },
-    WorkspaceUrgencyChanged { id: u64, urgent: bool },
+    WorkspacesChanged {
+        workspaces: Vec<Workspace>,
+    },
+    WorkspaceActivated {
+        id: u64,
+        focused: bool,
+    },
+    WorkspaceUrgencyChanged {
+        id: u64,
+        urgent: bool,
+    },
+    #[cfg(feature = "keyboard+niri")]
+    KeyboardLayoutsChanged {
+        keyboard_layouts: KeyboardLayouts,
+    },
+    #[cfg(feature = "keyboard+niri")]
+    KeyboardLayoutSwitched {
+        idx: u8,
+    },
     Other,
 }
 

--- a/src/clients/compositor/niri/mod.rs
+++ b/src/clients/compositor/niri/mod.rs
@@ -1,197 +1,253 @@
 use super::Visibility;
 use super::{Workspace as IronWorkspace, WorkspaceClient, WorkspaceUpdate};
 use crate::channels::SyncSenderExt;
-use crate::{arc_rw, read_lock, spawn, write_lock};
+#[cfg(feature = "keyboard+niri")]
+use crate::clients::compositor::{
+    KeyboardLayoutClient, KeyboardLayoutUpdate,
+    niri::connection::{KeyboardLayouts, LayoutSwitchTarget},
+};
+use crate::lock;
+use crate::spawn;
 use connection::{Action, Connection, Event, Request, WorkspaceReferenceArg};
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, Mutex};
 use tokio::sync::broadcast;
 use tracing::{debug, error, warn};
 
 mod connection;
 
+#[cfg(feature = "keyboard+niri")]
 #[derive(Debug)]
-pub struct Client {
+struct KeyboardLayoutHandler {
+    tx: broadcast::Sender<KeyboardLayoutUpdate>,
+    _rx: broadcast::Receiver<KeyboardLayoutUpdate>,
+
+    layouts: Mutex<KeyboardLayouts>,
+}
+
+#[cfg(feature = "keyboard+niri")]
+impl KeyboardLayoutHandler {
+    fn new() -> Self {
+        let (tx, rx) = broadcast::channel(32);
+        Self {
+            tx,
+            _rx: rx,
+            layouts: Mutex::default(),
+        }
+    }
+
+    fn handle(&self, event: Event) -> Option<Event> {
+        let update = {
+            let mut layouts = lock!(self.layouts);
+            match event {
+                Event::KeyboardLayoutsChanged { keyboard_layouts } => *layouts = keyboard_layouts,
+                Event::KeyboardLayoutSwitched { idx } => layouts.current_idx = idx,
+                other => return Some(other),
+            }
+            layouts
+                .current()
+                .map(|layout| KeyboardLayoutUpdate(layout.to_string()))
+        };
+
+        if let Some(update) = update {
+            self.tx.send_expect(update);
+        } else {
+            warn!("No active keyboard layouts found");
+        }
+
+        None
+    }
+}
+
+#[derive(Debug)]
+struct WorkspaceHandler {
     tx: broadcast::Sender<WorkspaceUpdate>,
     _rx: broadcast::Receiver<WorkspaceUpdate>,
 
-    workspaces: Arc<RwLock<Vec<IronWorkspace>>>,
+    workspaces: Mutex<Vec<IronWorkspace>>,
+}
+
+impl WorkspaceHandler {
+    fn new() -> Self {
+        let (tx, rx) = broadcast::channel(32);
+        Self {
+            tx,
+            _rx: rx,
+            workspaces: Mutex::default(),
+        }
+    }
+
+    fn handle(&self, event: Event) -> Option<Event> {
+        match event {
+            Event::WorkspacesChanged { workspaces } => {
+                debug!("WorkspacesChanged: {:?}", workspaces);
+
+                // Niri only has a WorkspacesChanged Event and Ironbar has 4 events which have to be handled: Add, Remove, Rename and Move.
+                // This is handled by keeping a previous state of workspaces and comparing with the new state for changes.
+                let new_workspaces: Vec<IronWorkspace> = workspaces
+                    .into_iter()
+                    .map(|w| IronWorkspace::from(&w))
+                    .collect();
+
+                let updates = {
+                    let mut workspaces = lock!(self.workspaces);
+
+                    // first pass - add/update
+                    let mut updates: Vec<WorkspaceUpdate> = vec![];
+                    for new in &new_workspaces {
+                        let old = workspaces
+                            .iter()
+                            .find(|&old: &&IronWorkspace| old.id == new.id);
+
+                        match old {
+                            None => updates.push(WorkspaceUpdate::Add(new.clone())),
+                            Some(old) => {
+                                if new.name != old.name {
+                                    updates.push(WorkspaceUpdate::Rename {
+                                        id: new.id,
+                                        name: new.name.clone(),
+                                    });
+                                }
+
+                                if new.monitor != old.monitor || new.index != old.index {
+                                    updates.push(WorkspaceUpdate::Move(new.clone()));
+                                }
+                            }
+                        }
+                    }
+
+                    // second pass - delete
+                    updates.extend(
+                        workspaces
+                            .iter()
+                            .filter(|old| !new_workspaces.iter().any(|new| new.id == old.id))
+                            .map(|old| WorkspaceUpdate::Remove(old.id)),
+                    );
+
+                    *workspaces = new_workspaces;
+                    updates
+                };
+
+                for update in updates {
+                    self.tx.send_expect(update);
+                }
+            }
+
+            Event::WorkspaceActivated { id, focused } => {
+                debug!("WorkspaceActivated: id: {}, focused: {}", id, focused);
+
+                // workspace with id is activated, if focus is true then it is also focused
+                // we use indexes here as both new/old need to be mutable
+                let update = {
+                    let mut workspaces = lock!(self.workspaces);
+
+                    let Some(new_index) = workspaces.iter().position(|w| w.id == id as i64) else {
+                        warn!("No workspace with id for new focus/visible workspace found");
+                        return None;
+                    };
+
+                    if focused {
+                        // if focused is true then focus has changed => find old focused workspace,
+                        // set it to inactive and change current to focused
+                        let old = workspaces
+                            .iter()
+                            .position(|w| w.visibility.is_focused())
+                            .filter(|&old_index| old_index != new_index)
+                            .map(|old_index| {
+                                workspaces[old_index].visibility = if workspaces[old_index].monitor
+                                    == workspaces[new_index].monitor
+                                {
+                                    Visibility::Hidden
+                                } else {
+                                    Visibility::visible()
+                                };
+                                workspaces[old_index].clone()
+                            });
+                        workspaces[new_index].visibility = Visibility::focused();
+
+                        WorkspaceUpdate::Focus {
+                            old,
+                            new: workspaces[new_index].clone(),
+                        }
+                    } else {
+                        // if focused is false then active workspace on a particular monitor has changed =>
+                        // change all workspaces on monitor to inactive and change current workspace to active
+                        let old_index = workspaces
+                            .iter()
+                            .position(|old| {
+                                old.visibility.is_visible()
+                                    && old.monitor == workspaces[new_index].monitor
+                            })
+                            .filter(|&old_index| old_index != new_index);
+
+                        if let Some(old_index) = old_index {
+                            workspaces[old_index].visibility = Visibility::Hidden;
+                        }
+
+                        workspaces[new_index].visibility = Visibility::visible();
+                        return None;
+                    }
+                };
+
+                self.tx.send_expect(update);
+            }
+            Event::WorkspaceUrgencyChanged { id, urgent } => {
+                self.tx.send_expect(WorkspaceUpdate::Urgent {
+                    id: id as i64,
+                    urgent,
+                });
+            }
+            other => return Some(other),
+        }
+
+        None
+    }
+}
+
+#[derive(Debug)]
+pub struct Client {
+    ws_handler: Arc<WorkspaceHandler>,
+
+    #[cfg(feature = "keyboard+niri")]
+    kb_handler: Arc<KeyboardLayoutHandler>,
 }
 
 impl Client {
     pub fn new() -> Self {
-        let (tx, rx) = broadcast::channel(32);
-        let tx2 = tx.clone();
-
-        let workspace_state = arc_rw!(vec![]);
-        let workspace_state2 = workspace_state.clone();
+        let instance = Self {
+            ws_handler: Arc::new(WorkspaceHandler::new()),
+            #[cfg(feature = "keyboard+niri")]
+            kb_handler: Arc::new(KeyboardLayoutHandler::new()),
+        };
+        let ws_handler = instance.ws_handler.clone();
+        #[cfg(feature = "keyboard+niri")]
+        let kb_handler = instance.kb_handler.clone();
 
         spawn(async move {
             let mut conn = Connection::connect().await?;
             let (_, mut event_listener) = conn.send(Request::EventStream).await?;
 
-            let mut first_event = true;
-
             loop {
-                let events = match event_listener() {
-                    Ok(Event::WorkspacesChanged { workspaces }) => {
-                        debug!("WorkspacesChanged: {:?}", workspaces);
+                match event_listener() {
+                    Ok(event) => {
+                        #[cfg(feature = "workspaces+niri")]
+                        let event = ws_handler.handle(event);
 
-                        // Niri only has a WorkspacesChanged Event and Ironbar has 4 events which have to be handled: Add, Remove, Rename and Move.
-                        // This is handled by keeping a previous state of workspaces and comparing with the new state for changes.
-                        let new_workspaces: Vec<IronWorkspace> = workspaces
-                            .into_iter()
-                            .map(|w| IronWorkspace::from(&w))
-                            .collect();
+                        #[cfg(feature = "keyboard+niri")]
+                        let event = event.and_then(|event| kb_handler.handle(event));
 
-                        let mut updates: Vec<WorkspaceUpdate> = vec![];
-
-                        if first_event {
-                            // Niri's WorkspacesChanged event does not initially sort workspaces by ID when first output,
-                            // which makes sort = added meaningless. Therefore, new_workspaces are sorted by ID here to ensure a consistent addition order.
-                            let mut new_workspaces = new_workspaces.clone();
-                            new_workspaces.sort_by_key(|w| w.id);
-                            updates.push(WorkspaceUpdate::Init(new_workspaces));
-                            first_event = false;
-                        } else {
-                            // first pass - add/update
-                            for workspace in &new_workspaces {
-                                let workspace_state = read_lock!(workspace_state);
-                                let old_workspace = workspace_state
-                                    .iter()
-                                    .find(|&w: &&IronWorkspace| w.id == workspace.id);
-
-                                match old_workspace {
-                                    None => updates.push(WorkspaceUpdate::Add(workspace.clone())),
-                                    Some(old_workspace) => {
-                                        if workspace.name != old_workspace.name {
-                                            updates.push(WorkspaceUpdate::Rename {
-                                                id: workspace.id,
-                                                name: workspace.name.clone(),
-                                            });
-                                        }
-
-                                        if workspace.monitor != old_workspace.monitor
-                                            || workspace.index != old_workspace.index
-                                        {
-                                            updates.push(WorkspaceUpdate::Move(workspace.clone()));
-                                        }
-                                    }
-                                }
-                            }
-
-                            // second pass - delete
-                            for workspace in read_lock!(workspace_state).iter() {
-                                let exists = new_workspaces.iter().any(|w| w.id == workspace.id);
-
-                                if !exists {
-                                    updates.push(WorkspaceUpdate::Remove(workspace.id));
-                                }
-                            }
-                        }
-
-                        *write_lock!(workspace_state) = new_workspaces;
-                        updates
-                    }
-
-                    Ok(Event::WorkspaceActivated { id, focused }) => {
-                        debug!("WorkspaceActivated: id: {}, focused: {}", id, focused);
-
-                        // workspace with id is activated, if focus is true then it is also focused
-                        // if focused is true then focus has changed => find old focused workspace. set it to inactive and set current
-                        //
-                        // we use indexes here as both new/old need to be mutable
-
-                        let new_index = read_lock!(workspace_state)
-                            .iter()
-                            .position(|w| w.id == id as i64);
-
-                        if let Some(new_index) = new_index {
-                            if focused {
-                                let old_index = read_lock!(workspace_state)
-                                    .iter()
-                                    .position(|w| w.visibility.is_focused());
-
-                                if let Some(old_index) = old_index {
-                                    write_lock!(workspace_state)[new_index].visibility =
-                                        Visibility::focused();
-
-                                    if read_lock!(workspace_state)[old_index].monitor
-                                        == read_lock!(workspace_state)[new_index].monitor
-                                    {
-                                        write_lock!(workspace_state)[old_index].visibility =
-                                            Visibility::Hidden;
-                                    } else {
-                                        write_lock!(workspace_state)[old_index].visibility =
-                                            Visibility::visible();
-                                    }
-
-                                    vec![WorkspaceUpdate::Focus {
-                                        old: Some(read_lock!(workspace_state)[old_index].clone()),
-                                        new: read_lock!(workspace_state)[new_index].clone(),
-                                    }]
-                                } else {
-                                    write_lock!(workspace_state)[new_index].visibility =
-                                        Visibility::focused();
-
-                                    vec![WorkspaceUpdate::Focus {
-                                        old: None,
-                                        new: read_lock!(workspace_state)[new_index].clone(),
-                                    }]
-                                }
-                            } else {
-                                // if focused is false means active workspace on a particular monitor has changed =>
-                                // change all workspaces on monitor to inactive and change current workspace as active
-                                write_lock!(workspace_state)[new_index].visibility =
-                                    Visibility::visible();
-
-                                let old_index = read_lock!(workspace_state).iter().position(|w| {
-                                    (w.visibility.is_focused() || w.visibility.is_visible())
-                                        && w.monitor
-                                            == read_lock!(workspace_state)[new_index].monitor
-                                });
-
-                                if let Some(old_index) = old_index {
-                                    write_lock!(workspace_state)[old_index].visibility =
-                                        Visibility::Hidden;
-
-                                    vec![]
-                                } else {
-                                    vec![]
-                                }
-                            }
-                        } else {
-                            warn!("No workspace with id for new focus/visible workspace found");
-                            vec![]
-                        }
-                    }
-                    Ok(Event::WorkspaceUrgencyChanged { id, urgent }) => {
-                        vec![WorkspaceUpdate::Urgent {
-                            id: id as i64,
-                            urgent,
-                        }]
-                    }
-                    Ok(Event::Other) => {
-                        vec![]
+                        let _ = event;
                     }
                     Err(err) => {
                         error!("{err:?}");
                         break;
                     }
-                };
-
-                for event in events {
-                    tx.send_expect(event);
                 }
             }
 
             Ok::<(), std::io::Error>(())
         });
 
-        Self {
-            tx: tx2,
-            _rx: rx,
-            workspaces: workspace_state2,
-        }
+        instance
     }
 }
 
@@ -217,12 +273,47 @@ impl WorkspaceClient for Client {
     }
 
     fn subscribe(&self) -> broadcast::Receiver<WorkspaceUpdate> {
-        let rx = self.tx.subscribe();
+        let rx = self.ws_handler.tx.subscribe();
 
-        let workspaces = read_lock!(self.workspaces);
+        let workspaces = lock!(self.ws_handler.workspaces).clone();
         if !workspaces.is_empty() {
-            self.tx
-                .send_expect(WorkspaceUpdate::Init(workspaces.clone()));
+            self.ws_handler
+                .tx
+                .send_expect(WorkspaceUpdate::Init(workspaces));
+        }
+
+        rx
+    }
+}
+
+#[cfg(feature = "keyboard+niri")]
+impl KeyboardLayoutClient for Client {
+    fn set_next_active(&self) {
+        spawn(async move {
+            let mut conn = Connection::connect().await?;
+
+            let command = Request::Action(Action::SwitchLayout {
+                layout: LayoutSwitchTarget::Next,
+            });
+
+            if let Err(err) = conn.send(command).await {
+                error!("failed to send command: {err:?}");
+            }
+            Ok::<(), std::io::Error>(())
+        });
+    }
+
+    fn subscribe(&self) -> broadcast::Receiver<KeyboardLayoutUpdate> {
+        let rx = self.kb_handler.tx.subscribe();
+
+        let update = lock!(self.kb_handler.layouts)
+            .current()
+            .map(|layout| KeyboardLayoutUpdate(layout.to_string()));
+
+        if let Some(update) = update {
+            self.kb_handler.tx.send_expect(update);
+        } else {
+            error!("Failed to get current keyboard layout");
         }
 
         rx

--- a/src/clients/compositor/niri/mod.rs
+++ b/src/clients/compositor/niri/mod.rs
@@ -1,225 +1,32 @@
-use super::Visibility;
-use super::{Workspace as IronWorkspace, WorkspaceClient, WorkspaceUpdate};
 use crate::channels::SyncSenderExt;
-#[cfg(feature = "keyboard+niri")]
-use crate::clients::compositor::{
-    KeyboardLayoutClient, KeyboardLayoutUpdate,
-    niri::connection::{KeyboardLayouts, LayoutSwitchTarget},
-};
-use crate::lock;
-use crate::spawn;
-use connection::{Action, Connection, Event, Request, WorkspaceReferenceArg};
+use crate::{lock, spawn};
+use connection::{Connection, Request};
 use std::sync::{Arc, Mutex};
 use tokio::sync::broadcast;
 use tracing::{debug, error, warn};
 
 mod connection;
 
-#[cfg(feature = "keyboard+niri")]
-#[derive(Debug)]
-struct KeyboardLayoutHandler {
-    tx: broadcast::Sender<KeyboardLayoutUpdate>,
-    _rx: broadcast::Receiver<KeyboardLayoutUpdate>,
-
-    layouts: Mutex<KeyboardLayouts>,
-}
-
-#[cfg(feature = "keyboard+niri")]
-impl KeyboardLayoutHandler {
-    fn new() -> Self {
-        let (tx, rx) = broadcast::channel(32);
-        Self {
-            tx,
-            _rx: rx,
-            layouts: Mutex::default(),
-        }
-    }
-
-    fn handle(&self, event: Event) -> Option<Event> {
-        let update = {
-            let mut layouts = lock!(self.layouts);
-            match event {
-                Event::KeyboardLayoutsChanged { keyboard_layouts } => *layouts = keyboard_layouts,
-                Event::KeyboardLayoutSwitched { idx } => layouts.current_idx = idx,
-                other => return Some(other),
-            }
-            layouts
-                .current()
-                .map(|layout| KeyboardLayoutUpdate(layout.to_string()))
-        };
-
-        if let Some(update) = update {
-            self.tx.send_expect(update);
-        } else {
-            warn!("No active keyboard layouts found");
-        }
-
-        None
-    }
-}
-
-#[derive(Debug)]
-struct WorkspaceHandler {
-    tx: broadcast::Sender<WorkspaceUpdate>,
-    _rx: broadcast::Receiver<WorkspaceUpdate>,
-
-    workspaces: Mutex<Vec<IronWorkspace>>,
-}
-
-impl WorkspaceHandler {
-    fn new() -> Self {
-        let (tx, rx) = broadcast::channel(32);
-        Self {
-            tx,
-            _rx: rx,
-            workspaces: Mutex::default(),
-        }
-    }
-
-    fn handle(&self, event: Event) -> Option<Event> {
-        match event {
-            Event::WorkspacesChanged { workspaces } => {
-                debug!("WorkspacesChanged: {:?}", workspaces);
-
-                // Niri only has a WorkspacesChanged Event and Ironbar has 4 events which have to be handled: Add, Remove, Rename and Move.
-                // This is handled by keeping a previous state of workspaces and comparing with the new state for changes.
-                let new_workspaces: Vec<IronWorkspace> = workspaces
-                    .into_iter()
-                    .map(|w| IronWorkspace::from(&w))
-                    .collect();
-
-                let updates = {
-                    let mut workspaces = lock!(self.workspaces);
-
-                    // first pass - add/update
-                    let mut updates: Vec<WorkspaceUpdate> = vec![];
-                    for new in &new_workspaces {
-                        let old = workspaces
-                            .iter()
-                            .find(|&old: &&IronWorkspace| old.id == new.id);
-
-                        match old {
-                            None => updates.push(WorkspaceUpdate::Add(new.clone())),
-                            Some(old) => {
-                                if new.name != old.name {
-                                    updates.push(WorkspaceUpdate::Rename {
-                                        id: new.id,
-                                        name: new.name.clone(),
-                                    });
-                                }
-
-                                if new.monitor != old.monitor || new.index != old.index {
-                                    updates.push(WorkspaceUpdate::Move(new.clone()));
-                                }
-                            }
-                        }
-                    }
-
-                    // second pass - delete
-                    updates.extend(
-                        workspaces
-                            .iter()
-                            .filter(|old| !new_workspaces.iter().any(|new| new.id == old.id))
-                            .map(|old| WorkspaceUpdate::Remove(old.id)),
-                    );
-
-                    *workspaces = new_workspaces;
-                    updates
-                };
-
-                for update in updates {
-                    self.tx.send_expect(update);
-                }
-            }
-
-            Event::WorkspaceActivated { id, focused } => {
-                debug!("WorkspaceActivated: id: {}, focused: {}", id, focused);
-
-                // workspace with id is activated, if focus is true then it is also focused
-                // we use indexes here as both new/old need to be mutable
-                let update = {
-                    let mut workspaces = lock!(self.workspaces);
-
-                    let Some(new_index) = workspaces.iter().position(|w| w.id == id as i64) else {
-                        warn!("No workspace with id for new focus/visible workspace found");
-                        return None;
-                    };
-
-                    if focused {
-                        // if focused is true then focus has changed => find old focused workspace,
-                        // set it to inactive and change current to focused
-                        let old = workspaces
-                            .iter()
-                            .position(|w| w.visibility.is_focused())
-                            .filter(|&old_index| old_index != new_index)
-                            .map(|old_index| {
-                                workspaces[old_index].visibility = if workspaces[old_index].monitor
-                                    == workspaces[new_index].monitor
-                                {
-                                    Visibility::Hidden
-                                } else {
-                                    Visibility::visible()
-                                };
-                                workspaces[old_index].clone()
-                            });
-                        workspaces[new_index].visibility = Visibility::focused();
-
-                        WorkspaceUpdate::Focus {
-                            old,
-                            new: workspaces[new_index].clone(),
-                        }
-                    } else {
-                        // if focused is false then active workspace on a particular monitor has changed =>
-                        // change all workspaces on monitor to inactive and change current workspace to active
-                        let old_index = workspaces
-                            .iter()
-                            .position(|old| {
-                                old.visibility.is_visible()
-                                    && old.monitor == workspaces[new_index].monitor
-                            })
-                            .filter(|&old_index| old_index != new_index);
-
-                        if let Some(old_index) = old_index {
-                            workspaces[old_index].visibility = Visibility::Hidden;
-                        }
-
-                        workspaces[new_index].visibility = Visibility::visible();
-                        return None;
-                    }
-                };
-
-                self.tx.send_expect(update);
-            }
-            Event::WorkspaceUrgencyChanged { id, urgent } => {
-                self.tx.send_expect(WorkspaceUpdate::Urgent {
-                    id: id as i64,
-                    urgent,
-                });
-            }
-            other => return Some(other),
-        }
-
-        None
-    }
-}
-
 #[derive(Debug)]
 pub struct Client {
-    ws_handler: Arc<WorkspaceHandler>,
+    #[cfg(feature = "workspaces")]
+    ws_handler: Arc<ws::WorkspaceHandler>,
 
-    #[cfg(feature = "keyboard+niri")]
-    kb_handler: Arc<KeyboardLayoutHandler>,
+    #[cfg(feature = "keyboard")]
+    kb_handler: Arc<kb::KeyboardLayoutHandler>,
 }
 
 impl Client {
     pub fn new() -> Self {
         let instance = Self {
-            ws_handler: Arc::new(WorkspaceHandler::new()),
-            #[cfg(feature = "keyboard+niri")]
-            kb_handler: Arc::new(KeyboardLayoutHandler::new()),
+            #[cfg(feature = "workspaces")]
+            ws_handler: Arc::new(ws::WorkspaceHandler::new()),
+            #[cfg(feature = "keyboard")]
+            kb_handler: Arc::new(kb::KeyboardLayoutHandler::new()),
         };
+        #[cfg(feature = "workspaces")]
         let ws_handler = instance.ws_handler.clone();
-        #[cfg(feature = "keyboard+niri")]
+        #[cfg(feature = "keyboard")]
         let kb_handler = instance.kb_handler.clone();
 
         spawn(async move {
@@ -229,10 +36,12 @@ impl Client {
             loop {
                 match event_listener() {
                     Ok(event) => {
-                        #[cfg(feature = "workspaces+niri")]
-                        let event = ws_handler.handle(event);
+                        let event = Some(event);
 
-                        #[cfg(feature = "keyboard+niri")]
+                        #[cfg(feature = "workspaces")]
+                        let event = event.and_then(|event| ws_handler.handle(event));
+
+                        #[cfg(feature = "keyboard")]
                         let event = event.and_then(|event| kb_handler.handle(event));
 
                         let _ = event;
@@ -251,71 +60,278 @@ impl Client {
     }
 }
 
-impl WorkspaceClient for Client {
-    fn focus(&self, id: i64) {
-        debug!("focusing workspace with id: {}", id);
+#[cfg(feature = "keyboard")]
+mod kb {
+    use super::connection::kb::{KeyboardLayouts, LayoutSwitchTarget};
+    use super::connection::{Action, Connection, Event, Request};
+    use super::{Mutex, SyncSenderExt, broadcast, error, lock, spawn, warn};
+    use crate::clients::compositor::{KeyboardLayoutClient, KeyboardLayoutUpdate};
 
-        // this does annoyingly require spawning a separate connection for every focus call
-        // the alternative is sticking the conn behind a mutex which could perform worse
-        spawn(async move {
-            let mut conn = Connection::connect().await?;
+    #[derive(Debug)]
+    pub(super) struct KeyboardLayoutHandler {
+        tx: broadcast::Sender<KeyboardLayoutUpdate>,
+        _rx: broadcast::Receiver<KeyboardLayoutUpdate>,
 
-            let command = Request::Action(Action::FocusWorkspace {
-                reference: WorkspaceReferenceArg::Id(id as u64),
-            });
-
-            if let Err(err) = conn.send(command).await {
-                error!("failed to send command: {err:?}");
-            }
-
-            Ok::<(), std::io::Error>(())
-        });
+        layouts: Mutex<KeyboardLayouts>,
     }
 
-    fn subscribe(&self) -> broadcast::Receiver<WorkspaceUpdate> {
-        let rx = self.ws_handler.tx.subscribe();
-
-        let workspaces = lock!(self.ws_handler.workspaces).clone();
-        if !workspaces.is_empty() {
-            self.ws_handler
-                .tx
-                .send_expect(WorkspaceUpdate::Init(workspaces));
+    impl KeyboardLayoutHandler {
+        pub fn new() -> Self {
+            let (tx, rx) = broadcast::channel(32);
+            Self {
+                tx,
+                _rx: rx,
+                layouts: Mutex::default(),
+            }
         }
 
-        rx
+        pub fn handle(&self, event: Event) -> Option<Event> {
+            let update = {
+                let mut layouts = lock!(self.layouts);
+                match event {
+                    Event::KeyboardLayoutsChanged { keyboard_layouts } => {
+                        *layouts = keyboard_layouts
+                    }
+                    Event::KeyboardLayoutSwitched { idx } => layouts.current_idx = idx,
+                    other => return Some(other),
+                }
+                layouts
+                    .current()
+                    .map(|layout| KeyboardLayoutUpdate(layout.to_string()))
+            };
+
+            if let Some(update) = update {
+                self.tx.send_expect(update);
+            } else {
+                warn!("No active keyboard layouts found");
+            }
+
+            None
+        }
+    }
+
+    impl KeyboardLayoutClient for super::Client {
+        fn set_next_active(&self) {
+            spawn(async move {
+                let mut conn = Connection::connect().await?;
+
+                let command = Request::Action(Action::SwitchLayout {
+                    layout: LayoutSwitchTarget::Next,
+                });
+
+                if let Err(err) = conn.send(command).await {
+                    error!("failed to send command: {err:?}");
+                }
+                Ok::<(), std::io::Error>(())
+            });
+        }
+
+        fn subscribe(&self) -> broadcast::Receiver<KeyboardLayoutUpdate> {
+            let rx = self.kb_handler.tx.subscribe();
+
+            let update = lock!(self.kb_handler.layouts)
+                .current()
+                .map(|layout| KeyboardLayoutUpdate(layout.to_string()));
+
+            if let Some(update) = update {
+                self.kb_handler.tx.send_expect(update);
+            } else {
+                error!("Failed to get current keyboard layout");
+            }
+
+            rx
+        }
     }
 }
 
-#[cfg(feature = "keyboard+niri")]
-impl KeyboardLayoutClient for Client {
-    fn set_next_active(&self) {
-        spawn(async move {
-            let mut conn = Connection::connect().await?;
+#[cfg(feature = "workspaces")]
+mod ws {
+    use super::connection::ws::WorkspaceReferenceArg;
+    use super::connection::{Action, Connection, Event, Request};
+    use super::{Mutex, SyncSenderExt, broadcast, debug, error, lock, spawn, warn};
+    use crate::clients::compositor::{
+        Visibility, Workspace as IronWorkspace, WorkspaceClient, WorkspaceUpdate,
+    };
 
-            let command = Request::Action(Action::SwitchLayout {
-                layout: LayoutSwitchTarget::Next,
-            });
+    #[derive(Debug)]
+    pub(super) struct WorkspaceHandler {
+        tx: broadcast::Sender<WorkspaceUpdate>,
+        _rx: broadcast::Receiver<WorkspaceUpdate>,
 
-            if let Err(err) = conn.send(command).await {
-                error!("failed to send command: {err:?}");
-            }
-            Ok::<(), std::io::Error>(())
-        });
+        workspaces: Mutex<Vec<IronWorkspace>>,
     }
 
-    fn subscribe(&self) -> broadcast::Receiver<KeyboardLayoutUpdate> {
-        let rx = self.kb_handler.tx.subscribe();
-
-        let update = lock!(self.kb_handler.layouts)
-            .current()
-            .map(|layout| KeyboardLayoutUpdate(layout.to_string()));
-
-        if let Some(update) = update {
-            self.kb_handler.tx.send_expect(update);
-        } else {
-            error!("Failed to get current keyboard layout");
+    impl WorkspaceHandler {
+        pub fn new() -> Self {
+            let (tx, rx) = broadcast::channel(32);
+            Self {
+                tx,
+                _rx: rx,
+                workspaces: Mutex::default(),
+            }
         }
 
-        rx
+        pub fn handle(&self, event: Event) -> Option<Event> {
+            match event {
+                Event::WorkspacesChanged { workspaces } => {
+                    debug!("WorkspacesChanged: {:?}", workspaces);
+
+                    // Niri only has a WorkspacesChanged Event and Ironbar has 4 events which have to be handled: Add, Remove, Rename and Move.
+                    // This is handled by keeping a previous state of workspaces and comparing with the new state for changes.
+                    let new_workspaces: Vec<IronWorkspace> = workspaces
+                        .into_iter()
+                        .map(|w| IronWorkspace::from(&w))
+                        .collect();
+
+                    let updates = {
+                        let mut workspaces = lock!(self.workspaces);
+
+                        // first pass - add/update
+                        let mut updates: Vec<WorkspaceUpdate> = vec![];
+                        for new in &new_workspaces {
+                            let old = workspaces
+                                .iter()
+                                .find(|&old: &&IronWorkspace| old.id == new.id);
+
+                            match old {
+                                None => updates.push(WorkspaceUpdate::Add(new.clone())),
+                                Some(old) => {
+                                    if new.name != old.name {
+                                        updates.push(WorkspaceUpdate::Rename {
+                                            id: new.id,
+                                            name: new.name.clone(),
+                                        });
+                                    }
+
+                                    if new.monitor != old.monitor || new.index != old.index {
+                                        updates.push(WorkspaceUpdate::Move(new.clone()));
+                                    }
+                                }
+                            }
+                        }
+
+                        // second pass - delete
+                        updates.extend(
+                            workspaces
+                                .iter()
+                                .filter(|old| !new_workspaces.iter().any(|new| new.id == old.id))
+                                .map(|old| WorkspaceUpdate::Remove(old.id)),
+                        );
+
+                        *workspaces = new_workspaces;
+                        updates
+                    };
+
+                    for update in updates {
+                        self.tx.send_expect(update);
+                    }
+                }
+
+                Event::WorkspaceActivated { id, focused } => {
+                    debug!("WorkspaceActivated: id: {}, focused: {}", id, focused);
+
+                    // workspace with id is activated, if focus is true then it is also focused
+                    // we use indexes here as both new/old need to be mutable
+                    let update = {
+                        let mut workspaces = lock!(self.workspaces);
+
+                        let Some(new_index) = workspaces.iter().position(|w| w.id == id as i64)
+                        else {
+                            warn!("No workspace with id for new focus/visible workspace found");
+                            return None;
+                        };
+
+                        if focused {
+                            // if focused is true then focus has changed => find old focused workspace,
+                            // set it to inactive and change current to focused
+                            let old = workspaces
+                                .iter()
+                                .position(|w| w.visibility.is_focused())
+                                .filter(|&old_index| old_index != new_index)
+                                .map(|old_index| {
+                                    workspaces[old_index].visibility = if workspaces[old_index]
+                                        .monitor
+                                        == workspaces[new_index].monitor
+                                    {
+                                        Visibility::Hidden
+                                    } else {
+                                        Visibility::visible()
+                                    };
+                                    workspaces[old_index].clone()
+                                });
+                            workspaces[new_index].visibility = Visibility::focused();
+
+                            WorkspaceUpdate::Focus {
+                                old,
+                                new: workspaces[new_index].clone(),
+                            }
+                        } else {
+                            // if focused is false then active workspace on a particular monitor has changed =>
+                            // change all workspaces on monitor to inactive and change current workspace to active
+                            let old_index = workspaces
+                                .iter()
+                                .position(|old| {
+                                    old.visibility.is_visible()
+                                        && old.monitor == workspaces[new_index].monitor
+                                })
+                                .filter(|&old_index| old_index != new_index);
+
+                            if let Some(old_index) = old_index {
+                                workspaces[old_index].visibility = Visibility::Hidden;
+                            }
+
+                            workspaces[new_index].visibility = Visibility::visible();
+                            return None;
+                        }
+                    };
+
+                    self.tx.send_expect(update);
+                }
+                Event::WorkspaceUrgencyChanged { id, urgent } => {
+                    self.tx.send_expect(WorkspaceUpdate::Urgent {
+                        id: id as i64,
+                        urgent,
+                    });
+                }
+                other => return Some(other),
+            }
+
+            None
+        }
+    }
+
+    impl WorkspaceClient for super::Client {
+        fn focus(&self, id: i64) {
+            debug!("focusing workspace with id: {}", id);
+
+            // this does annoyingly require spawning a separate connection for every focus call
+            // the alternative is sticking the conn behind a mutex which could perform worse
+            spawn(async move {
+                let mut conn = Connection::connect().await?;
+
+                let command = Request::Action(Action::FocusWorkspace {
+                    reference: WorkspaceReferenceArg::Id(id as u64),
+                });
+
+                if let Err(err) = conn.send(command).await {
+                    error!("failed to send command: {err:?}");
+                }
+
+                Ok::<(), std::io::Error>(())
+            });
+        }
+
+        fn subscribe(&self) -> broadcast::Receiver<WorkspaceUpdate> {
+            let rx = self.ws_handler.tx.subscribe();
+
+            let workspaces = lock!(self.ws_handler.workspaces).clone();
+            if !workspaces.is_empty() {
+                self.ws_handler
+                    .tx
+                    .send_expect(WorkspaceUpdate::Init(workspaces));
+            }
+
+            rx
+        }
     }
 }

--- a/src/clients/mod.rs
+++ b/src/clients/mod.rs
@@ -55,6 +55,8 @@ pub struct Clients {
     sway: Option<Arc<sway::Client>>,
     #[cfg(feature = "hyprland")]
     hyprland: Option<Arc<compositor::hyprland::Client>>,
+    #[cfg(feature = "niri")]
+    niri: Option<Arc<compositor::niri::Client>>,
     #[cfg(feature = "bindmode")]
     bindmode: Option<Arc<dyn compositor::BindModeClient>>,
     #[cfg(feature = "clipboard")]
@@ -182,6 +184,17 @@ impl Clients {
         } else {
             let client = Arc::new(compositor::hyprland::Client::new());
             self.hyprland.replace(client.clone());
+            client
+        }
+    }
+
+    #[cfg(feature = "niri")]
+    pub fn niri(&mut self) -> Arc<compositor::niri::Client> {
+        if let Some(client) = &self.niri {
+            client.clone()
+        } else {
+            let client = Arc::new(compositor::niri::Client::new());
+            self.niri.replace(client.clone());
             client
         }
     }


### PR DESCRIPTION
### Refactor `niri::Client` and implement `KeyboardLayoutClient` for it

Shared workspace and keyboard layout state now uses `Mutex`. Previously, during single transition, individual reads and writes where performed under separate lock guards. It made state transitions non-atomic; theoretically, another task could observe an intermediate state or modify it, invalidating indices into `workspaces` vec.

In practice, it was unlikely to happen, because the only reason the state is shared is that `WorkspaceClient::subscribe` and `KeyboardLayoutClient::subscribe` need it during startup. After that, the state is only accessed by the task spawned in `Client::new`, making `RwLock` overhead unnecessary.

Event handlers are organized as a chain, each handler either consumes the event or passes it to the next one.

Removed the `first_event` special case: workspace ordering is already handled by `WorkspaceModule` according to its `SortOrder`. When the order is `SortOrder::Added`, there is no meaningful initial sorting anyway.
