### PR TITLE
fix(network_manager): recover module when update channel lags

### DIFF
--- a/src/clients/networkmanager/mod.rs
+++ b/src/clients/networkmanager/mod.rs
@@ -432,6 +432,12 @@ impl Client {
         spawn(async move { this.watch_devices_changed().await });
     }
 
+    /// Requests a full state refresh,
+    /// sending a complete `Devices` update to all subscribers.
+    pub async fn refresh(&self) {
+        self.send_device_update().await;
+    }
+
     pub fn subscribe(self: &Arc<Self>) -> broadcast::Receiver<NetworkManagerUpdate> {
         let rx = self.tx.subscribe();
         let this = Arc::clone(self);

--- a/src/modules/networkmanager.rs
+++ b/src/modules/networkmanager.rs
@@ -125,8 +125,23 @@ impl Module<GtkBox> for NetworkManagerModule {
 
         spawn(async move {
             let mut client_signal = client.subscribe();
-            while let Ok(state) = client_signal.recv().await {
-                tx.send_update(state).await;
+            loop {
+                match client_signal.recv().await {
+                    Ok(state) => tx.send_update(state).await,
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(count)) => {
+                        tracing::warn!(
+                            "Network manager update channel lagged behind by {count}; requesting full state refresh"
+                        );
+                        // Skipped messages may have included a `Devices` update,
+                        // leaving the widget's icon list out of sync. Force a
+                        // full state resend to recover.
+                        client.refresh().await;
+                    }
+                    Err(err) => {
+                        tracing::error!("{err:?}");
+                        break;
+                    }
+                }
             }
         });
 


### PR DESCRIPTION
## Description

The network_manager module's controller forwarded client updates with a `while let Ok(...)` loop over a broadcast channel. When the receiver fell behind the channel capacity, `recv` returned `Err(RecvError::Lagged)` and the loop exited silently, permanently stopping all updates to the module.

This was most visible after a suspend/resume cycle (e.g. locking with hyprlock and suspending from the lock screen): on resume, NetworkManager emits a burst of signals as wifi reconnects, which can exceed the broadcast channel capacity. If the wifi passed through a disconnected state (which maps to an empty icon) before the loop died, the wifi/network icons stayed hidden until the bar was restarted or reloaded via IPC.

### Changes

- Handle `RecvError::Lagged` in the module controller: log a warning and request a full state refresh from the client, then keep receiving. Mirrors the existing pattern in the keyboard module.
- Add `Client::refresh()` which sends a complete `Devices` update, so the module re-syncs even if the skipped messages included the `Devices` snapshot that sizes its icon list.

## How Has This Been Tested?

- Built with the `network_manager` feature, ran the binary on niri, and cycled wifi with `nmcli radio wifi off/on`: the icon cycled through `network-wireless-acquiring-symbolic` → `network-wireless-signal-good-symbolic` across a ~30-message burst, and updates kept flowing afterwards.
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test` all pass.

## Notes

- Reported as wifi/network symbols sometimes missing after unlocking from hyprlock; `ironbar reload` was a working session-level workaround, and this fixes the underlying cause.
- The channel capacity of 32 was left unchanged intentionally to keep the fix minimal; the lag path is now recoverable.
