### PR TITLE
fix(tray): call AboutToShow before opening tray menus

### DIFF
--- a/src/clients/tray.rs
+++ b/src/clients/tray.rs
@@ -107,6 +107,17 @@ impl Client {
     pub async fn activate(&self, req: ActivateRequest) -> system_tray::error::Result<()> {
         self.client.activate(req).await
     }
+
+    /// Requests the menu to refresh its contents before being shown
+    /// (DBusMenu `AboutToShow`). Returns whether the menu should be re-fetched.
+    pub async fn about_to_show_menuitem(
+        &self,
+        address: String,
+        menu_path: String,
+        id: i32,
+    ) -> system_tray::error::Result<bool> {
+        self.client.about_to_show_menuitem(address, menu_path, id).await
+    }
 }
 
 register_fallible_client!(Client, tray);

--- a/src/modules/tray/interface.rs
+++ b/src/modules/tray/interface.rs
@@ -11,7 +11,9 @@ use gtk::{
     ShortcutTrigger, prelude::*,
 };
 use gtk::{Button, Label, PopoverMenu};
+use std::cell::RefCell;
 use std::path::PathBuf;
+use std::rc::Rc;
 use system_tray::client::ActivateRequest;
 use system_tray::item::{IconPixmap, Status, StatusNotifierItem, Tooltip};
 use system_tray::menu::ToggleState;
@@ -27,7 +29,7 @@ pub(crate) struct TrayMenu {
     image_widget: Option<Picture>,
     label_widget: Option<Label>,
     tx: mpsc::Sender<UiEvent>,
-    path: Option<String>,
+    path: Rc<RefCell<Option<String>>>,
     address: String,
 
     pub title: Option<String>,
@@ -49,6 +51,10 @@ impl TrayMenu {
 
         let has_menu = item.menu.is_some();
 
+        // Shared with the click handlers so they can request a menu refresh
+        // (AboutToShow) using the D-Bus object path once it is known.
+        let path = Rc::new(RefCell::new(None));
+
         // Capture metadata for placeholder substitution in custom commands
         let item_name = if !item.id.is_empty() {
             item.id.clone()
@@ -64,6 +70,7 @@ impl TrayMenu {
                               tx: &mpsc::Sender<UiEvent>,
                               address: &str,
                               has_menu: bool,
+                              path: &Option<String>,
                               name: &str,
                               title: &Option<String>,
                               icon_name: &Option<String>| {
@@ -72,6 +79,12 @@ impl TrayMenu {
                     trace!("TrayClickAction::Reserved(Menu)");
 
                     if has_menu {
+                        if let Some(path) = path {
+                            tx.send_spawn(UiEvent::AboutToShow {
+                                address: address.to_owned(),
+                                path: path.clone(),
+                            });
+                        }
                         popover.popup();
                         tx.send_spawn(UiEvent::Menu(true));
                     } else {
@@ -131,14 +144,17 @@ impl TrayMenu {
             let name = item_name.clone();
             let title = item_title.clone();
             let icon = item_icon_name.clone();
+            let path = path.clone();
 
             move || {
+                let path = path.borrow();
                 execute_action(
                     action.clone(),
                     &pe,
                     &tx,
                     &address_owned,
                     has_menu,
+                    &path,
                     &name,
                     &title,
                     &icon,
@@ -215,7 +231,7 @@ impl TrayMenu {
             icon_name: item.icon_name,
             icon_theme_path: item.icon_theme_path.map(PathBuf::from),
             icon_pixmap: item.icon_pixmap,
-            path: None,
+            path: path,
             address: address.to_owned(),
         }
     }
@@ -295,7 +311,7 @@ impl TrayMenu {
 
     pub fn set_menu(&mut self, menu: &str) {
         trace!("set menu {}", menu);
-        self.path = Some(menu.to_owned());
+        *self.path.borrow_mut() = Some(menu.to_owned());
     }
 
     pub fn set_menu_widget(&self, tray_menu: &system_tray::menu::TrayMenu) {
@@ -324,7 +340,7 @@ impl TrayMenu {
         let action = SimpleAction::new(&action_name, None);
         let address = self.address.clone();
 
-        if let Some(path) = self.path.clone() {
+        if let Some(path) = self.path.borrow().clone() {
             action.connect_activate(move |_, _| activate(&tx, &address, &path, id));
         }
 
@@ -347,7 +363,7 @@ impl TrayMenu {
 
         let address = self.address.clone();
 
-        if let Some(path) = self.path.clone() {
+        if let Some(path) = self.path.borrow().clone() {
             action.connect_change_state(move |_, _| activate(&tx, &address, &path, id));
 
             action.connect_change_state(move |ac, _| {
@@ -386,7 +402,7 @@ impl TrayMenu {
 
         let address = self.address.clone();
 
-        if let Some(path) = self.path.clone() {
+        if let Some(path) = self.path.borrow().clone() {
             action.connect_change_state(move |_, _| activate(&tx, &address, &path, id));
         }
 

--- a/src/modules/tray/mod.rs
+++ b/src/modules/tray/mod.rs
@@ -186,6 +186,7 @@ impl Default for TrayModule {
 
 pub enum UiEvent {
     Menu(bool),
+    AboutToShow { address: String, path: String },
     Activate(ActivateRequest),
 }
 
@@ -250,6 +251,14 @@ impl Module<gtk::Box> for TrayModule {
                 match cmd {
                     UiEvent::Menu(open) => {
                         tx.send_expect(ModuleUpdateEvent::LockVisible(open)).await;
+                    }
+                    UiEvent::AboutToShow { address, path } => {
+                        debug!("requesting menu refresh for '{address}'");
+                        if let Err(err) =
+                            client.about_to_show_menuitem(address.clone(), path.clone(), 0).await
+                        {
+                            error!("{err:?}");
+                        }
                     }
                     UiEvent::Activate(action) => {
                         debug!("activating: {action:?}");


### PR DESCRIPTION
## What

Follows the [DBusMenu spec](https://wiki.ubuntu.com/NotificationArea/MenuImplementation) by sending an `AboutToShow` signal to the SNI item **before** (and while) its popover menu is opened, using the `about_to_show_menuitem(address, path, id)` method already exposed by the `system-tray` crate.

## Why

Many items build their menus lazily and only refresh their layout in response to `AboutToShow`. The most visible example is `nm-applet`: the list of available Wi-Fi networks is only populated when something explicitly triggers it. Native panels (GNOME Shell, Plasma, etc.) do this automatically, so this is invisible to most users — but on a standalone bar like ironbar the network list stays empty/stale until a coincidental `LayoutUpdated` arrives.

## Changes

- `src/clients/tray.rs`: passthrough `about_to_show_menuitem` on ironbar's tray client (mirrors the existing `activate` passthrough).
- `src/modules/tray/mod.rs`: new `UiEvent::AboutToShow { address, path }`, handled in the module controller by calling `about_to_show_menuitem(address, path, 0)`.
- `src/modules/tray/interface.rs`: the click handler now sends this event when opening the menu. To let the handler read the D-Bus object path (previously only stored on the struct and not used at click time), the path is shared through an `Rc<RefCell<Option<String>>>` instead of a plain `Option<String>`.