### PR TITLE
feat: support Lua 5.5 instead of LuaJIT

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1952,7 +1952,6 @@ dependencies = [
  "hyprland",
  "indexmap",
  "libpulse-binding",
- "lua-src",
  "mlua",
  "mpd-utils",
  "mpris",
@@ -2192,15 +2191,6 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
-
-[[package]]
-name = "lua-src"
-version = "551.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "087097f9936a7d819bda525b32d6e96f9c54f3d35ff23ff72fc0c1697d2127db"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "macaddr"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ bluetooth = ["dep:bluer"]
 
 brightness = ["zbus"]
 
-cairo = ["lua-src", "mlua"]
+cairo = ["mlua"]
 
 clipboard = ["dep:rustix"]
 
@@ -185,8 +185,7 @@ clap = { version = "4.6.1", optional = true, features = ["derive", "env"] }
 reqwest = { version = "0.13.4", default-features = false, features = ["default-tls", "http2"], optional = true }
 
 # cairo
-lua-src = { version = "551.0.0", optional = true }
-mlua = { version = "0.12.0", optional = true, features = ["luajit", "send"] }
+mlua = { version = "0.12.0", optional = true, features = ["lua55", "send"] }
 
 # keyboard
 colpetto = { version = "0.7.0", features = ["tokio", "tracing"], optional = true }

--- a/lua/init.lua
+++ b/lua/init.lua
@@ -1,3 +1,27 @@
+-- Workaround for lgi incompatibility with Lua 5.5:
+-- for-loop variables are read-only since Lua 5.5, but lgi's
+-- component.lua reassigns the `en` loop variable. Patch the
+-- module before loading it through the normal searcher.
+do
+    -- Find lgi.component on the module path
+    local file = package.searchpath('lgi.component', package.path)
+    if file then
+        local f = assert(io.open(file, 'rb'))
+        local src = assert(f:read('a'))
+        f:close()
+
+        -- Only fix the assignment inside the `for en, idx in pairs(index)`
+        -- loop, anchored on the preceding line which only occurs there.
+        -- The `while`-loop assignment (line ~60) must stay intact.
+        src = src:gsub(
+            '(val = xvalue%(children%[idx%]%)\n%s-)en = not xform_name_reverse and en or xform_name_reverse%(en%)',
+            '%1local en = not xform_name_reverse and en or xform_name_reverse(en)'
+        )
+
+        package.preload['lgi.component'] = load(src, '@' .. file)
+    end
+end
+
 local lgi = require('lgi')
 cairo = lgi.cairo
 

--- a/src/clients/lua.rs
+++ b/src/clients/lua.rs
@@ -16,7 +16,7 @@ pub struct LuaEngine {
 
 impl LuaEngine {
     pub fn new(config_dir: &Path) -> Self {
-        let lua = Lua::new();
+        let lua = unsafe { Lua::unsafe_new() };
 
         if let Err(err) = lua
             .globals()

--- a/src/clients/lua.rs
+++ b/src/clients/lua.rs
@@ -16,7 +16,7 @@ pub struct LuaEngine {
 
 impl LuaEngine {
     pub fn new(config_dir: &Path) -> Self {
-        let lua = unsafe { Lua::unsafe_new() };
+        let lua = Lua::new();
 
         if let Err(err) = lua
             .globals()


### PR DESCRIPTION
## What

Swaps the bundled LuaJIT for Lua 5.5 and fixes an incompatibility between lgi and Lua 5.5.

## Why

The `cairo` module loads cairo through `lgi`, and lgi is a C module that must be compiled against the exact same interpreter as the one `mlua` embeds/links. With the current `luajit` feature + vendored `lua-src`:

- `mlua` embeds a vendored LuaJIT, but the system `lgi`/`lua-lgi` is built against the system Lua interpreter, so `require("lgi")` fails ("attempt to load a C module" / incompatible ABI).
- Distributions such as Arch now ship Lua **5.5**; LuaJIT remains pinned to 5.1 semantics and its lib is not what the system `lua-lgi` targets.

Switching `mlua` to the `lua55` feature makes ironbar link against the system Lua 5.5 (via pkg-config), exactly matching the interpreter the distro's `lgi` was built for.

## Changes

- `Cargo.toml`: `mlua` feature `luajit` → `lua55`, drop the vendored `lua-src` dependency. The `cairo` feature now requires a system Lua 5.5 (`pkg-config liblua`), i.e. the `lua` package on Arch.
- `lua/init.lua`: workaround for lgi vs Lua 5.5. Since Lua 5.5, `for`-loop variables are read-only, but lgi's `component.lua` reassigns the `en` loop variable:

  ```lua
  for en, idx in pairs(index) do
      val = xvalue(children[idx])
      en = not xform_name_reverse and en or xform_name_reverse(en)
  end
  ```

  → `attempt to assign to const variable 'en'`. The initialiser now patches a preload copy of `lgi.component` before the normal searcher loads it. The gsub is anchored on the unique preceding line so the unrelated `while`-loop assignment is left untouched.

## Notes for reviewers / trade-off

- This intentionally drops the vendored, fully-offline build. A system Lua 5.5 is now required at build time, so the (vendored-lua) Windows/CI setups need a decision: either add a `lua55`-aware CI image, or keep both backends selectable via a cargo feature.
- Alternative considered: keeping `lua-src` with the `lua55` feature would still vendor an interpreter that does **not** match the distro's `lgi`, defeating the purpose.
- `Lua::unsafe_new()` is already upstream's code (required to load C modules such as lgi); no change needed there.